### PR TITLE
style: add dynamic padding for scaled-contain artwork modes

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -227,7 +227,8 @@ export const yampCardStyles = css`
     display: block;
     border-radius: var(--border-radius);
     box-shadow: var(--ha-card-box-shadow, none);
-    background: transparent;
+    background: var(--card-bg);
+    padding: 0 5px;
     color: var(--primary-text);
     transition: background var(--transition-normal);
     overflow: visible;
@@ -1720,6 +1721,7 @@ export const yampCardStyles = css`
   }
 
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .inset-artwork {
+    box-sizing: border-box;
     border-radius: var(--ha-card-border-radius, 12px);
     border: var(--ha-card-border-width, 1px) solid var(--ha-card-border-color, var(--divider-color, #e0e0e0));
   }

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -227,15 +227,21 @@ export const yampCardStyles = css`
     display: block;
     border-radius: var(--border-radius);
     box-shadow: var(--ha-card-box-shadow, none);
-    background: var(--card-bg);
-    padding: 0 5px;
+    background: transparent;
     color: var(--primary-text);
-    transition: background var(--transition-normal);
+    transition: background var(--transition-normal), padding var(--transition-normal);
     overflow: visible;
     font-size: inherit;
     position: relative;
     clip-path: none;
     transform: translateZ(0);
+  }
+
+  /* Add side padding only for scaled-contain modes where artwork doesn't fill the card edges */
+  ha-card.yamp-card:has(> .yamp-card-inner[data-artwork-fit="scaled-contain"]),
+  ha-card.yamp-card:has(> .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"]) {
+    background: var(--card-bg);
+    padding: 0 5px;
   }
 
   .yamp-card-inner {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -229,7 +229,7 @@ export const yampCardStyles = css`
     box-shadow: var(--ha-card-box-shadow, none);
     background: transparent;
     color: var(--primary-text);
-    transition: background var(--transition-normal), padding var(--transition-normal);
+    transition: background var(--transition-normal);
     overflow: visible;
     font-size: inherit;
     position: relative;
@@ -241,7 +241,6 @@ export const yampCardStyles = css`
   ha-card.yamp-card:has(> .yamp-card-inner[data-artwork-fit="scaled-contain"]),
   ha-card.yamp-card:has(> .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"]) {
     background: var(--card-bg);
-    padding: 0 5px;
   }
 
   .yamp-card-inner {
@@ -1726,8 +1725,13 @@ export const yampCardStyles = css`
     }
   }
 
+  .yamp-card-inner[data-artwork-fit="scaled-contain"] .inset-artwork,
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .inset-artwork {
     box-sizing: border-box;
+    padding: 0 5px;
+  }
+
+  .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .inset-artwork {
     border-radius: var(--ha-card-border-radius, 12px);
     border: var(--ha-card-border-width, 1px) solid var(--ha-card-border-color, var(--divider-color, #e0e0e0));
   }


### PR DESCRIPTION
Adds a small 5px padding on the left and right sides of the artwork area when using `scaled-contain` or `scaled-contain-alternate` artwork fit modes. This prevents the card's rounded borders from clipping the artwork image.

**User-facing changes:**
- Improves visual layout for `scaled-contain` and `scaled-contain-alternate` artwork display modes.

**Notes:**
- Tested styling by verifying padding applied properly without affecting other artwork fit modes like `cover`.