### PR TITLE
feat: Support Jinja2 templating for action in_menu property

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Below you will find a list of all configuration options.
 | `navigation_path`          | string       | No           | —           | Destination for navigation shortcuts (supports anchors like `#pop-up-menu`, relative paths, or full URLs) |
 | `navigation_new_tab`       | boolean      | No           | `false`     | When `true`, external URLs open in a new browser tab instead of replacing the current view      |
 | `menu_item`                | string       | No           | —           | Opens a card menu by type: `search`, `search-recently-played`, `search-next-up`, `source`, `more-info`, `group-players`, `transfer-queue` |
-| `in_menu`                  | choice       | No           | `false`     | Placement of the action: `false` (Action Chip), `true` (In Menu), or `hidden` (Hidden - only triggerable via card gestures) |
+| `in_menu`                  | choice       | No           | `false`     | Placement of the action: `false` (Action Chip), `true` (In Menu), or `hidden` (Hidden - only triggerable via card gestures) ([Supports Templates](#template-support)) |
 | `card_trigger`             | choice       | No           | `none`      | Assign action to a card-level gesture: `none`, `tap`, `hold`, `double_tap`, `swipe_left`, or `swipe_right` (only for `hidden` actions) |
 | `script_variable`          | boolean      | No           | `false`     | Pass the currently selected entity as `yamp_entity` to a script                                 |
 | `sync_entity_helper`       | string       | No           | —           | `input_text` entity to sync the currently selected entity to (used with `action: sync_selected_entity`) |
@@ -548,6 +548,7 @@ The following configuration keys support templates:
 - **`navigation_path`**: Create dynamic navigation URLs (e.g., search IMDb or Genius).
 - **`volume_entity`**: Dynamically select which entity controls volume for a specific player.
 - **`music_assistant_entity`**: Dynamically select the companion Music Assistant entity.
+- **`in_menu`**: Dynamically determine where an action is placed (`true`, `false`, or `hidden`).
 - **`image_url` / `missing_art_url`**: (Inside `media_artwork_overrides`) Dynamically determine artwork.
 
 ## Available Variables

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -155,18 +155,18 @@ export function resolveStringTemplateSync(hass, templateString, context = {}) {
       let compareVal = statesMatch[5];
 
       const state = hass?.states?.[entityId];
+      let val = 'unknown';
       if (state && state.state !== undefined) {
-        let val = String(state.state);
-        
-        if (operator) {
-          let isMatch = operator === '==' ? (val === compareVal) : (val !== compareVal);
-          let boolStr = isMatch ? 'true' : 'false';
-          return useUrlEncode ? encodeURIComponent(boolStr) : boolStr;
-        }
-        
-        return useUrlEncode ? encodeURIComponent(val) : val;
+        val = String(state.state);
       }
-      return operator ? 'false' : '';
+      
+      if (operator) {
+        let isMatch = operator === '==' ? (val === compareVal) : (val !== compareVal);
+        let boolStr = isMatch ? 'true' : 'false';
+        return useUrlEncode ? encodeURIComponent(boolStr) : boolStr;
+      }
+      
+      return useUrlEncode ? encodeURIComponent(val) : val;
     }
 
     // 2.5 Check for is_state(...)

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -146,18 +146,43 @@ export function resolveStringTemplateSync(hass, templateString, context = {}) {
       return '';
     }
 
-    // 2. Check for states(...)
-    let statesMatch = expr.match(/^states\(\s*(['"]?)([\w.]+)\1\s*\)$/);
+    // 2. Check for states(...) with optional equality check
+    let statesMatch = expr.match(/^states\(\s*(['"]?)([\w.]+)\1\s*\)(?:\s*(==|!=)\s*(['"])(.*?)\4)?$/);
     if (statesMatch) {
       let entityArg = statesMatch[2];
       let entityId = (context[entityArg] !== undefined && !statesMatch[1]) ? context[entityArg] : entityArg;
+      let operator = statesMatch[3];
+      let compareVal = statesMatch[5];
 
       const state = hass?.states?.[entityId];
       if (state && state.state !== undefined) {
         let val = String(state.state);
+        
+        if (operator) {
+          let isMatch = operator === '==' ? (val === compareVal) : (val !== compareVal);
+          let boolStr = isMatch ? 'true' : 'false';
+          return useUrlEncode ? encodeURIComponent(boolStr) : boolStr;
+        }
+        
         return useUrlEncode ? encodeURIComponent(val) : val;
       }
-      return '';
+      return operator ? 'false' : '';
+    }
+
+    // 2.5 Check for is_state(...)
+    let isStateMatch = expr.match(/^is_state\(\s*(['"]?)([\w.]+)\1\s*,\s*(['"])(.*?)\3\s*\)$/);
+    if (isStateMatch) {
+      let entityArg = isStateMatch[2];
+      let entityId = (context[entityArg] !== undefined && !isStateMatch[1]) ? context[entityArg] : entityArg;
+      let compareVal = isStateMatch[4];
+
+      const state = hass?.states?.[entityId];
+      if (state && state.state !== undefined) {
+        let val = String(state.state);
+        let boolStr = (val === compareVal) ? 'true' : 'false';
+        return useUrlEncode ? encodeURIComponent(boolStr) : boolStr;
+      }
+      return 'false';
     }
 
     // 3. direct context variable matching

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -177,12 +177,12 @@ export function resolveStringTemplateSync(hass, templateString, context = {}) {
       let compareVal = isStateMatch[4];
 
       const state = hass?.states?.[entityId];
+      let val = 'unknown';
       if (state && state.state !== undefined) {
-        let val = String(state.state);
-        let boolStr = (val === compareVal) ? 'true' : 'false';
-        return useUrlEncode ? encodeURIComponent(boolStr) : boolStr;
+        val = String(state.state);
       }
-      return 'false';
+      let boolStr = (val === compareVal) ? 'true' : 'false';
+      return useUrlEncode ? encodeURIComponent(boolStr) : boolStr;
     }
 
     // 3. direct context variable matching

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7084,8 +7084,24 @@ class YetAnotherMediaPlayerCard extends LitElement {
     // Action placement logic
     const getPlacement = (act) => {
       if (act?.placement) return act.placement;
-      if (act?.in_menu === "hidden") return "hidden";
-      return act?.in_menu === true ? "menu" : "chip";
+      
+      let inMenuVal = act?.in_menu;
+      if (typeof inMenuVal === "string" && (inMenuVal.includes("{{") || inMenuVal.includes("{%"))) {
+        const context = {
+          entity: this.currentEntityId,
+          state: this.hass?.states[this.currentEntityId]?.state || "unknown",
+          attributes: this.hass?.states[this.currentEntityId]?.attributes || {}
+        };
+        const resolved = resolveStringTemplateSync(this.hass, inMenuVal, context);
+        if (resolved !== null) {
+          inMenuVal = resolved;
+        }
+      }
+      
+      if (inMenuVal === "true") inMenuVal = true;
+      if (inMenuVal === "false") inMenuVal = false;
+      if (inMenuVal === "hidden") return "hidden";
+      return inMenuVal === true ? "menu" : "chip";
     };
 
     const rowActions = visibleActions.filter(({ action }) => getPlacement(action) === "chip");

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -929,6 +929,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       this.config.actions.forEach((_, idx) => {
         this._unsubscribeFromTemplate(idx, 'action_in_menu');
         if (this._actionInMenuTemplateValues[idx]) delete this._actionInMenuTemplateValues[idx];
+        if (this._actionInMenuResolveCache[idx]) delete this._actionInMenuResolveCache[idx];
       });
       this._lastActionEntityId = this.currentEntityId;
     }

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -924,14 +924,15 @@ class YetAnotherMediaPlayerCard extends LitElement {
   _ensureResolvedActions() {
     if (!this.hass || !this.config?.actions) return;
     
-    // Clear old subscriptions if entity changed to ensure context updates
-    if (this._lastActionEntityId !== this.currentEntityId) {
+    // Clear old subscriptions if context changed to ensure context updates
+    const currentContext = JSON.stringify(this._getTemplateContext());
+    if (this._lastActionTemplateContextKey !== currentContext) {
       this.config.actions.forEach((_, idx) => {
         this._unsubscribeFromTemplate(idx, 'action_in_menu');
         if (this._actionInMenuTemplateValues[idx]) delete this._actionInMenuTemplateValues[idx];
         if (this._actionInMenuResolveCache[idx]) delete this._actionInMenuResolveCache[idx];
       });
-      this._lastActionEntityId = this.currentEntityId;
+      this._lastActionTemplateContextKey = currentContext;
     }
 
     this.config.actions.forEach((act, idx) => {
@@ -5622,8 +5623,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
         void this._resolveCardHeightTemplate();
       }
     }
+    void this._ensureResolvedActions();
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
-      void this._ensureResolvedActions();
       void this._updateTransferQueueAvailability({ refresh: false });
     }
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -794,6 +794,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
     // Save current template to state
     templateVals[idx] = { template: templateString, resolved: null };
 
+    // Generate a unique token for this subscription request to prevent race conditions
+    const subToken = Symbol('subToken');
+    this._templateSubscriptions[subKey] = subToken;
+
     // Subscribe to template rendering
     try {
       const context = this._getTemplateContext();
@@ -803,6 +807,11 @@ class YetAnotherMediaPlayerCard extends LitElement {
       const finalTemplate = `${setStatements} ${templateString}`;
 
       this.hass.connection.subscribeMessage((msg) => {
+        // If we have unsubscribed or started a new subscription since, ignore message
+        if (this._templateSubscriptions[subKey] !== subToken && typeof this._templateSubscriptions[subKey] !== 'function') {
+          return;
+        }
+
         const resolved = (msg.result || '').toString().trim();
         let isValid = false;
 
@@ -839,7 +848,14 @@ class YetAnotherMediaPlayerCard extends LitElement {
         type: 'render_template',
         template: finalTemplate
       }).then((unsub) => {
-        this._templateSubscriptions[subKey] = unsub;
+        // If it was cancelled while subscribing, call unsub immediately to avoid resource leak
+        if (this._templateSubscriptions[subKey] !== subToken) {
+          try {
+            unsub();
+          } catch (e) { /* ignore */ }
+        } else {
+          this._templateSubscriptions[subKey] = unsub;
+        }
       });
     } catch (err) {
       console.warn('yamp: failed to subscribe to template:', err);
@@ -848,10 +864,13 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
   _unsubscribeFromTemplate(idx, type) {
     const subKey = `${idx}_${type}`;
-    if (this._templateSubscriptions[subKey]) {
-      try {
-        this._templateSubscriptions[subKey]();
-      } catch (e) { /* ignore */ }
+    const unsub = this._templateSubscriptions[subKey];
+    if (unsub) {
+      if (typeof unsub === 'function') {
+        try {
+          unsub();
+        } catch (e) { /* ignore */ }
+      }
       delete this._templateSubscriptions[subKey];
     }
   }
@@ -945,6 +964,16 @@ class YetAnotherMediaPlayerCard extends LitElement {
         delete this._actionInMenuResolveCache[idx];
       }
     });
+
+    // Clean up any stale subscriptions for indices beyond the current actions length
+    const currentLength = this.config.actions.length;
+    let checkIdx = currentLength;
+    while (this._templateSubscriptions[`${checkIdx}_action_in_menu`] || this._actionInMenuTemplateValues[checkIdx]) {
+      this._unsubscribeFromTemplate(checkIdx, 'action_in_menu');
+      delete this._actionInMenuTemplateValues[checkIdx];
+      delete this._actionInMenuResolveCache[checkIdx];
+      checkIdx++;
+    }
   }
 
   // Get the resolved playback entity id for a chip index, preferring cache
@@ -5623,7 +5652,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         void this._resolveCardHeightTemplate();
       }
     }
-    void this._ensureResolvedActions();
+    this._ensureResolvedActions();
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
       void this._updateTransferQueueAvailability({ refresh: false });
     }

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -733,6 +733,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._manualSelectTimeout = null;
     // Track active websocket template subscriptions
     this._templateSubscriptions = {}; // { [idx_type]: unsubscribeFunction }
+    this._activeSubscriptionTokens = {}; // { [idx_type]: Symbol }
     this._maTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
     this._volTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
     this._actionInMenuTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
@@ -796,6 +797,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
     // Generate a unique token for this subscription request to prevent race conditions
     const subToken = Symbol('subToken');
+    this._activeSubscriptionTokens[subKey] = subToken;
     this._templateSubscriptions[subKey] = subToken;
 
     // Subscribe to template rendering
@@ -808,7 +810,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
       this.hass.connection.subscribeMessage((msg) => {
         // If we have unsubscribed or started a new subscription since, ignore message
-        if (this._templateSubscriptions[subKey] !== subToken && typeof this._templateSubscriptions[subKey] !== 'function') {
+        if (this._activeSubscriptionTokens[subKey] !== subToken) {
           return;
         }
 
@@ -849,7 +851,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         template: finalTemplate
       }).then((unsub) => {
         // If it was cancelled while subscribing, call unsub immediately to avoid resource leak
-        if (this._templateSubscriptions[subKey] !== subToken) {
+        if (this._activeSubscriptionTokens[subKey] !== subToken) {
           try {
             unsub();
           } catch (e) { /* ignore */ }
@@ -872,6 +874,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         } catch (e) { /* ignore */ }
       }
       delete this._templateSubscriptions[subKey];
+      delete this._activeSubscriptionTokens[subKey];
     }
   }
 
@@ -7185,7 +7188,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
           // Fallback for initial render before subscription resolves
           if (!actionTemplateFallbackContext) {
             actionTemplateFallbackContext = {
-              entity: this.currentEntityId,
+              ...this._getTemplateContext(),
               state: this.hass?.states[this.currentEntityId]?.state || "unknown",
               attributes: this.hass?.states[this.currentEntityId]?.attributes || {}
             };
@@ -9167,6 +9170,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       }
     });
     this._templateSubscriptions = {};
+    this._activeSubscriptionTokens = {};
 
     if (this._adaptiveScrollTimer) {
       clearTimeout(this._adaptiveScrollTimer);

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -735,6 +735,9 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._templateSubscriptions = {}; // { [idx_type]: unsubscribeFunction }
     this._maTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
     this._volTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
+    this._actionInMenuTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
+    this._actionInMenuResolveCache = {}; // { [idx]: { value: string, ts: number } }
+    this._lastActionEntityId = null;
     // Cache resolved Volume entity per index (template or static)
     this._volResolveCache = {}; // { [idx:number]: { id: string, ts: number } }
     this._volResolveTtlMs = 7000; // Used for static caching now
@@ -763,8 +766,24 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
     const subKey = `${idx}_${type}`;
 
+    let currentCache;
+    let templateVals;
+    let cache;
+    if (type === 'ma') {
+      currentCache = this._maTemplateValues[idx];
+      templateVals = this._maTemplateValues;
+      cache = this._maResolveCache;
+    } else if (type === 'vol') {
+      currentCache = this._volTemplateValues[idx];
+      templateVals = this._volTemplateValues;
+      cache = this._volResolveCache;
+    } else if (type === 'action_in_menu') {
+      currentCache = this._actionInMenuTemplateValues[idx];
+      templateVals = this._actionInMenuTemplateValues;
+      cache = this._actionInMenuResolveCache;
+    }
+
     // Check if there's already an active subscription for this exact template
-    const currentCache = type === 'ma' ? this._maTemplateValues[idx] : this._volTemplateValues[idx];
     if (this._templateSubscriptions[subKey] && currentCache?.template === templateString) {
       return;
     }
@@ -773,7 +792,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._unsubscribeFromTemplate(idx, type);
 
     // Save current template to state
-    const templateVals = type === 'ma' ? this._maTemplateValues : this._volTemplateValues;
     templateVals[idx] = { template: templateString, resolved: null };
 
     // Subscribe to template rendering
@@ -786,7 +804,13 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
       this.hass.connection.subscribeMessage((msg) => {
         const resolved = (msg.result || '').toString().trim();
-        const isValid = resolved && /^([a-z0-9_]+)\.[a-zA-Z0-9_]+$/.test(resolved);
+        let isValid = false;
+
+        if (type === 'ma' || type === 'vol') {
+          isValid = resolved && /^([a-z0-9_]+)\.[a-zA-Z0-9_]+$/.test(resolved);
+        } else if (type === 'action_in_menu') {
+          isValid = true; // Any string result is valid for in_menu
+        }
 
         let shouldUpdate = false;
 
@@ -794,12 +818,18 @@ class YetAnotherMediaPlayerCard extends LitElement {
           templateVals[idx].resolved = isValid ? resolved : null;
         }
 
-        const cache = type === 'ma' ? this._maResolveCache : this._volResolveCache;
-        const currentCached = cache[idx]?.id;
-
-        if (isValid && currentCached !== resolved) {
-          cache[idx] = { id: resolved, ts: Date.now() };
-          shouldUpdate = true;
+        if (type === 'ma' || type === 'vol') {
+          const currentCached = cache[idx]?.id;
+          if (isValid && currentCached !== resolved) {
+            cache[idx] = { id: resolved, ts: Date.now() };
+            shouldUpdate = true;
+          }
+        } else if (type === 'action_in_menu') {
+          const currentCached = cache[idx]?.value;
+          if (isValid && currentCached !== resolved) {
+            cache[idx] = { value: resolved, ts: Date.now() };
+            shouldUpdate = true;
+          }
         }
 
         if (shouldUpdate) {
@@ -888,6 +918,31 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
     // Setup subscription for reactivity
     this._subscribeToTemplate(idx, 'vol', raw);
+  }
+
+  // Ensure action in_menu templates are resolved and subscribed for the current entity context
+  _ensureResolvedActions() {
+    if (!this.hass || !this.config?.actions) return;
+    
+    // Clear old subscriptions if entity changed to ensure context updates
+    if (this._lastActionEntityId !== this.currentEntityId) {
+      this.config.actions.forEach((_, idx) => {
+        this._unsubscribeFromTemplate(idx, 'action_in_menu');
+        if (this._actionInMenuTemplateValues[idx]) delete this._actionInMenuTemplateValues[idx];
+      });
+      this._lastActionEntityId = this.currentEntityId;
+    }
+
+    this.config.actions.forEach((act, idx) => {
+      const raw = act?.in_menu;
+      if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
+        this._subscribeToTemplate(idx, 'action_in_menu', raw);
+      } else {
+        this._unsubscribeFromTemplate(idx, 'action_in_menu');
+        if (this._actionInMenuTemplateValues[idx]) delete this._actionInMenuTemplateValues[idx];
+        delete this._actionInMenuResolveCache[idx];
+      }
+    });
   }
 
   // Get the resolved playback entity id for a chip index, preferring cache
@@ -3771,6 +3826,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
   _getTemplateContext() {
     return {
+      entity: this.currentEntityId || '',
       is_idle: this._isIdle,
       is_playing: this._isCurrentEntityPlaying(),
       is_search: this._showSearchInSheet,
@@ -5566,6 +5622,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       }
     }
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
+      void this._ensureResolvedActions();
       void this._updateTransferQueueAvailability({ refresh: false });
     }
 
@@ -7081,20 +7138,31 @@ class YetAnotherMediaPlayerCard extends LitElement {
     // Filter out sync_selected_entity / select_entity actions entirely - they don't render as chips
     const visibleActions = decoratedActions.filter(({ action }) => action?.action !== "sync_selected_entity" && action?.action !== "select_entity");
 
+    // Shared context for synchronous template fallback
+    let actionTemplateFallbackContext = null;
+
     // Action placement logic
-    const getPlacement = (act) => {
+    const getPlacement = (act, actIdx) => {
       if (act?.placement) return act.placement;
       
       let inMenuVal = act?.in_menu;
       if (typeof inMenuVal === "string" && (inMenuVal.includes("{{") || inMenuVal.includes("{%"))) {
-        const context = {
-          entity: this.currentEntityId,
-          state: this.hass?.states[this.currentEntityId]?.state || "unknown",
-          attributes: this.hass?.states[this.currentEntityId]?.attributes || {}
-        };
-        const resolved = resolveStringTemplateSync(this.hass, inMenuVal, context);
-        if (resolved !== null) {
-          inMenuVal = resolved;
+        const cached = this._actionInMenuResolveCache?.[actIdx]?.value;
+        if (cached !== undefined) {
+          inMenuVal = cached;
+        } else {
+          // Fallback for initial render before subscription resolves
+          if (!actionTemplateFallbackContext) {
+            actionTemplateFallbackContext = {
+              entity: this.currentEntityId,
+              state: this.hass?.states[this.currentEntityId]?.state || "unknown",
+              attributes: this.hass?.states[this.currentEntityId]?.attributes || {}
+            };
+          }
+          const resolved = resolveStringTemplateSync(this.hass, inMenuVal, actionTemplateFallbackContext);
+          if (resolved !== null) {
+            inMenuVal = resolved;
+          }
         }
       }
       
@@ -7104,8 +7172,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
       return inMenuVal === true ? "menu" : "chip";
     };
 
-    const rowActions = visibleActions.filter(({ action }) => getPlacement(action) === "chip");
-    const menuOnlyActions = visibleActions.filter(({ action }) => getPlacement(action) === "menu");
+    const rowActions = visibleActions.filter(({ action, idx }) => getPlacement(action, idx) === "chip");
+    const menuOnlyActions = visibleActions.filter(({ action, idx }) => getPlacement(action, idx) === "menu");
 
     // Gesture trigger logic
     const tapAction = visibleActions.find(({ action }) => action?.card_trigger === "tap");

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -971,7 +971,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     // Clean up any stale subscriptions for indices beyond the current actions length
     const currentLength = this.config.actions.length;
     let checkIdx = currentLength;
-    while (this._templateSubscriptions[`${checkIdx}_action_in_menu`] || this._actionInMenuTemplateValues[checkIdx]) {
+    while (this._templateSubscriptions[`${checkIdx}_action_in_menu`] || this._actionInMenuTemplateValues[checkIdx] || this._actionInMenuResolveCache[checkIdx]) {
       this._unsubscribeFromTemplate(checkIdx, 'action_in_menu');
       delete this._actionInMenuTemplateValues[checkIdx];
       delete this._actionInMenuResolveCache[checkIdx];


### PR DESCRIPTION
## Changes
* Add dynamic Jinja2 template resolution and caching for action `in_menu` properties
* Add synchronous fallbacks for template rendering during initial component initialization
* Add `is_state()` utility function and support for comparison operators in `states()` evaluation
* Update configuration documentation to reflect template support
* Fix: clear `_actionInMenuResolveCache` on entity change to prevent stale UI state
* Refactor: use template context hash to make action subscriptions responsive to internal state variables (e.g. `is_playing`)
* Refactor: standardize template state handling and prevent subscription race conditions during rapid updates with unique tokens