### PR TITLE
force plain text for radio

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7477,7 +7477,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
                         .loading=${this._fetchingLyrics}
                         .error=${this._lyricsError}
                         .activeThemeColor=${this.config.match_theme === true ? "var(--state-media_player-active-color, var(--primary-color, #ffffff))" : "var(--custom-accent, #ffffff)"}
-                        .mode=${this.config.lyrics_mode || 'default'}
+                        .mode=${this._isCurrentlyPlayingRadio() ? 'text' : (this.config.lyrics_mode || 'default')}
                         .preRoll=${this.config.lyrics_pre_roll ?? 0}
                       ></yamp-lyrics-view>
                     ` : nothing}

--- a/yet-another-media-player.js
+++ b/yet-another-media-player.js
@@ -6325,7 +6325,7 @@
                         .loading=${this._fetchingLyrics}
                         .error=${this._lyricsError}
                         .activeThemeColor=${this.config.match_theme===!0?"var(--state-media_player-active-color, var(--primary-color, #ffffff))":"var(--custom-accent, #ffffff)"}
-                        .mode=${this.config.lyrics_mode||"default"}
+                        .mode=${this._isCurrentlyPlayingRadio()?"text":this.config.lyrics_mode||"default"}
                         .preRoll=${this.config.lyrics_pre_roll??0}
                       ></yamp-lyrics-view>
                     `:v}


### PR DESCRIPTION
Highlighted lyrics require an accurate media position which is not possible with radio stations, if lyrics are fetched for a song playing from radio it will just show as plain text