### PR TITLE
Fix search result thumbnail padding and slide-out button icon hover color

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3478,13 +3478,6 @@ export const yampCardStyles = css`
     margin-right: 12px;
   }
 
-  .yamp-search-result-thumb {
-    width: 38px;
-    height: 38px;
-    border-radius: 8px;
-    object-fit: var(--yamp-artwork-fit, cover);
-    margin-right: 12px;
-  }
 
   .search-result-card .yamp-search-result-thumb,
   .search-result-card .yamp-search-result-thumb-placeholder {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2702,6 +2702,12 @@ export const yampCardStyles = css`
   .slide-out-button ha-icon {
     width: 18px;
     height: 18px;
+    color: inherit;
+    --mdc-icon-color: currentColor;
+    --icon-color: currentColor;
+    --paper-item-icon-color: currentColor;
+    --ha-icon-color: currentColor;
+    fill: currentColor;
   }
 
   .slide-out-close {
@@ -3464,8 +3470,15 @@ export const yampCardStyles = css`
     }
   }
 
-  .yamp-search-result-thumb,
   .yamp-search-result-thumb-placeholder {
+    width: 38px;
+    height: 38px;
+    border-radius: 8px;
+    object-fit: var(--yamp-artwork-fit, cover);
+    margin-right: 12px;
+  }
+
+  .yamp-search-result-thumb {
     width: 38px;
     height: 38px;
     border-radius: 8px;
@@ -3492,6 +3505,7 @@ export const yampCardStyles = css`
     position: relative;
     width: auto;
     flex-shrink: 0;
+    padding-left: 5px;
   }
 
   .search-result-card .search-sheet-thumb-container {


### PR DESCRIPTION
This PR addresses alignment and hover styling issues in the search results components:
1. **Thumbnail Layout Adjustment:** Moves the `padding-left: 5px` from the `yamp-search-result-thumb` element to its parent container (`search-sheet-thumb-container`) to avoid creating a white space within the thumb itself.
2. **Icon Hover Color Alignment:** Adds CSS color inheritance variables (`color: inherit`, `--mdc-icon-color: currentColor`, etc.) to the `<ha-icon>` inside `.slide-out-button` so the icon color matches the text on hover.