### PR TITLE
Action editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "js-yaml": "^4.1.0",
         "lit": "^3.3.1"
       },
       "devDependencies": {
@@ -2044,6 +2045,11 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -2547,6 +2553,17 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "rollup.config.js",
   "type": "module",
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "lit": "^3.3.1"
   },
   "devDependencies": {

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css, nothing } from "https://unpkg.com/lit-element@3.3.3/lit-element.js?module";
 // import { LitElement, html, css, nothing } from "lit";
+import yaml from 'js-yaml';
 
 import {SUPPORT_GROUPING} from "./constants.js";
   
@@ -9,21 +10,45 @@ class YetAnotherMediaPlayerEditor extends LitElement {
         hass: {},
         _config: {},
         _entityEditorIndex: { type: Number },
+        _actionEditorIndex: { type: Number },
         _entityMoveMode: { type: Boolean },
+        _actionMoveMode: { type: Boolean },
+        _actionMode: { type: String },
       };
     }
   
     constructor() {
       super();
       this._entityEditorIndex = null;
+      this._actionEditorIndex = null;
       this._entityMoveMode = false;
+      this._actionMoveMode = false;
+
+      this._yamlDraft = "";
+      this._parsedYaml = null;
+      this._yamlError = false;
+      this._serviceItems = [];
+    }
+
+    firstUpdated() {
+      this._serviceItems = this._getServiceItems();
     }
   
     _supportsFeature(stateObj, featureBit) {
       if (!stateObj || typeof stateObj.attributes.supported_features !== "number") return false;
       return (stateObj.attributes.supported_features & featureBit) !== 0;
     }
-  
+
+    _getServiceItems() {
+      if (!this.hass?.services) return [];
+      return Object.entries(this.hass.services).flatMap(([domain, services]) =>
+        Object.keys(services).map((svc) => ({
+          label: `${domain}.${svc}`,
+          value: `${domain}.${svc}`,
+        }))
+      );
+    }
+
     setConfig(config) {
       const rawEntities = config.entities ?? [];
       const normalizedEntities = rawEntities.map((e) =>
@@ -44,14 +69,23 @@ class YetAnotherMediaPlayerEditor extends LitElement {
         bubbles: true,
         composed: true,
       }));
-    }c
-  
+    }
+
     _updateEntityProperty(key, value) {
       const entities = [...(this._config.entities ?? [])];
       const idx = this._entityEditorIndex;
       if (entities[idx]) {
         entities[idx] = { ...entities[idx], [key]: value };
         this._updateConfig("entities", entities);
+      }
+    }
+
+    _updateActionProperty(key, value) {
+      const actions = [...(this._config.actions ?? [])];
+      const idx = this._actionEditorIndex;
+      if (actions[idx]) {
+        actions[idx] = { ...actions[idx], [key]: value };
+        this._updateConfig("actions", actions);
       }
     }
   
@@ -76,13 +110,14 @@ class YetAnotherMediaPlayerEditor extends LitElement {
         .entity-row {
           padding: 6px;
         }
-        /* visually isolate the list of entity controls */
-        .entity-group {
+        /* visually isolate grouped controls */
+        .entity-group, .action-group {
           background: var(--card-background-color, #f7f7f7);
           border: 1px solid var(--divider-color, #ccc);
           border-radius: 6px;
           padding: 12px 16px;
           margin-bottom: 16px;
+          margin-top: 16px;
         }
         /* wraps the entity selector and edit button */
         .entity-row-inner {
@@ -92,66 +127,149 @@ class YetAnotherMediaPlayerEditor extends LitElement {
           padding: 6px;
           margin: 0px;
         }
-        /* allow a selector to fill all available space when combined with other elements */
-        .selector-grow {
+        /* wraps the action icon, name textbox and edit button */
+        .action-row-inner {
+          display: flex;
+          align-items: flex-start;
+          gap: 8px;
+          padding: 6px;
+          margin: 0px;
+        }
+        .action-row-inner > ha-icon {
+          margin-right: 5px;
+          margin-top: 0px;
+        }
+        /* allow children to fill all available space */
+        .grow-children {
           flex: 1;
           display: flex;
         }
-        .selector-grow ha-selector, .selector-grow ha-entity-picker {
-          width: 100%;
-        } 
-        .entity-editor-header {
+        .grow-children > * {
+          flex: 1;
+          min-width: 0;
+        }
+        .entity-editor-header, .action-editor-header {
           display: flex;
           align-items: center;
           gap: 12px;
           padding: 8px;
         }
-        .entity-editor-title {
+        .entity-editor-title, .action-editor-title {
           font-weight: 500;
           font-size: 1.1em;
           line-height: 1;
-          margin-top: 7px; /* tweak to align with icon */
+        }
+        .action-icon-placeholder {
+          width: 29px; 
+          height: 24px; 
+          display: inline-block;
         }
         .full-width {
           width: 100%;
         }
-        .entity-group-header {
+        .entity-group-header, .action-group-header {
           display: flex;
           align-items: center;
           justify-content: space-between;
           gap: 8px;
           padding: 0px 6px;
         }
-        .entity-group-title {
+        .entity-group-title, action-group-title {
           font-weight: 500;
         }
-        .entity-group-actions {
+        .entity-group-actions, action-group-actions {
           display: flex;
           align-items: center;
         }
-        .entity-group-actions ha-icon, .entity-row-actions ha-icon {
-          position: relative;
-          top: -3px;
+        entity-row-actions {
+          display: flex;
+          align-items: center;
+        }
+        .action-row-actions {
+          display: flex;
+          align-items: flex-start;
+          padding-top: 3px;
+        }
+        .action-icon {
+          align-self: flex-start;
+          padding-top: 16px;
+        }
+        .service-data-editor-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding-bottom: 4px;
+        }
+        .service-data-editor-title {
+          font-weight: 500;
+        }
+        .service-data-editor-actions {
+          display: flex;
+          gap: 8px;
+        }
+        .code-editor-wrapper.error {
+          border: 1px solid color: var(--error-color, red);
+          border-radius: 4px;
+          padding: 1px;
+        }
+        .yaml-error-message {
+          color: var(--error-color, red);
+          font-size: 14px;
+          margin: 6px;
+          white-space: pre-wrap;
+          font-family: Consolas, Menlo, Monaco, monospace;
+          line-height: 1.4;
+        }
+        .help-table {
+          width: 100%;
+          border-collapse: collapse;
+          margin-top: 8px;
+          font-size: 0.9em;
+        }
+        .help-table th,
+        .help-table td {
+          border: 1px solid var(--divider-color, #444);
+          padding: 8px;
+          text-align: left;
+          vertical-align: top;
+        }
+        .help-table thead {
+          background: var(--card-background-color, #222);
+          font-weight: bold;
+        }
+        .help-title {
+          font-weight: bold;
+          margin-top: 16px;
+          font-size: 1em;
+        }
+        code {
+          font-family: monospace;
+          background: rgba(255, 255, 255, 0.05);
+          padding: 2px 4px;
+          border-radius: 4px;
         } 
-        .form-row > ha-selector,
-        .form-row > ha-entity-picker {
-          flex: 1;
-          width: 100%;
-        }
-        .form-row > div > ha-selector {
-          width: 100%;
-        }
-        .form-row mwc-icon-button {
-          position: relative;
-        }
-        .form-row .reset-icon {
+        .icon-button {
+          display: inline-flex;
           cursor: pointer;
           position: relative;
-          top: -3px;
           transition: color 0.2s;
+          align-self: center;
+          align-items: center;
+          padding: 12px;
         }
-        .form-row .reset-icon:hover {
+        .icon-button:hover {
           color: var(--primary-color, #2196f3);
+        }
+        .icon-button-disabled {
+          opacity: 0.4;
+          pointer-events: none;
+        }
+        .help-text {
+          padding: 12px 25px;
+        }
+        .add-action-button-wrapper {
+          display: flex;
+          justify-content: center;
         }
       `;
     }
@@ -162,7 +280,9 @@ class YetAnotherMediaPlayerEditor extends LitElement {
       if (this._entityEditorIndex !== null) {
         const entity = this._config.entities?.[this._entityEditorIndex];
         return this._renderEntityEditor(entity);
-
+      } else if (this._actionEditorIndex !== null) {
+        const action = this._config.actions?.[this._actionEditorIndex];
+        return this._renderActionEditor(action);
       }
     
       return this._renderMainEditor();
@@ -172,6 +292,7 @@ class YetAnotherMediaPlayerEditor extends LitElement {
       if (!this._config) return html``;
   
       let entities = [...(this._config.entities ?? [])];
+      let actions = [...(this._config.actions ?? [])];
   
       // Append a blank row only for rendering (not saved)
       if (entities.length === 0 || entities[entities.length - 1].entity_id) {
@@ -186,7 +307,7 @@ class YetAnotherMediaPlayerEditor extends LitElement {
             </div>
             <div class="entity-group-actions">
               <ha-icon
-                class="reset-icon"
+                class="icon-button"
                 icon=${this._entityMoveMode ? "mdi:pencil" : "mdi:swap-vertical"}
                 title=${this._entityMoveMode ? "Back to Edit Mode" : "Enable Move Mode"}
                 @mousedown=${(e) => e.preventDefault()}
@@ -196,7 +317,7 @@ class YetAnotherMediaPlayerEditor extends LitElement {
           </div>
           ${entities.map((ent, idx) => html`
             <div class="entity-row-inner">
-              <div class="selector-grow">
+              <div class="grow-children">
                 ${ 
                 /* ha-entity-picker will show "[Object object]" for entities with extra properties,
                    so we'll get around that by using ha-selector. However ha-selector always renders 
@@ -230,28 +351,25 @@ class YetAnotherMediaPlayerEditor extends LitElement {
               <div class="entity-row-actions">
                 ${!this._entityMoveMode ? html`
                 <ha-icon
-                  class="reset-icon"
+                  class="icon-button ${!ent.entity_id ? "icon-button-disabled" : ""}"
                   icon="mdi:pencil"
                   title="Edit Entity Settings"
                   @click=${() => this._onEditEntity(idx)}
-                  style=${!ent.entity_id ? "opacity:0.4;pointer-events:none;" : ""}
                 ></ha-icon>
                 ` : html`
                   <ha-icon
-                    class="reset-icon"
+                    class="icon-button ${idx === 0 || idx === entities.length - 1 ? "icon-button-disabled" : ""}"
                     icon="mdi:arrow-up"
                     title="Move Up"
                     @mousedown=${(e) => e.preventDefault()}
                     @click=${(e) => this._moveEntity(idx, -1)}
-                    style=${idx === 0 || idx === entities.length - 1 ? "opacity:0.4;pointer-events:none;" : ""}
                   ></ha-icon>
                   <ha-icon
-                    class="reset-icon"
+                    class="icon-button ${idx >= entities.length - 2 ? "icon-button-disabled" : ""}"
                     icon="mdi:arrow-down"
                     title="Move Down"
                     @mousedown=${(e) => e.preventDefault()}
                     @click=${(e) => this._moveEntity(idx, 1)}
-                    style=${idx >= entities.length - 2 ? "opacity:0.4;pointer-events:none;" : ""}
                   ></ha-icon>
                 `}
               </div>
@@ -297,8 +415,8 @@ class YetAnotherMediaPlayerEditor extends LitElement {
           </div>
         </div>
 
-        <div class="form-row" style="display:flex; align-items:center; gap:8px;">
-          <div style="flex:1">
+        <div class="form-row form-row-multi-column">
+          <div class="grow-children">
             <ha-selector
               .hass=${this.hass}
               .selector=${{
@@ -315,7 +433,7 @@ class YetAnotherMediaPlayerEditor extends LitElement {
             ></ha-selector>
           </div>
           <ha-icon
-            class="reset-icon"
+            class="icon-button"
             icon="mdi:restore"
             title="Reset to default"
             @click=${() => this._updateConfig("idle_timeout_ms", 60000)}
@@ -340,8 +458,8 @@ class YetAnotherMediaPlayerEditor extends LitElement {
           ></ha-selector>
         </div>
         ${this._config.volume_mode === "stepper" ? html`
-          <div class="form-row" style="display:flex; align-items:center; gap:8px;">
-            <div style="flex:1">
+          <div class="form-row form-row-multi-column">
+            <div class="grow-children">
               <ha-selector
                 .hass=${this.hass}
                 .selector=${{
@@ -359,7 +477,7 @@ class YetAnotherMediaPlayerEditor extends LitElement {
               ></ha-selector>
             </div>
             <ha-icon
-              class="reset-icon"
+              class="icon-button"
               icon="mdi:restore"
               title="Reset to default"
               @click=${() => this._updateConfig("volume_step", 0.05)}
@@ -404,10 +522,107 @@ class YetAnotherMediaPlayerEditor extends LitElement {
             @value-changed=${(e) => this._updateConfig("idle_image", e.detail.value)}
           ></ha-entity-picker>
         </div>
+
+         <div class="form-row action-group">
+          <div class="action-group-header">
+            <div class="action-group-title">
+              Actions
+            </div>
+            <div class="action-group-actions">
+              <ha-icon
+                class="icon-button"
+                icon=${this._actionMoveMode ? "mdi:pencil" : "mdi:swap-vertical"}
+                title=${this._actionMoveMode ? "Back to Edit Mode" : "Enable Move Mode"}
+                @mousedown=${(e) => e.preventDefault()}
+                @click=${(e) => {
+                  this._toggleActionMoveMode();
+                  e.currentTarget.blur();
+                }}
+              ></ha-icon>
+            </div>
+          </div>
+          ${actions.map((act, idx) => html`
+            <div class="action-row-inner">
+              ${act?.icon ? html`
+                <ha-icon 
+                class="action-icon"
+                icon="${act?.icon}"></ha-icon>
+              ` : html`
+                <span class="action-icon-placeholder"></span>
+              `
+              }
+              <div class="grow-children">
+                <ha-textfield
+                  placeholder="(Icon Only)"
+                  .value=${act?.name ?? ""}
+                  helper="${
+                    act?.menu_item
+                    ? `Open Menu Item: ${act?.menu_item}`
+                    : act?.service 
+                    ? `Call Service: ${act?.service}`
+                    : `Not Configured`
+                  }"
+                  .helperPersistent=${true}
+                  @input=${a => this._onActionChanged(idx, a.target.value)}
+                ></ha-textfield>
+              </div>
+              <div class="action-row-actions">
+               ${!this._actionMoveMode ? html`
+                <ha-icon
+                  class="icon-button"
+                  icon="mdi:pencil"
+                  title="Edit Action Settings"
+                  @click=${() => this._onEditAction(idx)}
+                ></ha-icon>
+                <ha-icon
+                  class="icon-button"
+                  icon="mdi:trash-can"
+                  title="Delete Action"
+                  @click=${() => this._removeAction(idx)}
+                ></ha-icon>
+              ` : html`
+                <ha-icon
+                  class="icon-button ${idx === 0 ? "icon-button-disabled" : ""}"
+                  icon="mdi:arrow-up"
+                  title="Move Up"
+                  @mousedown=${(e) => e.preventDefault()}
+                  @click=${(e) => {
+                    this._moveAction(idx, -1);
+                    e.currentTarget.blur();
+                  }}
+                ></ha-icon>
+                <ha-icon
+                  class="icon-button ${idx >= actions.length - 1 ? "icon-button-disabled" : ""}"
+                  icon="mdi:arrow-down"
+                  title="Move Down"
+                  @mousedown=${(e) => e.preventDefault()}
+                  @click=${(e) => {
+                    this._moveAction(idx, 1);
+                    e.currentTarget.blur();
+                  }}
+                ></ha-icon>
+                `}
+              </div>
+            </div>
+          `)}
+          <div class="add-action-button-wrapper">
+            <ha-icon
+              class="icon-button"
+              icon="mdi:plus"
+              title="Add Action"
+              @click=${() => {
+                const newActions = [...(this._config.actions ?? []), {}];
+                const newIndex = newActions.length - 1;
+                this._updateConfig("actions", newActions);
+                this._onEditAction(newIndex);
+              }}
+            ></ha-icon>
+          </div>
+        </div>
+
       `;
     }
   
-
     _renderEntityEditor(entity) {
 
       const stateObj = this.hass?.states?.[entity?.entity_id];
@@ -415,9 +630,11 @@ class YetAnotherMediaPlayerEditor extends LitElement {
   
       return html`
         <div class="entity-editor-header">
-          <mwc-icon-button @click=${this._onBackFromEntityEditor} title="Back">
-            <ha-icon icon="mdi:chevron-left"></ha-icon>
-          </mwc-icon-button>
+          <ha-icon
+            class="icon-button"
+            icon="mdi:chevron-left"
+            @click=${this._onBackFromEntityEditor}>
+          </ha-icon>
           <div class="entity-editor-title">Edit Entity</div>
         </div>
 
@@ -472,7 +689,6 @@ class YetAnotherMediaPlayerEditor extends LitElement {
           ></ha-entity-picker>
         </div>
 
-
         ${entity?.volume_entity && entity.volume_entity !== entity.entity_id
 
           ? html`
@@ -492,7 +708,197 @@ class YetAnotherMediaPlayerEditor extends LitElement {
         </div>
       `;
     }
-  
+
+    _renderActionEditor(action) {
+
+      const actionMode = this._actionMode ?? (action?.menu_item?.trim() ? "menu" : "service");
+
+      return html`
+        <div class="action-editor-header">
+          <ha-icon
+            class="icon-button"
+            icon="mdi:chevron-left"
+            @click=${this._onBackFromActionEditor}>
+          </ha-icon>
+          <div class="action-editor-title">Edit Action</div>
+        </div>
+
+        <div class="form-row">
+          <ha-textfield
+            class="full-width"
+            label="Name"
+            placeholder="(Icon Only)"
+            .value=${action?.name ?? ""}
+            @input=${(e) => this._updateActionProperty("name", e.target.value)}
+          ></ha-textfield>
+        </div>
+
+        <div class="form-row">
+          <ha-icon-picker
+            label="Icon"
+            .hass=${this.hass}
+            .value=${action?.icon ?? ""}
+            @value-changed=${(e) =>
+              this._updateActionProperty("icon", e.detail.value)}
+          ></ha-icon-picker>
+        </div>
+
+        <div class="form-row">
+          <ha-selector
+            .hass=${this.hass}
+            label="Action Type"
+            .selector=${{
+              select: {
+                mode: "dropdown",
+                options: [
+                  { value: "menu", label: "Open a Card Menu Item" },
+                  { value: "service", label: "Call a Service" }
+                ]
+              }
+            }}
+            .value=${this._actionMode ?? (action?.menu_item?.trim() ? "menu" : "service")}
+            @value-changed=${(e) => {
+              const mode = e.detail.value;
+              this._actionMode = mode;
+              if (mode === "service") {
+                this._updateActionProperty("menu_item", undefined);
+              } else if (mode === "menu") {
+                this._updateActionProperty("service", undefined);
+                this._updateActionProperty("service_data", undefined);
+                this._updateActionProperty("script_variable", undefined);
+              }
+            }}
+          ></ha-selector>
+        </div>
+        
+        ${actionMode === "menu" ? html`
+          <div class="form-row">
+            <ha-selector
+              .hass=${this.hass}
+              label="Menu Item"
+              .selector=${{
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    { value: "", label: "" },
+                    { value: "search", label: "Search" },
+                    { value: "source", label: "Source" },
+                    { value: "more-info", label: "More Info" },
+                    { value: "group-players", label: "Group Players" }
+                  ]
+                }
+              }}
+              .value=${action?.menu_item ?? ""}
+              @value-changed=${(e) =>
+                this._updateActionProperty("menu_item", e.detail.value || undefined)}
+            ></ha-selector>
+          </div>
+        ` : nothing} 
+        ${actionMode === 'service' ? html`
+          <div class="form-row">
+            <ha-combo-box
+              label="Service"
+              .hass=${this.hass}
+              .value=${action.service ?? ""}
+              .items=${this._serviceItems ?? []}
+              item-value-path="value"
+              item-label-path="label"
+              required
+              @value-changed=${(e) => this._updateActionProperty("service", e.detail.value)}
+            ></ha-combo-box>
+          </div>
+
+          ${typeof action.service === "string" && action.service.startsWith("script.") ? html`
+            <div class="form-row form-row-multi-column">
+              <div>
+                <ha-switch
+                  id="script-variable-toggle"
+                  .checked=${action?.script_variable ?? false}
+                  @change=${(e) =>
+                    this._updateActionProperty("script_variable", e.target.checked)}
+                ></ha-switch>
+                <span>Script Variable (yamp_entity)</span>
+              </div>
+            </div>
+          ` : nothing}
+
+          ${action.service ? html`
+            <div class="help-text">
+              <ha-icon
+                icon="mdi:information-outline"
+              ></ha-icon>
+              Use <code>entity_id: current</code> to target the card's 
+              currently selected media player entity.
+            </div>
+            <div class="help-text">
+              <ha-icon
+                icon="mdi:information-outline"
+              ></ha-icon>
+            Changes to the service data below are not committed to the config until 
+            <ha-icon icon="mdi:content-save"></ha-icon> is clicked!
+            </div>
+            <div class="form-row">
+              <div class="service-data-editor-header">
+                <div class="service-data-editor-title">Service Data</div>
+                <div class="service-data-editor-actions">
+                  <ha-icon
+                    class="icon-button ${!this._yamlModified ? "icon-button-disabled": ""}"
+                    icon="mdi:content-save"
+                    title="Save Service Data"
+                    @click=${this._saveYamlEditor}
+                  ></ha-icon>
+                  <ha-icon
+                    class="icon-button ${!this._yamlModified ? "icon-button-disabled": ""}"
+                    icon="mdi:backup-restore"
+                    title="Revert to Saved Service Data"
+                    @click=${this._revertYamlEditor}
+                  ></ha-icon>
+                  <ha-icon
+                    class="icon-button ${this._yamlError || !action?.service ? "icon-button-disabled": ""}"
+                    icon="mdi:play-circle-outline"
+                    title="Test Action"
+                    @click=${this._testServiceCall}
+                  ></ha-icon>              
+                </div>
+            </div>
+            <div class=${this._yamlError && this._yamlDraft.trim() !== "" 
+              ? "code-editor-wrapper error" 
+              : "code-editor-wrapper"}>
+              <ha-code-editor
+                id="service-data-editor"
+                label="Service Data"
+                autocomplete-entities
+                autocomplete-icons
+                .hass=${this.hass}
+                mode="yaml"
+                .value=${action?.service_data ? yaml.dump(action.service_data) : ""}
+                @value-changed=${(e) => {
+                  /* the yaml will be parsed in real time to detect errors, but we will defer 
+                    updating the config until the save button above the editor is clicked.
+                  */
+                  this._yamlDraft = e.detail.value;
+                  this._yamlModified = true;
+                  try {
+                    const parsed = yaml.load(this._yamlDraft);
+                    if (parsed && typeof parsed === "object") {
+                      this._yamlError = null;
+                    } else {
+                      this._yamlError = "Invalid YAML";
+                    }
+                  } catch (err) {
+                    this._yamlError = err.message;
+                  }
+                }}
+              ></ha-code-editor>
+              ${this._yamlError && this._yamlDraft.trim() !== ""
+                ? html`<div class="yaml-error-message">${this._yamlError}</div>`
+                : nothing}
+            </div>
+          ` : nothing}
+        ` : nothing}
+      </div>`
+    }
+ 
     _onEntityChanged(index, newValue) {
       const original = this._config.entities ?? [];
       const updated = [...original];
@@ -509,17 +915,40 @@ class YetAnotherMediaPlayerEditor extends LitElement {
     
       this._updateConfig("entities", cleaned);
     }
+
+    _onActionChanged(index, newValue) {
+      const original = this._config.actions ?? [];
+      const updated = [...original];
+    
+      updated[index] = { ...updated[index], name: newValue };
+   
+      this._updateConfig("actions", updated);
+    }
   
     _onEditEntity(index) {
       this._entityEditorIndex = index;
     }
   
+    _onEditAction(index) {
+      this._actionEditorIndex = index;
+      const action = this._config.actions?.[index];
+      this._actionMode = action?.menu_item ? "menu" : "service";
+    }
+
     _onBackFromEntityEditor() {
       this._entityEditorIndex = null;
+    }
+  
+    _onBackFromActionEditor() {
+      this._actionEditorIndex = null;
     }
 
     _toggleEntityMoveMode() {
       this._entityMoveMode = !this._entityMoveMode;
+    }
+
+    _toggleActionMoveMode() {
+      this._actionMoveMode = !this._actionMoveMode;
     }
 
     _moveEntity(idx, offset) {
@@ -535,6 +964,95 @@ class YetAnotherMediaPlayerEditor extends LitElement {
     
       this._updateConfig("entities", entities);
     }
+    
+    _moveAction(idx, offset) {
+      const actions = [...this._config.actions];
+      const newIndex = idx + offset;
+    
+      if (newIndex < 0 || newIndex >= actions.length) {
+        return;
+      }
+    
+      const [moved] = actions.splice(idx, 1);
+      actions.splice(newIndex, 0, moved);
+    
+      this._updateConfig("actions", actions);
+    }
+
+    _removeAction(index) {
+      const actions = [...(this._config.actions ?? [])];
+      if (index < 0 || index >= actions.length) return;
+    
+      actions.splice(index, 1);
+      this._updateConfig("actions", actions);
+    }
+
+    _saveYamlEditor() {
+      try {
+        const parsed = yaml.load(this._yamlDraft);
+    
+        if (!parsed || typeof parsed !== "object") {
+          this._yamlError = "YAML is not a valid object.";
+          return;
+        }
+    
+        this._updateActionProperty("service_data", parsed);
+        this._yamlDraft = yaml.dump(parsed);
+        this._yamlError = null;
+        this._parsedYaml = parsed;
+      } catch (err) {
+        this._yamlError = err.message;
+      }
+    }
+
+    _revertYamlEditor() {
+      const editor = this.shadowRoot.querySelector("#service-data-editor");
+      const currentAction = this._config.actions?.[this._actionEditorIndex];
+    
+      if (!editor || !currentAction) return;
+    
+      const yamlText = currentAction.service_data ? yaml.dump(currentAction.service_data): "";
+      editor.value = yamlText;
+    
+      this._yamlDraft = yamlText;
+      this._yamlError = null;
+      this._yamlModified = false;
+    }
+
+    async _testServiceCall() {
+      if (this._yamlError || !this._yamlDraft?.trim()) {
+        return;
+      }
+    
+      let serviceData;
+      try {
+        serviceData = yaml.load(this._yamlDraft);
+        if (typeof serviceData !== "object" || serviceData === null) {
+          console.error("Service data must be a valid object.");
+          return;
+        }
+      } catch (e) {
+        this._yamlError = e.message;
+        return;
+      }
+    
+      const action = this._config.actions?.[this._actionEditorIndex];
+      const service = action?.service;
+      if (!service || !this.hass) {
+        return;
+      }
+    
+      const [domain, serviceName] = service.split(".");
+      if (!domain || !serviceName) {
+        return;
+      }
+    
+      try {
+        await this.hass.callService(domain, serviceName, serviceData);
+      } catch (err) {
+        console.error("Failed to call service:", err);
+      }
+    }
 
     _onToggleChanged(e) {
       const newConfig = {
@@ -548,3 +1066,4 @@ class YetAnotherMediaPlayerEditor extends LitElement {
 
   customElements.define("yet-another-media-player-editor-beta", YetAnotherMediaPlayerEditor);
   export { YetAnotherMediaPlayerEditor };
+  


### PR DESCRIPTION
**Action Editor!**
- Added Dependency: jsyaml.
- Add, remove, and reorder actions, just like entities.
- Main screen shows action name (editable), icon, and summary of what the action does.
- Edit all action properties on a separate screen.
- YAML code editor for service_data:
  - Parses in real time and displays errors.
  - Save button to commit to preview config. Revert button to go back. Saving is disabled if there are errors.
  - Test button to run service (works before saving changes)
- script_variable toggle is hidden unless a script is selected.

**Misc**
- All icon buttons in the UI use the new pattern from your last update (ha-icon)
- Added icon-button, icon-button-disabled CSS classes. Added padding back in for sausage fingers.
- Removed my old CSS tweaks for vertical icon alignment (not needed anymore)
- Removed some redundant "grow-to-fit" CSS rules. (Already have .grow-children for this).


