### PR TITLE
feat: add card templates system, layout cleanups, and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Below you will find a list of all configuration options.
 | `disable_mass_queue`       | boolean      | No           | `false`     | Disable the optional mass_queue integration even if it is installed |
 |                                                                                                 |
 | **Look and Feel**          |              |              |             |                                                                                                 |
+| `template`                 | choice       | No           | `custom`    | Apply a predefined card layout template; see [Card Templates](#card-templates)                  |
 | `match_theme`              | boolean      | No           | `false`     | Updates card accent colors to match your Home Assistant theme                                   |
 | `appearance`               | choice       | No           | `automatic` | Force the card into `light` or `dark` mode, or use `automatic` to follow system/theme settings |
 | `display_timestamps`       | boolean      | No           | `false`     | Display timestamps on the progress bar                                                          |
@@ -498,6 +499,32 @@ Set `card_type: group_players` to lock YAMP to the group players menu.
 - **Auto-Sync**: Quickly join or unjoin players and adjust individual volumes from a single, persistent screen.
 
 # Look and Feel
+
+## Card Templates
+
+YAMP supports predefined layout templates to quickly change the look and behavior of the card without writing extensive YAML. You can apply a template and then fine-tune any configuration option from there to meet your needs. 
+
+To use a template, configure the `template` key at the root of the card:
+```yaml
+type: custom:yet-another-media-player
+template: large_modern
+entities:
+  - media_player.living_room
+```
+
+### Available Templates
+
+- **`custom`** (Default): Your original, fully customized configuration. No template values are applied, and the card respects all manual overrides.
+- **`large_modern`**: A slightly larger modern design featuring a cover artwork background, modern player control layout, adaptive control sizing, and dynamic card height.
+- **`crisp_clean`**: A clean, minimalist layout with scaled-contain artwork, modern player controls, center-aligned track details, and stepper volume controls.
+- **`minimal_mini`**: A compact mini card with no visible artwork, stepper volume control, and clean text alignment.
+- **`normal_mini`**: The standard compact mini player card with a blurred background artwork effect.
+- **`dedicated_search`**: A standalone search and library browsing card without the main media player interface (forces `card_type: search`).
+- **`dedicated_grouping`**: A standalone player grouping card (forces `card_type: group_players`).
+- **`quick_and_easy`**: Designed for high accessibility and fast control, featuring a persistent entity chip row, volume overlays, and always-active quick grouping mode.
+- **`huge_yamp`**: Maximized controls, large text, and a massive progress bar designed for across-the-room viewing.
+
+---
 
 ## Theme & Layout
 > Match dashboard styling and control the overall footprint.

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const SUPPORT_PLAY_MEDIA = 512;
 export const SUPPORT_STOP = 4096;
 export const SUPPORT_PLAY = 16384;
 export const SUPPORT_SHUFFLE = 32768;
-export const SUPPORT_GROUPING = 524288;  
+export const SUPPORT_GROUPING = 524288;
 export const SUPPORT_REPEAT_SET = 262144;
 
 export const ARTWORK_OVERRIDE_MATCH_KEYS = Object.freeze([
@@ -27,3 +27,81 @@ export const ARTWORK_OVERRIDE_MATCH_KEYS = Object.freeze([
 ]);
 
 export const DEFAULT_PROGRESS_BAR_HEIGHT = 6;
+
+export const TEMPLATE_CONFIGS = Object.freeze({
+  custom: {},
+  large_modern: {
+    match_theme: true,
+    appearance: "automatic",
+    control_layout: "modern",
+    adaptive_controls: true,
+    adaptive_text: true,
+    artwork_object_fit: "cover",
+    extend_artwork: true,
+    show_chip_row: "in_menu_on_idle",
+    hold_to_pin: true
+  },
+  crisp_clean: {
+    match_theme: true,
+    appearance: "automatic",
+    artwork_object_fit: "scaled-contain-alternate",
+    control_layout: "modern",
+    adaptive_controls: true,
+    hold_to_pin: true
+  },
+  minimal_mini: {
+    match_theme: true,
+    appearance: "automatic",
+    always_collapsed: true,
+    show_chip_row: "in_menu",
+    details_alignment: "left",
+    hold_to_pin: true
+  },
+  auto_compact: {
+    match_theme: true,
+    appearance: "automatic",
+    collapse_on_idle: true,
+    show_chip_row: "in_menu_on_idle",
+    hold_to_pin: true
+  },
+  music_explorer: {
+    match_theme: true,
+    appearance: "automatic",
+    idle_screen: "search",
+    hide_search_headers_on_idle: true,
+    search_view: "card",
+    search_card_columns: 4,
+    hold_to_pin: true
+  },
+  dedicated_search: {
+    match_theme: true,
+    appearance: "automatic",
+    card_type: "search",
+    search_view: "card",
+    hide_menu_player: false,
+    hold_to_pin: true
+  },
+  quick_and_easy: {
+    match_theme: true,
+    appearance: "automatic",
+    always_show_quick_group: true,
+    show_chip_row: "always",
+    dismiss_search_on_play: true,
+    show_volume_overlay: true,
+    hold_to_pin: true
+  },
+  huge_yamp: {
+    match_theme: true,
+    appearance: "automatic",
+    control_layout: "modern",
+    adaptive_controls: true,
+    adaptive_text: true,
+    progress_bar_height: 48,
+    display_timestamps: true,
+    artwork_object_fit: "cover",
+    extend_artwork: true,
+    search_view: "card",
+    search_card_columns: 2,
+    show_volume_overlay: true
+  }
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,7 +39,13 @@ export const TEMPLATE_CONFIGS = Object.freeze({
     artwork_object_fit: "cover",
     extend_artwork: true,
     show_chip_row: "in_menu_on_idle",
-    hold_to_pin: true
+    hold_to_pin: true,
+    pin_search_headers: true,
+    progress_bar_height: 16,
+    search_view: "card",
+    search_card_columns: 3,
+    display_timestamps: true,
+    details_alignment: "left"
   },
   crisp_clean: {
     match_theme: true,
@@ -47,7 +53,12 @@ export const TEMPLATE_CONFIGS = Object.freeze({
     artwork_object_fit: "scaled-contain-alternate",
     control_layout: "modern",
     adaptive_controls: true,
-    hold_to_pin: true
+    hold_to_pin: true,
+    show_chip_row: "in_menu",
+    alternate_progress_bar: true,
+    search_view: "card_minimal",
+    search_card_columns: 3,
+    details_alignment: "center"
   },
   minimal_mini: {
     match_theme: true,
@@ -55,14 +66,12 @@ export const TEMPLATE_CONFIGS = Object.freeze({
     always_collapsed: true,
     show_chip_row: "in_menu",
     details_alignment: "left",
-    hold_to_pin: true
-  },
-  auto_compact: {
-    match_theme: true,
-    appearance: "automatic",
-    collapse_on_idle: true,
-    show_chip_row: "in_menu_on_idle",
-    hold_to_pin: true
+    hold_to_pin: true,
+    progress_bar_height: 2,
+    volume_mode: "stepper",
+    extend_artwork: true,
+    blurred_artwork: true,
+    hide_collapsed_artwork: true
   },
   music_explorer: {
     match_theme: true,

--- a/src/constants.js
+++ b/src/constants.js
@@ -73,15 +73,6 @@ export const TEMPLATE_CONFIGS = Object.freeze({
     blurred_artwork: true,
     hide_collapsed_artwork: true
   },
-  music_explorer: {
-    match_theme: true,
-    appearance: "automatic",
-    idle_screen: "search",
-    hide_search_headers_on_idle: true,
-    search_view: "card",
-    search_card_columns: 4,
-    hold_to_pin: true
-  },
   dedicated_search: {
     match_theme: true,
     appearance: "automatic",

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,16 +49,23 @@ export const TEMPLATE_CONFIGS = Object.freeze({
   },
   crisp_clean: {
     match_theme: true,
-    appearance: "automatic",
-    artwork_object_fit: "scaled-contain-alternate",
-    control_layout: "modern",
-    adaptive_controls: true,
+    volume_mode: "stepper",
     hold_to_pin: true,
+    volume_step: 0.05,
     show_chip_row: "in_menu",
-    alternate_progress_bar: true,
-    search_view: "card_minimal",
-    search_card_columns: 3,
-    details_alignment: "center"
+    extend_artwork: true,
+    search_results_sort: "play_count_desc",
+    control_layout: "modern",
+    dismiss_search_on_play: true,
+    keep_filters_on_search: false,
+    display_timestamps: true,
+    search_view: "list",
+    default_search_filter: "all",
+    default_search_favorites: true,
+    appearance: "automatic",
+    details_alignment: "center",
+    artwork_object_fit: "scaled-contain-alternate",
+    progress_bar_height: 2
   },
   minimal_mini: {
     match_theme: true,
@@ -73,13 +80,34 @@ export const TEMPLATE_CONFIGS = Object.freeze({
     blurred_artwork: true,
     hide_collapsed_artwork: true
   },
+  normal_mini: {
+    match_theme: true,
+    appearance: "automatic",
+    always_collapsed: true,
+    show_chip_row: "auto",
+    details_alignment: "left",
+    hold_to_pin: true,
+    progress_bar_height: 2,
+    volume_mode: "slider",
+    extend_artwork: true,
+    blurred_artwork: true
+  },
   dedicated_search: {
     match_theme: true,
     appearance: "automatic",
     card_type: "search",
     search_view: "card",
-    hide_menu_player: false,
-    hold_to_pin: true
+    hide_menu_player: true,
+    hold_to_pin: true,
+    show_chip_row: "in_menu",
+    disable_autofocus: true
+  },
+  dedicated_grouping: {
+    match_theme: true,
+    appearance: "automatic",
+    card_type: "group_players",
+    hide_menu_player: true,
+    show_chip_row: "in_menu"
   },
   quick_and_easy: {
     match_theme: true,
@@ -87,6 +115,7 @@ export const TEMPLATE_CONFIGS = Object.freeze({
     always_show_quick_group: true,
     show_chip_row: "always",
     dismiss_search_on_play: true,
+    extend_artwork: true,
     show_volume_overlay: true,
     hold_to_pin: true
   },

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Musik suchen..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Eine kompakte Karte ohne Artwork."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "Die Standard-Kompaktkarte."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -55,10 +55,6 @@ export default {
                 "label": "Quick & Easy",
                 "description": "Optimized for speed with persistent chip rows and quick grouping."
             },
-            "music_explorer": {
-                "label": "Music Explorer",
-                "description": "Focuses heavily on search and discovery with a prominent search interface."
-            },
             "dedicated_search": {
                 "label": "Dedicated Search Mode",
                 "description": "A standalone search card without the main media player interface."

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -34,6 +34,44 @@ export default {
             "artwork": "Artwork",
             "actions": "Actions"
         },
+        "templates": {
+            "custom": {
+                "label": "Custom (Original Config)",
+                "description": "Your original, fully customized configuration."
+            },
+            "large_modern": {
+                "label": "Large Modern",
+                "description": "A sleek, modern design with adaptive controls and full-bleed artwork."
+            },
+            "crisp_clean": {
+                "label": "Crisp & Clean",
+                "description": "A clean layout with scaled artwork and modern controls."
+            },
+            "minimal_mini": {
+                "label": "Minimal Mini",
+                "description": "A compact, always-collapsed card ideal for tight spaces."
+            },
+            "auto_compact": {
+                "label": "Auto-Compact",
+                "description": "Automatically collapses to save space when no media is playing."
+            },
+            "quick_and_easy": {
+                "label": "Quick & Easy",
+                "description": "Optimized for speed with persistent chip rows and quick grouping."
+            },
+            "music_explorer": {
+                "label": "Music Explorer",
+                "description": "Focuses heavily on search and discovery with a prominent search interface."
+            },
+            "dedicated_search": {
+                "label": "Dedicated Search Mode",
+                "description": "A standalone search card without the main media player interface."
+            },
+            "huge_yamp": {
+                "label": "That's a Huge YAMP!",
+                "description": "Maximized controls, large text, and a massive progress bar for an ultra-large visual experience."
+            }
+        },
         "placeholders": {
             "search": "Search music..."
         },

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -40,28 +40,36 @@ export default {
                 "description": "Your original, fully customized configuration."
             },
             "large_modern": {
-                "label": "Large Modern",
-                "description": "A sleek, modern design with adaptive controls and full-bleed artwork."
+                "label": "Big Ol' Modern YAMP",
+                "description": "A slightly larger modern design with adaptive controls."
             },
             "crisp_clean": {
-                "label": "Crisp & Clean",
+                "label": "Clean",
                 "description": "A clean layout with scaled artwork and modern controls."
             },
             "minimal_mini": {
-                "label": "Minimal Mini",
-                "description": "A compact, always-collapsed card ideal for tight spaces."
+                "label": "MINImal",
+                "description": "A compact card with no artwork"
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "The standard compact card."
             },
             "quick_and_easy": {
-                "label": "Quick & Easy",
-                "description": "Optimized for speed with persistent chip rows and quick grouping."
+                "label": "No Time To Explain",
+                "description": "Used for speed with persistent chip rows and quick grouping."
             },
             "dedicated_search": {
-                "label": "Dedicated Search Mode",
-                "description": "A standalone search card without the main media player interface."
+                "label": "All About That Search",
+                "description": "A standalone search card without the main media player."
+            },
+            "dedicated_grouping": {
+                "label": "Group Therapy",
+                "description": "A standalone player grouping card. Requires multiple entities configured."
             },
             "huge_yamp": {
                 "label": "That's a Huge YAMP!",
-                "description": "Maximized controls, large text, and a massive progress bar for an ultra-large visual experience."
+                "description": "Maximized controls, large text, and a massive progress bar for across room viewing."
             }
         },
         "placeholders": {

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -51,10 +51,6 @@ export default {
                 "label": "Minimal Mini",
                 "description": "A compact, always-collapsed card ideal for tight spaces."
             },
-            "auto_compact": {
-                "label": "Auto-Compact",
-                "description": "Automatically collapses to save space when no media is playing."
-            },
             "quick_and_easy": {
                 "label": "Quick & Easy",
                 "description": "Optimized for speed with persistent chip rows and quick grouping."

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -34,6 +34,7 @@ export default {
             "artwork": "Artwork",
             "actions": "Actions"
         },
+        "template_label": "Card Template",
         "templates": {
             "custom": {
                 "label": "Custom (Original Config)",
@@ -49,7 +50,7 @@ export default {
             },
             "minimal_mini": {
                 "label": "MINImal",
-                "description": "A compact card with no artwork"
+                "description": "A compact card with no artwork."
             },
             "normal_mini": {
                 "label": "Mini Mode",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Buscar música..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Una tarjeta compacta sin carátula."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "La tarjeta compacta estándar."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Rechercher de la musique..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Une carte compacte sans pochette."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "La carte compacte standard."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Cerca musica..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Una scheda compatta senza copertina."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "La scheda compatta standard."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Zoek muziek..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Een compacte kaart zonder artwork."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "De standaard compacte kaart."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Procurar música..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Um cartão compacto sem capa."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "O cartão compacto padrão."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Hľadať hudbu..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Kompaktná karta bez obalu."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "Štandardná kompaktná karta."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -37,6 +37,16 @@ export default {
         "placeholders": {
             "search": "Išči glasbo..."
         },
+        "templates": {
+            "minimal_mini": {
+                "label": "MINImal",
+                "description": "Kompaktna kartica brez naslovnice."
+            },
+            "normal_mini": {
+                "label": "Mini Mode",
+                "description": "Standardna kompaktna kartica."
+            }
+        },
         "sections": {
             "artwork": {
                 "general": {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3332,9 +3332,6 @@ export const yampCardStyles = css`
   .search-sheet-results.search-results-card-view,
   .entity-options-search-results.search-results-card-view,
   .search-sheet[data-card-view="true"] .search-sheet-results {
-    display: grid;
-    grid-template-columns: repeat(var(--search-card-columns, 4), 1fr);
-    gap: 12px;
     padding: 12px;
   }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3342,6 +3342,11 @@ export const yampCardStyles = css`
     ${HIDE_SCROLLBAR}
   }
 
+  .entity-options-sheet:not([data-pin-search-headers="true"]) .search-sheet-results,
+  .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search-results {
+    overflow-y: visible;
+  }
+
   .yamp-search-result.search-result-card {
     flex-direction: column;
     padding: 8px;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2969,7 +2969,14 @@ export const yampCardStyles = css`
   }
 
   .entity-options-sheet .entity-options-search-results {
-    min-height: 210px;
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    margin: 12px 0;
+    padding-bottom: 0px;
+    /* Hide scrollbars */
+    ${HIDE_SCROLLBAR}
   }
 
   /* Search layout */
@@ -3046,6 +3053,12 @@ export const yampCardStyles = css`
     padding-bottom: 0px ;
   }
 
+  .entity-options-sheet[data-pin-search-headers="true"] .entity-options-scroll {
+    overflow-y: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
   /* Unified Header and Scroll Containers for Menu Sheets */
   .entity-options-header {
     flex: 0 0 auto;
@@ -3073,7 +3086,7 @@ export const yampCardStyles = css`
 
   /* Reserved space for persistent media controls when pinning is active */
   .entity-options-sheet[data-pin-search-headers="true"] .entity-options-scroll,
-  .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search-results,
+  .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search,
   .entity-options-sheet[data-pin-search-headers="true"] .group-list-scroll {
     margin-bottom: 80px;
     padding-bottom: 0px ;
@@ -3088,23 +3101,13 @@ export const yampCardStyles = css`
 
   /* Clean up legacy margin override rules since we now use padding on parent */
   :host([data-hide-persistent-controls="true"]) .entity-options-sheet[data-pin-search-headers="true"] .entity-options-scroll,
-  :host([data-hide-persistent-controls="true"]) .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search-results,
+  :host([data-hide-persistent-controls="true"]) .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search,
   :host([data-hide-persistent-controls="true"]) .entity-options-sheet[data-pin-search-headers="true"] .group-list-scroll,
   :host([data-hide-menu-player="true"]) .entity-options-sheet[data-pin-search-headers="true"] .entity-options-scroll,
-  :host([data-hide-menu-player="true"]) .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search-results,
+  :host([data-hide-menu-player="true"]) .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search,
   :host([data-hide-menu-player="true"]) .entity-options-sheet[data-pin-search-headers="true"] .group-list-scroll {
     margin-bottom: 0px;
   }
-
-  .entity-options-sheet .entity-options-search-results {
-    flex: 1;
-    overflow-y: auto;
-    margin: 12px 0;
-    padding-bottom: 0px;
-    /* Hide scrollbars */
-    ${HIDE_SCROLLBAR}
-  }
-
   /* Hide scrollbars for Webkit browsers (Chrome, Safari, etc.) */
 
 
@@ -3329,14 +3332,11 @@ export const yampCardStyles = css`
     100% { opacity: 0; transform: translate(-50%, -40%); }
   }
 
-  .search-sheet-results.search-results-card-view,
-  .entity-options-search-results.search-results-card-view,
-  .search-sheet[data-card-view="true"] .search-sheet-results {
-    padding: 12px;
-  }
 
   .search-sheet-results {
+    position: relative;
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     /* Hide scrollbars */
     ${HIDE_SCROLLBAR}

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -859,7 +859,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                     { value: "large_modern", label: localize('editor.templates.large_modern.label') },
                     { value: "crisp_clean", label: localize('editor.templates.crisp_clean.label') },
                     { value: "minimal_mini", label: localize('editor.templates.minimal_mini.label') },
-                    { value: "auto_compact", label: localize('editor.templates.auto_compact.label') },
                     { value: "quick_and_easy", label: localize('editor.templates.quick_and_easy.label') },
                     { value: "music_explorer", label: localize('editor.templates.music_explorer.label') },
                     { value: "dedicated_search", label: localize('editor.templates.dedicated_search.label') },

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -860,7 +860,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                     { value: "crisp_clean", label: localize('editor.templates.crisp_clean.label') },
                     { value: "minimal_mini", label: localize('editor.templates.minimal_mini.label') },
                     { value: "quick_and_easy", label: localize('editor.templates.quick_and_easy.label') },
-                    { value: "music_explorer", label: localize('editor.templates.music_explorer.label') },
                     { value: "dedicated_search", label: localize('editor.templates.dedicated_search.label') },
                     { value: "huge_yamp", label: localize('editor.templates.huge_yamp.label') }
                   ]

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -859,8 +859,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                     { value: "large_modern", label: localize('editor.templates.large_modern.label') },
                     { value: "crisp_clean", label: localize('editor.templates.crisp_clean.label') },
                     { value: "minimal_mini", label: localize('editor.templates.minimal_mini.label') },
+                    { value: "normal_mini", label: localize('editor.templates.normal_mini.label') },
                     { value: "quick_and_easy", label: localize('editor.templates.quick_and_easy.label') },
                     { value: "dedicated_search", label: localize('editor.templates.dedicated_search.label') },
+                    { value: "dedicated_grouping", label: localize('editor.templates.dedicated_grouping.label') },
                     { value: "huge_yamp", label: localize('editor.templates.huge_yamp.label') }
                   ]
                 }

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -46,6 +46,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     this._useTemplate = null; // auto-detect per entity on open
     this._useVolTemplate = null; // auto-detect per entity on open
     this._artworkOverrides = [];
+    this._preTemplateConfig = null;
   }
 
   firstUpdated() {
@@ -850,21 +851,14 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           <div class="form-row">
             <ha-selector
               .hass=${this.hass}
-              label="Card Template"
+              label=${localize('editor.template_label')}
               .selector=${{
                 select: {
                   mode: "dropdown",
-                  options: [
-                    { value: "custom", label: localize('editor.templates.custom.label') },
-                    { value: "large_modern", label: localize('editor.templates.large_modern.label') },
-                    { value: "crisp_clean", label: localize('editor.templates.crisp_clean.label') },
-                    { value: "minimal_mini", label: localize('editor.templates.minimal_mini.label') },
-                    { value: "normal_mini", label: localize('editor.templates.normal_mini.label') },
-                    { value: "quick_and_easy", label: localize('editor.templates.quick_and_easy.label') },
-                    { value: "dedicated_search", label: localize('editor.templates.dedicated_search.label') },
-                    { value: "dedicated_grouping", label: localize('editor.templates.dedicated_grouping.label') },
-                    { value: "huge_yamp", label: localize('editor.templates.huge_yamp.label') }
-                  ]
+                  options: Object.keys(TEMPLATE_CONFIGS).map(key => ({
+                    value: key,
+                    label: localize(`editor.templates.${key}.label`)
+                  }))
                 }
               }}
               .value=${currentTemplate}

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -5,7 +5,7 @@ import yaml from 'js-yaml';
 import { localize } from "./localize/localize.js";
 
 
-import { SUPPORT_GROUPING } from "./constants.js";
+import { SUPPORT_GROUPING, TEMPLATE_CONFIGS } from "./constants.js";
 import { isMusicAssistantEntity } from "./yamp-utils.js";
 import "./yamp-sortable.js";
 
@@ -21,6 +21,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     return {
       hass: {},
       _config: {},
+      _yamlConfig: {},
       _activeTab: { type: String },
       _entityEditorIndex: { type: Number },
       _actionEditorIndex: { type: Number },
@@ -40,6 +41,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     this._yamlDraft = "";
     this._parsedYaml = null;
     this._yamlError = false;
+    this._yamlConfig = {};
     this._serviceItems = [];
     this._useTemplate = null; // auto-detect per entity on open
     this._useVolTemplate = null; // auto-detect per entity on open
@@ -251,12 +253,17 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
   }
 
   setConfig(config) {
+    this._yamlConfig = { ...config };
     const rawEntities = config.entities ?? [];
     const normalizedEntities = rawEntities.map((e) =>
       typeof e === "string" ? { entity_id: e } : e
     );
 
+    const templateName = config.template || "custom";
+    const templateBase = TEMPLATE_CONFIGS[templateName] || {};
+
     this._config = {
+      ...templateBase,
       ...config,
       entities: normalizedEntities,
     };
@@ -264,10 +271,58 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
   }
 
   _updateConfig(key, value) {
+    if (key === "template") {
+      this._changeTemplate(value);
+      return;
+    }
+
+    const newYaml = { ...this._yamlConfig, [key]: value };
+    this._yamlConfig = newYaml;
+
     const newConfig = { ...this._config, [key]: value };
     this._config = newConfig;
     this.dispatchEvent(new CustomEvent("config-changed", {
-      detail: { config: newConfig },
+      detail: { config: newYaml },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  _changeTemplate(templateName) {
+    let newYaml = { ...this._yamlConfig };
+
+    // Save snapshot if moving away from custom
+    if (templateName !== "custom" && (!newYaml.template || newYaml.template === "custom")) {
+      this._preTemplateConfig = { ...newYaml };
+    }
+
+    if (templateName === "custom") {
+      if (this._preTemplateConfig) {
+        newYaml = { ...this._preTemplateConfig, template: "custom" };
+      } else {
+        newYaml.template = "custom";
+      }
+    } else {
+      const templateBase = TEMPLATE_CONFIGS[templateName] || {};
+      // Delete keys that the template provides so they don't override the template
+      for (const k of Object.keys(templateBase)) {
+        delete newYaml[k];
+      }
+      newYaml.template = templateName;
+    }
+
+    this._yamlConfig = newYaml;
+    
+    // Compute the new merged UI config
+    const activeTemplateBase = TEMPLATE_CONFIGS[templateName] || {};
+    this._config = {
+      ...activeTemplateBase,
+      ...newYaml,
+      entities: this._config.entities, // preserve normalized entities
+    };
+
+    this.dispatchEvent(new CustomEvent("config-changed", {
+      detail: { config: newYaml },
       bubbles: true,
       composed: true,
     }));
@@ -784,11 +839,42 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
   render() {
     if (!this._config) return html``;
 
+    const currentTemplate = this._yamlConfig.template || "custom";
+
     // When editing an entity/action, keep tabs visible but show editor content
     const editingEntity = this._entityEditorIndex !== null;
     const editingAction = this._actionEditorIndex !== null;
 
     return html`
+        <div class="config-section" style="margin-top: 0; margin-bottom: 12px;">
+          <div class="form-row">
+            <ha-selector
+              .hass=${this.hass}
+              label="Card Template"
+              .selector=${{
+                select: {
+                  mode: "dropdown",
+                  options: [
+                    { value: "custom", label: localize('editor.templates.custom.label') },
+                    { value: "large_modern", label: localize('editor.templates.large_modern.label') },
+                    { value: "crisp_clean", label: localize('editor.templates.crisp_clean.label') },
+                    { value: "minimal_mini", label: localize('editor.templates.minimal_mini.label') },
+                    { value: "auto_compact", label: localize('editor.templates.auto_compact.label') },
+                    { value: "quick_and_easy", label: localize('editor.templates.quick_and_easy.label') },
+                    { value: "music_explorer", label: localize('editor.templates.music_explorer.label') },
+                    { value: "dedicated_search", label: localize('editor.templates.dedicated_search.label') },
+                    { value: "huge_yamp", label: localize('editor.templates.huge_yamp.label') }
+                  ]
+                }
+              }}
+              .value=${currentTemplate}
+              @value-changed=${(e) => this._updateConfig("template", e.detail.value)}
+            ></ha-selector>
+            <div class="config-subtitle small" style="margin-top: 8px;">
+              ${localize(`editor.templates.${currentTemplate}.description`)}
+            </div>
+          </div>
+        </div>
         <div class="tabs">
           ${["entities", "behavior", "look_and_feel", "artwork", "actions"].map((key) => {
       const name = localize(`editor.tabs.${key}`);

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -299,7 +299,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
     if (templateName === "custom") {
       if (this._preTemplateConfig) {
-        newYaml = { ...this._preTemplateConfig, template: "custom" };
+        newYaml = { ...this._preTemplateConfig, ...newYaml, template: "custom" };
       } else {
         newYaml.template = "custom";
       }

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -56,7 +56,8 @@ import {
   SUPPORT_GROUPING,
   SUPPORT_REPEAT_SET,
   ARTWORK_OVERRIDE_MATCH_KEYS,
-  DEFAULT_PROGRESS_BAR_HEIGHT
+  DEFAULT_PROGRESS_BAR_HEIGHT,
+  TEMPLATE_CONFIGS
 } from "./constants.js";
 
 const PLAYLIST_FETCH_LIMIT = 500;
@@ -4018,12 +4019,15 @@ class YetAnotherMediaPlayerCard extends LitElement {
     return trimmed;
   }
 
-  setConfig(config) {
-    if (!config.entities || !Array.isArray(config.entities) || config.entities.length === 0) {
+  setConfig(rawConfig) {
+    if (!rawConfig.entities || !Array.isArray(rawConfig.entities) || rawConfig.entities.length === 0) {
       throw new Error("You must define at least one media_player entity.");
     }
     const oldConfig = this.config;
-    this.config = { ...config };
+    const templateName = rawConfig.template || "custom";
+    const templateBase = TEMPLATE_CONFIGS[templateName] || {};
+    const config = { ...templateBase, ...rawConfig };
+    this.config = config;
     const layoutPref = typeof config.control_layout === "string" ? config.control_layout.toLowerCase() : "classic";
     this._controlLayout = layoutPref === "modern" ? "modern" : "classic";
     this._swapPauseForStop = config.swap_pause_for_stop === true;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7821,7 +7821,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
           this._showGrouping ? this._renderGroupingSheet() :
             this._showTransferQueue ? this._renderTransferQueueSheet() :
               this._showResolvedEntities ? this._renderResolvedEntitiesSheet() :
-                this._showSearchInSheet ? this._renderSearchInOptions(showSearchHeaders) :
+                this._showSearchInSheet ? this._renderSearchInOptions(showSearchHeaders, effectivePinHeaders) :
                   this._renderSourceListSheet(sourceList, sourceLetters, availableSourceFirstLetters)}
               </div>
             </div>
@@ -8224,7 +8224,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     `;
   }
 
-  _renderSearchInOptions(showSearchHeaders) {
+  _renderSearchInOptions(showSearchHeaders, pinSearchHeaders = false) {
     return html`
       <div class="entity-options-search" style="margin-top:12px;">
         ${this._searchHierarchy.length > 0 ? html`
@@ -8385,9 +8385,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
           ? virtualize({
               items: paddedResults,
               renderItem: renderItemFn,
-              layout: this._cachedSearchGridLayout
+              layout: this._cachedSearchGridLayout,
+              scroller: pinSearchHeaders
             })
-          : virtualize({ items: paddedResults, renderItem: renderItemFn });
+          : virtualize({ items: paddedResults, renderItem: renderItemFn, scroller: pinSearchHeaders });
       })()}
         </div>
       </div>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8373,8 +8373,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
           this._cachedSearchGridLayoutIsMinimal = isMinimal;
           this._cachedSearchGridLayout = yampGrid({
             columns: this._cachedSearchGridLayoutColumns,
-            gap: 12,
-            padding: 12,
+            gap: '12px',
+            padding: '12px',
             itemSize: isMinimal
               ? { width: 150, height: 150 }
               : { width: 150, height: 244 }

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7542,8 +7542,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     let artworkPos = this.config.artwork_position || "top center";
     if (artworkFullBleed) {
       // Offset artwork away from edges to account for the chip row / controls that overlay the artwork
-      if (artworkPos === "top center") artworkPos = "center 50px";
-      else if (artworkPos === "bottom center") artworkPos = "center calc(100% - 50px)";
+      if (artworkPos === "top center" || artworkPos === "center top") artworkPos = "center 50px";
+      else if (artworkPos === "bottom center" || artworkPos === "center bottom") artworkPos = "center calc(100% - 50px)";
     }
 
     const sharedBackgroundStyle = [

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7539,10 +7539,16 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const backgroundFilter = (artworkUrl && (this.config.blurred_artwork === true || (this.config.blurred_artwork !== false && (collapsed || (useInsetArtwork && activeArtworkFit === "scaled-contain")))))
       ? "blur(18px) brightness(0.7) saturate(1.15)"
       : "none";
+    let artworkPos = this.config.artwork_position || "top center";
+    if (artworkFullBleed) {
+      if (artworkPos === "top center") artworkPos = "center 50px";
+      else if (artworkPos === "bottom center") artworkPos = "center calc(100% - 50px)";
+    }
+
     const sharedBackgroundStyle = [
       `background-image: ${backgroundImageValue}`,
       `background-size: ${useInsetArtwork ? "cover" : backgroundSize}`,
-      `background-position: ${this.config.artwork_position || "top center"}`,
+      `background-position: ${artworkPos}`,
       "background-repeat: no-repeat",
       `filter: ${backgroundFilter}`
     ].join('; ');

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7541,6 +7541,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       : "none";
     let artworkPos = this.config.artwork_position || "top center";
     if (artworkFullBleed) {
+      // Offset artwork away from edges to account for the chip row / controls that overlay the artwork
       if (artworkPos === "top center") artworkPos = "center 50px";
       else if (artworkPos === "bottom center") artworkPos = "center calc(100% - 50px)";
     }
@@ -8329,7 +8330,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         
         ${this._renderSearchSubFilters(showSearchHeaders)}
  
-        <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} ${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? 'search-results-card-view' : 'list-view'}" 
+        <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'}" 
              style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? `--search-card-columns: ${this.config.search_card_columns || 4};` : ''}">
           ${(() => {
         const filter = this._searchMediaClassFilter || "all";


### PR DESCRIPTION
## Summary
This Pull Request introduces a new template-based configuration system to the card and its editor, simplifies layout styles, updates localized strings, and fixes visual bugs related to scrolling and cutoff.

## Changes
- **Templates System**:
  - Implemented card templates (`large_modern`, `crisp_clean`, `minimal_mini`, `normal_mini`, `quick_and_easy`, `dedicated_search`, `dedicated_grouping`, `huge_yamp`, `custom`).
  - Added dynamic generation of template selector options in the editor.
  - Removed outdated templates: `auto_compact` and `music_explorer`.
- **Layout & Visuals**:
  - Simplified search result styling and normalized gap/padding units.
  - Adjusted artwork background position for full-bleed display offsets and added artwork offset.
  - Fixed scroll issue when `pin_headers` is true.
  - Fixed bottom cutoff issue.
- **Localization**:
  - Added localized strings for new templates under `src/localize/languages/`.