### PR TITLE
ci: upgrade actions to v6 for native Node.js 24 support

### DIFF
--- a/.github/workflows/attach-release-asset.yaml
+++ b/.github/workflows/attach-release-asset.yaml
@@ -1,8 +1,5 @@
 name: Attach Release Bundle
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   release:
     types:
@@ -16,10 +13,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,8 +1,5 @@
 name: Validate
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches:
@@ -21,9 +18,9 @@ jobs:
     name: Build Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Install dependencies


### PR DESCRIPTION
This PR upgrades `actions/checkout` and `actions/setup-node` to **v6**, which natively supports the Node.js 24 runtime. This allows us to remove the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable and eliminates the "forced to run on Node.js 24" warnings.