### PR TITLE
style: fix chip text colors and update inset artwork layout logic

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -194,7 +194,7 @@ export const yampCardStyles = css`
     --yamp-error-color: var(--error-color, #f44336);
     --yamp-success-bg-light: color-mix(in srgb, var(--success-color, #4caf50) 20%, transparent);
     --yamp-success-bg-medium: color-mix(in srgb, var(--success-color, #4caf50) 40%, transparent);
-    --yamp-chip-selected-text: var(--text-primary-color, #fff);
+    --yamp-chip-selected-text: #fff;
     --search-text-secondary: var(--secondary-text-color, #aaa);
 
     /* Mode-aware chip defaults - used when appearance is automatic */
@@ -230,7 +230,7 @@ export const yampCardStyles = css`
     background: transparent;
     color: var(--primary-text);
     transition: background var(--transition-normal);
-    overflow: visible;
+    overflow: hidden;
     font-size: inherit;
     position: relative;
     clip-path: none;
@@ -1725,12 +1725,6 @@ export const yampCardStyles = css`
     }
   }
 
-  .yamp-card-inner[data-artwork-fit="scaled-contain"] .inset-artwork,
-  .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .inset-artwork {
-    box-sizing: border-box;
-    padding: 0 5px;
-  }
-
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .inset-artwork {
     border-radius: var(--ha-card-border-radius, 12px);
     border: var(--ha-card-border-width, 1px) solid var(--ha-card-border-color, var(--divider-color, #e0e0e0));
@@ -2578,10 +2572,17 @@ export const yampCardStyles = css`
     color: var(--yamp-overlay-text);
   }
 
-  /* Specific override to ensure selected chips keep their white text regardless of the global sheet rule above */
+  /* Specific override to ensure selected/hovered chips keep their text color regardless of the global sheet rule above */
   .entity-options-sheet .chip[selected],
   .entity-options-sheet .chip[selected] * {
     color: var(--yamp-chip-selected-text) !important;
+  }
+
+  @media (hover: hover) {
+    .entity-options-sheet .chip:hover,
+    .entity-options-sheet .chip:hover * {
+      color: var(--yamp-chip-selected-text) !important;
+    }
   }
 
   /* Search functionality */

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7642,7 +7642,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
                     style="${(this._cardTriggers.tap || this._cardTriggers.hold || this._cardTriggers.double_tap || this._cardTriggers.swipe_left || this._cardTriggers.swipe_right) ? 'cursor:pointer; pointer-events:auto;' : ''}"
                   >
                     ${useInsetArtwork && artworkUrl ? html`
-                      <div style="position: absolute; ${needsArtworkTopPadding ? 'top: 20px; right: 0; bottom: 0; left: 0;' : 'inset: 0;'} display: flex; align-items: center; justify-content: center; pointer-events: none;">
+                      <div style="position: absolute; ${needsArtworkTopPadding ? 'top: 20px; right: 0; bottom: 0; left: 0;' : 'inset: 0;'} display: flex; align-items: center; justify-content: center; pointer-events: none; box-sizing: border-box; padding: 0 5px;">
                         <img 
                           class="inset-artwork"
                           src="${artworkUrl}" 


### PR DESCRIPTION
## Summary
This PR addresses text color styling for chips in the options sheet, specifically fixing hover and selected states, and improves the container layout/padding rules for inset artwork.

## Changes
- **Chip Text Styling**:
  - Sets `--yamp-chip-selected-text` to `#fff` directly.
  - Implements `.chip` `overflow: hidden`.
  - Added CSS rule to keep white text for both selected and hovered chips in `.entity-options-sheet`.
- **Inset Artwork Layout**:
  - Replaces global CSS layout paddings for `.inset-artwork` under container queries with inline style padding (`0 5px` with `box-sizing: border-box`) on the parent `div` wrapper for cleaner rendering behavior.