### PR TITLE
ci: upgrade workflows to Node.js 24

### DIFF
--- a/.github/workflows/attach-release-asset.yaml
+++ b/.github/workflows/attach-release-asset.yaml
@@ -1,5 +1,8 @@
 name: Attach Release Bundle
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   release:
     types:
@@ -18,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,5 +1,8 @@
 name: Validate
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -22,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Build bundle


### PR DESCRIPTION
This PR upgrades the GitHub Action workflows to Node.js 24 and sets the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to resolve the deprecation warnings for Node.js 20.