### PR TITLE
feat: replace search and cancel text buttons with icon-only buttons

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8310,6 +8310,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
               style="min-width:48px; padding: 0;"
               @click=${() => this._handleSearchSubmit()}
               title="${localize('common.search')}"
+              aria-label="${localize('common.search')}"
               ?disabled=${this._searchLoading}>
               <ha-icon icon="mdi:magnify"></ha-icon>
             </button>
@@ -8318,6 +8319,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
               class="entity-options-item icon-only"
               style="min-width:48px; padding: 0;"
               title="${localize('common.cancel')}"
+              aria-label="${localize('common.cancel')}"
               @click=${() => { if (this._quickMenuInvoke) { this._dismissWithAnimation(); } else { this._hideSearchSheetInOptions(); } }}>
               <ha-icon icon="mdi:close"></ha-icon>
             </button>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8306,18 +8306,20 @@ class YetAnotherMediaPlayerCard extends LitElement {
               ` : nothing}
             </div>
             <button
-              class="entity-options-item"
-              style="min-width:80px;"
+              class="entity-options-item icon-only"
+              style="min-width:48px; padding: 0;"
               @click=${() => this._handleSearchSubmit()}
+              title="${localize('common.search')}"
               ?disabled=${this._searchLoading}>
-              ${localize('common.search')}
+              <ha-icon icon="mdi:magnify"></ha-icon>
             </button>
             ${this._cardType !== "search" ? html`
             <button
-              class="entity-options-item"
-              style="min-width:80px;"
+              class="entity-options-item icon-only"
+              style="min-width:48px; padding: 0;"
+              title="${localize('common.cancel')}"
               @click=${() => { if (this._quickMenuInvoke) { this._dismissWithAnimation(); } else { this._hideSearchSheetInOptions(); } }}>
-              ${localize('common.cancel')}
+              <ha-icon icon="mdi:close"></ha-icon>
             </button>
             ` : nothing}
           </div>


### PR DESCRIPTION
### Summary
This PR replaces the text-based "Search" and "Cancel" buttons in the search header UI with compact, icon-only equivalents (`mdi:magnify` and `mdi:close`) to save screen space and improve visual consistency.

### User-facing Changes
- Replaced "Search" text button with an icon-only magnify button (`mdi:magnify`).
- Replaced "Cancel" text button with an icon-only close button (`mdi:close`).
- Hover titles added to both icon buttons (`common.search` and `common.cancel`) for accessibility.