### PR TITLE
fix: forcefully stage ignored bundle before commit action

### DIFF
--- a/.github/workflows/build-bundle.yaml
+++ b/.github/workflows/build-bundle.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Build the bundle
         run: npm run build
 
+      - name: Stage the ignored bundle
+        run: git add -f yet-another-media-player.js
+
       - name: Commit built bundle
         uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
This PR adds a manual step to run `git add -f yet-another-media-player.js` so the git-auto-commit-action recognizes the built file and creates a commit.