### PR TITLE
ci: upgrade softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/attach-release-asset.yaml
+++ b/.github/workflows/attach-release-asset.yaml
@@ -27,6 +27,6 @@ jobs:
         run: npm run build
 
       - name: Upload bundle to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: yet-another-media-player.js


### PR DESCRIPTION
This PR upgrades `softprops/action-gh-release` to **v3**, which natively supports the Node.js 24 runtime. This completes the upgrade of all actions in the repository to Node.js 24 compatible versions.