### PR TITLE
fix: prevent idle state transition while entity options menu is active

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8592,6 +8592,14 @@ class YetAnotherMediaPlayerCard extends LitElement {
       return;
     }
 
+    // Defer idle state if user is actively browsing menus
+    if (this._showEntityOptions) {
+      this._idleTimeout = setTimeout(() => {
+        this._handleIdleTimeoutCallback();
+      }, this._idleTimeoutMs);
+      return;
+    }
+
     // Check if there is any playing entity before going idle
     const isAnyPlaying = this.entityIds.some((id, idx) => {
       if (this._isAutoSelectDisabled(idx)) return false;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8477,6 +8477,15 @@ class YetAnotherMediaPlayerCard extends LitElement {
   }
 
   _updateIdleState(changedProps) {
+    // Defer idle state if user is actively browsing menus
+    if (this._showEntityOptions) {
+      if (this._idleTimeout) {
+        clearTimeout(this._idleTimeout);
+        this._idleTimeout = null;
+      }
+      return;
+    }
+
     // Consider both main and Music Assistant entities so we can wake from idle
     // even if the active selection is frozen while idle.
     const isAnyUnrestrictedPlaying = this.entityIds.some((id, idx) => {
@@ -8589,14 +8598,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
         this._doSearch(defaultFilter).catch(() => { });
         this.requestUpdate();
       }
-      return;
-    }
-
-    // Defer idle state if user is actively browsing menus
-    if (this._showEntityOptions) {
-      this._idleTimeout = setTimeout(() => {
-        this._handleIdleTimeoutCallback();
-      }, this._idleTimeoutMs);
       return;
     }
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8419,11 +8419,11 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
         return isCard
           ? virtualize({
-              items: paddedResults,
-              renderItem: renderItemFn,
-              layout: this._cachedSearchGridLayout,
-              scroller: pinSearchHeaders
-            })
+            items: paddedResults,
+            renderItem: renderItemFn,
+            layout: this._cachedSearchGridLayout,
+            scroller: pinSearchHeaders
+          })
           : virtualize({ items: paddedResults, renderItem: renderItemFn, scroller: pinSearchHeaders });
       })()}
         </div>
@@ -8478,7 +8478,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
   _updateIdleState(changedProps) {
     // Defer idle state if user is actively browsing menus
-    if (this._showEntityOptions) {
+    if (this.isAnyMenuOpen) {
       if (this._idleTimeout) {
         clearTimeout(this._idleTimeout);
         this._idleTimeout = null;


### PR DESCRIPTION
Prevents the card from transitioning to the idle state (and auto-switching to a playing entity) if the user is actively interacting with the options/search menus.