### PR TITLE
Support entity card suggestions for HA 2026.6

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9609,3 +9609,20 @@ class YetAnotherMediaPlayerCard extends LitElement {
 }
 
 customElements.define("yet-another-media-player", YetAnotherMediaPlayerCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "yet-another-media-player",
+  name: "Yet Another Media Player",
+  description: "A custom card to control multiple media players.",
+  preview: true,
+  getEntitySuggestion: (hass, entityId) => {
+    const domain = entityId.split(".")[0];
+    if (domain !== "media_player") {
+      return null;
+    }
+    return {
+      config: { type: "custom:yet-another-media-player", entities: [entityId] },
+    };
+  },
+});

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9611,7 +9611,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
 customElements.define("yet-another-media-player", YetAnotherMediaPlayerCard);
 
 window.customCards = window.customCards || [];
-window.customCards.push({
+if (!window.customCards.some(card => card.type === "yet-another-media-player")) {
+  window.customCards.push({
   type: "yet-another-media-player",
   name: "Yet Another Media Player",
   description: "A custom card to control multiple media players.",
@@ -9626,3 +9627,4 @@ window.customCards.push({
     };
   },
 });
+}

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -83,12 +83,23 @@ const CARD_HEIGHT_MENU_PROPS = Object.freeze([
 ]);
 
 window.customCards = window.customCards || [];
-window.customCards.push({
-  type: "yet-another-media-player",
-  name: "Yet Another Media Player",
-  description: "YAMP is a multi-entity media card with custom actions",
-  preview: true
-});
+if (!window.customCards.some(card => card.type === "yet-another-media-player")) {
+  window.customCards.push({
+    type: "yet-another-media-player",
+    name: "Yet Another Media Player",
+    description: "YAMP is a multi-entity media card with custom actions",
+    preview: true,
+    getEntitySuggestion: (hass, entityId) => {
+      const domain = entityId.split(".")[0];
+      if (domain !== "media_player") {
+        return null;
+      }
+      return {
+        config: { type: "custom:yet-another-media-player", entities: [entityId] },
+      };
+    },
+  });
+}
 
 class YetAnotherMediaPlayerCard extends LitElement {
 
@@ -9609,22 +9620,3 @@ class YetAnotherMediaPlayerCard extends LitElement {
 }
 
 customElements.define("yet-another-media-player", YetAnotherMediaPlayerCard);
-
-window.customCards = window.customCards || [];
-if (!window.customCards.some(card => card.type === "yet-another-media-player")) {
-  window.customCards.push({
-  type: "yet-another-media-player",
-  name: "Yet Another Media Player",
-  description: "A custom card to control multiple media players.",
-  preview: true,
-  getEntitySuggestion: (hass, entityId) => {
-    const domain = entityId.split(".")[0];
-    if (domain !== "media_player") {
-      return null;
-    }
-    return {
-      config: { type: "custom:yet-another-media-player", entities: [entityId] },
-    };
-  },
-});
-}


### PR DESCRIPTION
## Description
This PR implements support for Home Assistant 2026.6's new `getEntitySuggestion` feature. 

When a user selects a `media_player` entity from their dashboard, Home Assistant will now display the Yet Another Media Player card as a suggested option within the "Community" section. 

## User-Facing Changes
- YAMP is now automatically suggested in the card picker dialog when configuring `media_player` entities on HA 2026.6+.
- Fixed a bug where the card could be registered twice in the standard custom card picker due to multiple script evaluations.