### PR TITLE
Add workflow to attach release bundle

### DIFF
--- a/.github/workflows/attach-release-asset.yaml
+++ b/.github/workflows/attach-release-asset.yaml
@@ -1,0 +1,21 @@
+name: Attach Release Bundle
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  upload-bundle:
+    name: Attach Bundle to Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload bundle to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: yet-another-media-player.js


### PR DESCRIPTION
## Summary
- Automatically attach the pre-built yet-another-media-player.js bundle to each published release so HACS download analytics keep working.
- No UI changes; workflow only uploads the existing root bundle.