### PR TITLE
feat: add template support for always_collapsed and control_layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Below you will find a list of all configuration options.
 |                                                                                                 |
 | **Behavior**               |              |              |             |                                                                                                 |
 | `collapse_on_idle`         | boolean      | No           | `false`     | Collapse the card when nothing is playing                                                       |
-| `always_collapsed`         | boolean      | No           | `false`     | Keep the card collapsed even when something is playing                                          |
+| `always_collapsed`         | boolean      | No           | `false`     | Keep the card collapsed even when something is playing ([Supports Templates](#template-support))                                          |
 | `expand_on_search`         | boolean      | No           | `false`     | Temporarily expand the card when search is open (only available when `always_collapsed` is `true`) |
 | `hide_menu_player`         | boolean      | No           | `false`     | Hide the persistent media controls in the bottom sheet menu to reclaim space (only available when `always_collapsed` is `false`) |
 | `idle_screen`              | choice       | No           | `default`   | Choose the idle experience: `default` keeps the artwork splash, `search` opens the search sheet immediately, `search-recently-played` jumps to the Recently Played view, and `search-next-up` opens the Next Up queue |
@@ -109,7 +109,7 @@ Below you will find a list of all configuration options.
 | `show_chip_row`            | choice       | No           | `auto`      | `auto`: hides chip row if only one entity, `always`: always shows the chip row, `in_menu`: moves chips into the entity-options menu, `in_menu_on_idle`: shows chips inline when active but moves them to the menu when idle |
 | `alternate_progress_bar`   | boolean      | No           | `false`     | Uses the collapsed progress bar when expanded                                                   |
 | `adaptive_controls`        | boolean      | No           | `false`     | Control buttons expand to fill extra horizontal space, giving you larger tap targets when there’s room |
-| `control_layout`           | choice       | No           | `classic`   | `classic` keeps the legacy evenly sized controls, while `modern` adopts Home Assistant’s more-info layout (shuffle/prev/play/next/repeat) and moves the favorite and power buttons along the bottom of the card |
+| `control_layout`           | choice       | No           | `classic`   | `classic` keeps the legacy evenly sized controls, while `modern` adopts Home Assistant’s more-info layout (shuffle/prev/play/next/repeat) and moves the favorite and power buttons along the bottom of the card ([Supports Templates](#template-support)) |
 | `swap_pause_for_stop`      | boolean      | No           | `false`     | Only for `control_layout: modern`; when `true`, the center pause button is replaced with a stop button |
 | `adaptive_text`            | boolean/array| No           | `false`     | Set to `true` to scale all text, or supply a list of targets (`details`, `menu`, `action_chips`) to choose exactly which sections adapt |
 | `hide_active_entity_label` | boolean      | No           | `false`     | Hide the small entity name label shown at the bottom center when chips are placed in the menu |
@@ -562,6 +562,8 @@ The following configuration keys support templates:
 - **`navigation_path`**: Create dynamic navigation URLs (e.g., search IMDb or Genius).
 - **`volume_entity`**: Dynamically select which entity controls volume for a specific player.
 - **`music_assistant_entity`**: Dynamically select the companion Music Assistant entity.
+- **`always_collapsed`**: Dynamically determine if the card should be fully collapsed.
+- **`control_layout`**: Dynamically select the control layout style (`classic` or `modern`).
 - **`in_menu`**: Dynamically determine where an action is placed (`true`, `false`, or `hidden`).
 - **`image_url` / `missing_art_url`**: (Inside `media_artwork_overrides`) Dynamically determine artwork.
 

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -210,14 +210,14 @@ export function renderSearchResultActions({
   return html`
     <div class="${containerClass}">
       ${isQueueItem && isInline
-      ? html`
+        ? html`
             <div class="queue-controls">
               <button
                 class="queue-btn queue-btn-up"
                 @click=${(e) => {
-          e.stopPropagation();
-          onMoveUp(item);
-        }}
+                  e.stopPropagation();
+                  onMoveUp(item);
+                }}
                 title="${localize("search.move_up")}"
               >
                 <ha-icon icon="mdi:chevron-up"></ha-icon>
@@ -225,9 +225,9 @@ export function renderSearchResultActions({
               <button
                 class="queue-btn queue-btn-down"
                 @click=${(e) => {
-          e.stopPropagation();
-          onMoveDown(item);
-        }}
+                  e.stopPropagation();
+                  onMoveDown(item);
+                }}
                 title="${localize("search.move_down")}"
               >
                 <ha-icon icon="mdi:chevron-down"></ha-icon>
@@ -235,9 +235,9 @@ export function renderSearchResultActions({
               <button
                 class="queue-btn queue-btn-next"
                 @click=${(e) => {
-          e.stopPropagation();
-          onMoveNext(item);
-        }}
+                  e.stopPropagation();
+                  onMoveNext(item);
+                }}
                 title="${localize("search.move_next")}"
               >
                 <ha-icon icon="mdi:playlist-play"></ha-icon>
@@ -245,41 +245,41 @@ export function renderSearchResultActions({
               <button
                 class="queue-btn queue-btn-remove"
                 @click=${(e) => {
-          e.stopPropagation();
-          onRemove(item);
-        }}
+                  e.stopPropagation();
+                  onRemove(item);
+                }}
                 title="${localize("search.remove")}"
               >
                 <ha-icon icon="mdi:close"></ha-icon>
               </button>
             </div>
           `
-      : nothing}
+        : nothing}
       <button
         class="${playClass}"
         @click=${(e) => {
-      e.stopPropagation();
-      onPlay(item);
-    }}
+          e.stopPropagation();
+          onPlay(item);
+        }}
         title="${localize("search.play_item", "{item}", item.title)}"
       >
         <ha-icon icon="mdi:play"></ha-icon>
       </button>
       ${!isQueueItem && !isRadio(item) && !minimal
-      ? html`
+        ? html`
             <button
               class="${queueClass}"
               @click=${(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onOptionsToggle(item);
-        }}
+                e.preventDefault();
+                e.stopPropagation();
+                onOptionsToggle(item);
+              }}
               title="${localize("common.more_options")}"
             >
               <ha-icon icon="mdi:dots-vertical"></ha-icon>
             </button>
           `
-      : nothing}
+        : nothing}
     </div>
   `;
 }
@@ -309,14 +309,14 @@ export function renderSearchResultSlideOut({
   return html`
     <div class="search-row-slide-out ${isActive ? "active" : ""}">
       ${isQueueItem && isCard
-      ? html`
+        ? html`
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onMoveUp(item);
-          onOptionsToggle(null);
-        }}
+                e.stopPropagation();
+                onMoveUp(item);
+                onOptionsToggle(null);
+              }}
               title="${localize("search.move_up")}"
             >
               ${localize("search.move_up")}
@@ -324,10 +324,10 @@ export function renderSearchResultSlideOut({
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onMoveDown(item);
-          onOptionsToggle(null);
-        }}
+                e.stopPropagation();
+                onMoveDown(item);
+                onOptionsToggle(null);
+              }}
               title="${localize("search.move_down")}"
             >
               ${localize("search.move_down")}
@@ -335,10 +335,10 @@ export function renderSearchResultSlideOut({
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onMoveNext(item);
-          onOptionsToggle(null);
-        }}
+                e.stopPropagation();
+                onMoveNext(item);
+                onOptionsToggle(null);
+              }}
               title="${localize("search.move_next")}"
             >
               ${localize("search.move_next")}
@@ -346,87 +346,87 @@ export function renderSearchResultSlideOut({
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onRemove(item);
-          onOptionsToggle(null);
-        }}
+                e.stopPropagation();
+                onRemove(item);
+                onOptionsToggle(null);
+              }}
               title="${localize("search.remove")}"
             >
               ${localize("search.remove")}
             </button>
           `
-      : html`
+        : html`
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onPlayOption(item, "replace");
-        }}
+                e.stopPropagation();
+                onPlayOption(item, "replace");
+              }}
               title="${localize("search.labels.replace")}"
             >
               ${isCard ? nothing : html`<ha-icon icon="mdi:playlist-remove"></ha-icon>`}${localize(
-          "search.labels.replace"
-        )}
+                "search.labels.replace"
+              )}
             </button>
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onPlayOption(item, "next");
-        }}
+                e.stopPropagation();
+                onPlayOption(item, "next");
+              }}
               title="${localize("search.labels.next")}"
             >
               ${isCard ? nothing : html`<ha-icon icon="mdi:playlist-play"></ha-icon>`}${localize(
-          "search.labels.next"
-        )}
+                "search.labels.next"
+              )}
             </button>
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onPlayOption(item, "replace_next");
-        }}
+                e.stopPropagation();
+                onPlayOption(item, "replace_next");
+              }}
               title="${localize("search.labels.replace_next")}"
             >
               ${isCard ? nothing : html`<ha-icon icon="mdi:playlist-music"></ha-icon>`}${localize(
-          "search.labels.replace_next"
-        )}
+                "search.labels.replace_next"
+              )}
             </button>
             <button
               class="slide-out-button"
               @click=${(e) => {
-          e.stopPropagation();
-          onPlayOption(item, "add");
-        }}
+                e.stopPropagation();
+                onPlayOption(item, "add");
+              }}
               title="${localize("search.labels.add")}"
             >
               ${isCard ? nothing : html`<ha-icon icon="mdi:playlist-plus"></ha-icon>`}${localize(
-          "search.labels.add"
-        )}
+                "search.labels.add"
+              )}
             </button>
             ${isTrack(item) && massQueueAvailable
-          ? html`
+              ? html`
                   <button
                     class="slide-out-button"
                     @click=${(e) => {
-              e.stopPropagation();
-              onPlayOption(item, "add_to_playlist");
-            }}
+                      e.stopPropagation();
+                      onPlayOption(item, "add_to_playlist");
+                    }}
                     title="${localize("search.labels.add_to_playlist")}"
                   >
                     ${isCard ? nothing : html`<ha-icon icon="mdi:plus"></ha-icon>`}${localize(
-              "search.labels.add_to_playlist"
-            )}
+                      "search.labels.add_to_playlist"
+                    )}
                   </button>
                 `
-          : nothing}
+              : nothing}
           `}
       <div
         class="slide-out-close"
         @click=${(e) => {
-      e.stopPropagation();
-      onOptionsToggle(null);
-    }}
+          e.stopPropagation();
+          onOptionsToggle(null);
+        }}
       >
         <ha-icon icon="mdi:close"></ha-icon>
       </div>
@@ -478,21 +478,21 @@ export function renderSearchResultItem({
   return html`
     <div
       class="yamp-search-result ${isCard ? "search-result-card" : ""} ${isMinimal
-      ? "minimal"
-      : ""} ${item._justMoved ? "just-moved" : ""} ${isActive ? "menu-active" : ""} ${isClickable
+        ? "minimal"
+        : ""} ${item._justMoved ? "just-moved" : ""} ${isActive ? "menu-active" : ""} ${isClickable
         ? "clickable"
         : ""}"
       @click=${(e) => {
-      if (isSelectionFlow || (!isCard && isClickable)) {
-        onResultClick?.(item, e);
-      } else if (isCard) {
-        onPlay?.(item);
-      }
-    }}
+        if (isSelectionFlow || (!isCard && isClickable)) {
+          onResultClick?.(item, e);
+        } else if (isCard) {
+          onPlay?.(item);
+        }
+      }}
     >
       <div class="search-sheet-thumb-container" data-clickable="${isCard}">
         ${item.thumbnail && isValidArtwork(item.thumbnail)
-      ? html`
+          ? html`
               <img
                 class="yamp-search-result-thumb"
                 src=${item.thumbnail}
@@ -500,42 +500,42 @@ export function renderSearchResultItem({
                 onerror="this.style.display='none'"
               />
             `
-      : html`
+          : html`
               <div class="yamp-search-result-thumb-placeholder">
                 <ha-icon icon="mdi:music"></ha-icon>
               </div>
             `}
         ${isCard
-      ? renderSearchResultActions({
-        item,
-        onPlay,
-        onOptionsToggle,
-        upcomingFilterActive: !!upcomingFilterActive,
-        isMusicAssistant: isMA,
-        massQueueAvailable,
-        searchView: searchViewType,
-        onMoveUp,
-        onMoveDown,
-        onMoveNext,
-        onRemove,
-        minimal: isMinimal,
-        hideActions,
-      })
-      : nothing}
+          ? renderSearchResultActions({
+              item,
+              onPlay,
+              onOptionsToggle,
+              upcomingFilterActive: !!upcomingFilterActive,
+              isMusicAssistant: isMA,
+              massQueueAvailable,
+              searchView: searchViewType,
+              onMoveUp,
+              onMoveDown,
+              onMoveNext,
+              onRemove,
+              minimal: isMinimal,
+              hideActions,
+            })
+          : nothing}
       </div>
 
       ${!isMinimal
-      ? html`
+        ? html`
             <div class="yamp-search-result-info">
               <span
                 class="yamp-search-result-title ${isClickable ? "clickable-search-result" : ""}"
                 @touchstart=${(e) => onResultTouch && onResultTouch(item, e)}
                 @click=${(e) => {
-          if (isClickable || isSelectionFlow) {
-            e.stopPropagation();
-            onResultClick && onResultClick(item, e);
-          }
-        }}
+                  if (isClickable || isSelectionFlow) {
+                    e.stopPropagation();
+                    onResultClick && onResultClick(item, e);
+                  }
+                }}
                 title=${getClickTitle(item)}
               >
                 ${item.title}
@@ -544,53 +544,53 @@ export function renderSearchResultItem({
                 class="yamp-search-result-subtitle ${isClickable ? "clickable-search-result" : ""}"
                 @touchstart=${(e) => onResultTouch && onResultTouch(item, e)}
                 @click=${(e) => {
-          if (isClickable || isSelectionFlow) {
-            e.stopPropagation();
-            onResultClick && onResultClick(item, e);
-          }
-        }}
+                  if (isClickable || isSelectionFlow) {
+                    e.stopPropagation();
+                    onResultClick && onResultClick(item, e);
+                  }
+                }}
               >
                 ${getSearchResultSubtitle(item, {
-          searchMediaClassFilter,
-          recentlyPlayedFilterActive,
-          upcomingFilterActive,
-          recommendationsFilterActive,
-        })}
+                  searchMediaClassFilter,
+                  recentlyPlayedFilterActive,
+                  upcomingFilterActive,
+                  recommendationsFilterActive,
+                })}
               </span>
               ${isCard && !isRadio(item) && !hideActions
-          ? html`
+                ? html`
                     <div
                       class="card-menu-button"
                       @click=${(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onOptionsToggle(item);
-            }}
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onOptionsToggle(item);
+                      }}
                     >
                       <ha-icon icon="mdi:dots-vertical"></ha-icon>
                     </div>
                   `
-          : nothing}
+                : nothing}
             </div>
           `
-      : nothing}
+        : nothing}
       ${!isCard
-      ? renderSearchResultActions({
-        item,
-        onPlay,
-        onOptionsToggle,
-        upcomingFilterActive: !!upcomingFilterActive,
-        isMusicAssistant: isMA,
-        massQueueAvailable,
-        searchView: searchViewType,
-        isInline: true,
-        onMoveUp,
-        onMoveDown,
-        onMoveNext,
-        onRemove,
-        hideActions,
-      })
-      : nothing}
+        ? renderSearchResultActions({
+            item,
+            onPlay,
+            onOptionsToggle,
+            upcomingFilterActive: !!upcomingFilterActive,
+            isMusicAssistant: isMA,
+            massQueueAvailable,
+            searchView: searchViewType,
+            isInline: true,
+            onMoveUp,
+            onMoveDown,
+            onMoveNext,
+            onRemove,
+            hideActions,
+          })
+        : nothing}
       ${renderSearchResultSlideOut({
         item,
         activeSearchRowMenuId,
@@ -608,37 +608,37 @@ export function renderSearchResultItem({
       ${loadingSearchRowMenuId != null &&
       item.media_content_id != null &&
       loadingSearchRowMenuId === item.media_content_id
-      ? html`
+        ? html`
             <div class="search-row-loading-overlay">
               <ha-icon icon="mdi:loading" class="spin"></ha-icon>
               <span>${localize("common.loading")}</span>
             </div>
           `
-      : nothing}
+        : nothing}
       ${errorSearchRowMenuId != null &&
       item.media_content_id != null &&
       errorSearchRowMenuId === item.media_content_id
-      ? html`
+        ? html`
             <div class="search-row-error-overlay">
               <ha-icon icon="mdi:alert-circle" class="error-icon"></ha-icon>
               <span>${localize("common.error") || "Error"}</span>
             </div>
           `
-      : nothing}
+        : nothing}
       ${successSearchRowMenuId != null &&
       item.media_content_id != null &&
       successSearchRowMenuId === item.media_content_id
-      ? html`
+        ? html`
             <div class="search-row-success-overlay">
               <span>✅</span>
               <span
                 >${successSearchRowType === "playlist"
-          ? localize("search.added_to_playlist")
-          : localize("search.added")}</span
+                  ? localize("search.added_to_playlist")
+                  : localize("search.added")}</span
               >
             </div>
           `
-      : nothing}
+        : nothing}
     </div>
   `;
 }
@@ -661,14 +661,14 @@ export function renderSearchOptionsOverlay({
           <div class="entity-options-title">${item.title}</div>
 
           ${playOptions
-      .filter((option) => {
-        if (option.mode === "add_to_playlist") {
-          return isTrack(item) && massQueueAvailable;
-        }
-        return true;
-      })
-      .map(
-        (option) => html`
+            .filter((option) => {
+              if (option.mode === "add_to_playlist") {
+                return isTrack(item) && massQueueAvailable;
+              }
+              return true;
+            })
+            .map(
+              (option) => html`
                 <button
                   class="entity-options-item menu-action-item"
                   @click=${() => onPlayOption(item, option.mode)}
@@ -677,7 +677,7 @@ export function renderSearchOptionsOverlay({
                   <span class="menu-action-label">${option.label}</span>
                 </button>
               `
-      )}
+            )}
 
           <div class="entity-options-divider"></div>
 
@@ -1114,8 +1114,8 @@ export async function isTrackFavorited(
           const byId =
             !byUri && /^\d+$/.test(idPart)
               ? searchItems.find(
-                (it) => typeof it?.uri === "string" && it.uri.endsWith(`/${idPart}`)
-              )
+                  (it) => typeof it?.uri === "string" && it.uri.endsWith(`/${idPart}`)
+                )
               : null;
           const foundItem = byUri || byId || null;
           if (foundItem && typeof foundItem.favorite === "boolean") {
@@ -1155,7 +1155,6 @@ export async function isTrackFavorited(
         }
       }
     }
-
 
     return false;
   } catch (error) {

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -69,19 +69,6 @@ const GESTURE_DOUBLE_TAP_IGNORE_NATIVE_DELAY = 500;
 const GESTURE_TAP_DELAY = 300;
 const GESTURE_SWIPE_THRESHOLD = 50;
 
-// Props that should trigger card_height template re-resolution when changed
-const CARD_HEIGHT_MENU_PROPS = Object.freeze([
-  "_showSearchInSheet",
-  "_showGrouping",
-  "_showSourceList",
-  "_lyricsActive",
-  "_showEntityOptions",
-  "_showTransferQueue",
-  "_showSourceMenu",
-  "_showResolvedEntities",
-  "_showMediaTitleOptions",
-]);
-
 window.customCards = window.customCards || [];
 if (!window.customCards.some(card => card.type === "yet-another-media-player")) {
   window.customCards.push({
@@ -594,10 +581,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._showSourceList = false;
     // Overlay state for transfer queue sheet
     this._showTransferQueue = false;
-    this._cardHeightTemplate = null;
-    this._cardHeightTemplateResult = null;
-    this._cardHeightTemplateNeedsResolve = false;
-    this._resolvingCardHeightTemplate = false;
+    this._cardHeightTemplateValue = {};
+    this._cardHeightResolveCache = {};
     this._lastCardHeightContextKey = null;
     this._transferQueuePendingTarget = null;
     this._transferQueueStatus = null;
@@ -827,6 +812,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
       currentCache = this._controlLayoutTemplateValue[idx];
       templateVals = this._controlLayoutTemplateValue;
       cache = this._controlLayoutResolveCache;
+    } else if (type === 'card_height') {
+      currentCache = this._cardHeightTemplateValue[idx];
+      templateVals = this._cardHeightTemplateValue;
+      cache = this._cardHeightResolveCache;
     }
 
     // Check if there's already an active subscription for this exact template
@@ -864,7 +853,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
         if (type === 'ma' || type === 'vol') {
           isValid = resolved && /^([a-z0-9_]+)\.[a-zA-Z0-9_]+$/.test(resolved);
-        } else if (type === 'action_in_menu' || type === 'always_collapsed' || type === 'control_layout') {
+        } else if (type === 'action_in_menu' || type === 'always_collapsed' || type === 'control_layout' || type === 'card_height') {
           isValid = true; // Any string result is valid
         }
 
@@ -880,7 +869,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
             cache[idx] = { id: resolved, ts: Date.now() };
             shouldUpdate = true;
           }
-        } else if (type === 'action_in_menu' || type === 'always_collapsed' || type === 'control_layout') {
+        } else if (type === 'action_in_menu' || type === 'always_collapsed' || type === 'control_layout' || type === 'card_height') {
           const currentCached = cache[idx]?.value;
           if (isValid && currentCached !== resolved) {
             cache[idx] = { value: resolved, ts: Date.now() };
@@ -1004,6 +993,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
       templateVals = this._controlLayoutTemplateValue;
       cache = this._controlLayoutResolveCache;
       contextKeyName = '_lastControlLayoutContextKey';
+    } else if (type === 'card_height') {
+      templateVals = this._cardHeightTemplateValue;
+      cache = this._cardHeightResolveCache;
+      contextKeyName = '_lastCardHeightContextKey';
     } else {
       return;
     }
@@ -1014,13 +1007,12 @@ class YetAnotherMediaPlayerCard extends LitElement {
     }
 
     const processItem = (idx, raw) => {
-      if (isContextChanged) {
-        this._unsubscribeFromTemplate(idx, type);
-        if (templateVals[idx]) delete templateVals[idx];
-        if (cache[idx]) delete cache[idx];
-      }
-
       if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
+        if (isContextChanged) {
+          this._unsubscribeFromTemplate(idx, type);
+          if (templateVals[idx]) delete templateVals[idx];
+          if (cache[idx]) delete cache[idx];
+        }
         this._subscribeToTemplate(idx, type, raw);
       } else {
         this._unsubscribeFromTemplate(idx, type);
@@ -1029,7 +1021,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       }
     };
 
-    if (type === 'always_collapsed' || type === 'control_layout') {
+    if (type === 'always_collapsed' || type === 'control_layout' || type === 'card_height') {
       processItem('card', rawConfigData);
     } else if (type === 'action_in_menu') {
       const actions = rawConfigData || [];
@@ -3885,8 +3877,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
   }
 
   _getAdaptiveBaselineHeight(collapsed = false) {
-    const raw = this._cardHeightTemplate
-      ? this._cardHeightTemplateResult
+    const raw = this._cardHeightTemplateValue?.card?.template
+      ? this._cardHeightResolveCache?.card?.value
       : this.config?.card_height;
     if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
       return raw;
@@ -3948,28 +3940,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._isIdle = idle;
     if (this._cardHeightTemplate) this._cardHeightTemplateNeedsResolve = true;
   }
-
-  async _resolveCardHeightTemplate() {
-    if (!this._cardHeightTemplate || this._resolvingCardHeightTemplate || !this.hass) return;
-    // Skip resolution if context hasn't changed since last resolve
-    const context = this._getTemplateContext();
-    const contextKey = JSON.stringify(context);
-    if (contextKey === this._lastCardHeightContextKey && !this._cardHeightTemplateNeedsResolve) return;
-    this._resolvingCardHeightTemplate = true;
-    try {
-      const result = await resolveStringTemplate(this.hass, this._cardHeightTemplate, context);
-      const parsed = Number(result);
-      this._cardHeightTemplateResult = (Number.isFinite(parsed) && parsed > 0) ? parsed : null;
-      this._lastCardHeightContextKey = contextKey;
-    } catch (error) {
-      this._cardHeightTemplateResult = null;
-    } finally {
-      this._resolvingCardHeightTemplate = false;
-      this._cardHeightTemplateNeedsResolve = false;
-      this.requestUpdate();
-    }
-  }
-
   _ensureArtworkOverrideIndexMap() {
     if (this._artworkOverrideIndexMap) return;
     this._artworkOverrideIndexMap = new WeakMap();
@@ -4283,18 +4253,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       this._idleImageTemplateNeedsResolve = false;
     }
     // Handle card_height templates (similar to idle_image)
-    if (typeof config.card_height === "string" &&
-      (config.card_height.includes("{{") || config.card_height.includes("{%"))) {
-      this._cardHeightTemplate = config.card_height;
-      this._cardHeightTemplateResult = null; // null = not yet resolved
-      this._cardHeightTemplateNeedsResolve = true;
-      this._lastCardHeightContextKey = null;
-    } else {
-      this._cardHeightTemplate = null;
-      this._cardHeightTemplateResult = null;
-      this._cardHeightTemplateNeedsResolve = false;
-      this._lastCardHeightContextKey = null;
-    }
+    // card_height now uses websocket template subscriptions
     // Set idle timeout ms
     this._idleTimeoutMs = typeof config.idle_timeout_ms === "number" ? config.idle_timeout_ms : 60000;
     if (this._idleTimeoutMs === 0) {
@@ -5705,17 +5664,11 @@ class YetAnotherMediaPlayerCard extends LitElement {
     if (this._idleImageTemplate && changedProps.has("hass")) {
       this._idleImageTemplateNeedsResolve = true;
     }
-    if (this._cardHeightTemplate) {
-      if (changedProps.has("hass") || this._cardHeightTemplateNeedsResolve || CARD_HEIGHT_MENU_PROPS.some(p => changedProps.has(p))) {
-        void this._resolveCardHeightTemplate();
-      }
-    }
-    if (changedProps.has("hass") || changedProps.has("config")) {
-      const currentContext = JSON.stringify(this._getTemplateContext());
-      this._syncTemplateSubscriptions('action_in_menu', currentContext, this.config?.actions);
-      this._syncTemplateSubscriptions('always_collapsed', currentContext, this.config?.always_collapsed);
-      this._syncTemplateSubscriptions('control_layout', currentContext, this.config?.control_layout);
-    }
+    const currentContext = JSON.stringify(this._getTemplateContext());
+    this._syncTemplateSubscriptions('action_in_menu', currentContext, this.config?.actions);
+    this._syncTemplateSubscriptions('always_collapsed', currentContext, this.config?.always_collapsed);
+    this._syncTemplateSubscriptions('control_layout', currentContext, this.config?.control_layout);
+    this._syncTemplateSubscriptions('card_height', currentContext, this.config?.card_height);
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
       void this._updateTransferQueueAvailability({ refresh: false });
     }
@@ -5993,11 +5946,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
       if (contentEl) {
         const measured = contentEl.offsetHeight;
         if (measured && measured > 0) {
-          const customHeight = Number(
-            this._cardHeightTemplate
-              ? this._cardHeightTemplateResult
-              : this.config?.card_height
-          );
+          const customHeightInput = this._cardHeightTemplateValue?.card?.template
+            ? this._cardHeightResolveCache?.card?.value
+            : this.config?.card_height;
+          const customHeight = Number(customHeightInput);
           const hasCustomCardHeight = Number.isFinite(customHeight) && customHeight > 0;
           if (!hasCustomCardHeight) {
             this._collapsedBaselineHeight = measured;
@@ -7200,8 +7152,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
 
 
-    const customCardHeightInput = this._cardHeightTemplate
-      ? this._cardHeightTemplateResult
+    const customCardHeightInput = this._cardHeightTemplateValue?.card?.template
+      ? this._cardHeightResolveCache?.card?.value
       : this.config.card_height;
     const customCardHeight = typeof customCardHeightInput === "string"
       ? (customCardHeightInput.includes('px') ? parseFloat(customCardHeightInput) : Number(customCardHeightInput))
@@ -8044,8 +7996,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
   }
 
   _getCardHeightMetrics(config) {
-    const customCardHeightInput = this._cardHeightTemplate
-      ? this._cardHeightTemplateResult
+    const customCardHeightInput = this._cardHeightTemplateValue?.card?.template
+      ? this._cardHeightResolveCache?.card?.value
       : config.card_height;
     const customCardHeight = typeof customCardHeightInput === "string"
       ? parseFloat(customCardHeightInput)

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -516,6 +516,27 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
   static styles = yampCardStyles;
 
+  get _alwaysCollapsed() {
+    const raw = this.config?.always_collapsed;
+    if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
+      const resolved = this._alwaysCollapsedResolveCache?.['card']?.value;
+      if (resolved !== undefined && resolved !== null && resolved !== "") {
+        const lower = resolved.toLowerCase();
+        return lower === "true" || lower === "1" || lower === "on" || lower === "yes";
+      }
+      return false; // Default until template resolves
+    }
+    return !!raw;
+  }
+
+  get _artworkObjectFit() {
+    const fit = this._baseArtworkObjectFit || "cover";
+    if (fit === "scaled-contain-alternate" && this._alwaysCollapsed) {
+      return "scaled-contain";
+    }
+    return fit;
+  }
+
   get _cardType() {
     return this.config?.card_type || "default";
   }
@@ -624,7 +645,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._collapsedBaselineHeight = 220;
     this._lastRenderedCollapsed = false;
     this._lastRenderedHideControls = false;
-    this._artworkObjectFit = "cover";
+    this._baseArtworkObjectFit = "cover";
     this._idleScreen = "default";
     this._idleScreenApplied = false;
     this._hasSeenPlayback = false;
@@ -736,6 +757,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._volTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
     this._actionInMenuTemplateValues = {}; // { [idx]: { template: string, resolved: string } }
     this._actionInMenuResolveCache = {}; // { [idx]: { value: string, ts: number } }
+    this._alwaysCollapsedTemplateValue = {}; // { card: { template: string, resolved: string } }
+    this._alwaysCollapsedResolveCache = {}; // { card: { value: string, ts: number } }
     this._lastActionEntityId = null;
     // Cache resolved Volume entity per index (template or static)
     this._volResolveCache = {}; // { [idx:number]: { id: string, ts: number } }
@@ -780,6 +803,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
       currentCache = this._actionInMenuTemplateValues[idx];
       templateVals = this._actionInMenuTemplateValues;
       cache = this._actionInMenuResolveCache;
+    } else if (type === 'always_collapsed') {
+      currentCache = this._alwaysCollapsedTemplateValue[idx];
+      templateVals = this._alwaysCollapsedTemplateValue;
+      cache = this._alwaysCollapsedResolveCache;
     }
 
     // Check if there's already an active subscription for this exact template
@@ -817,8 +844,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
         if (type === 'ma' || type === 'vol') {
           isValid = resolved && /^([a-z0-9_]+)\.[a-zA-Z0-9_]+$/.test(resolved);
-        } else if (type === 'action_in_menu') {
-          isValid = true; // Any string result is valid for in_menu
+        } else if (type === 'action_in_menu' || type === 'always_collapsed') {
+          isValid = true; // Any string result is valid
         }
 
         let shouldUpdate = false;
@@ -833,7 +860,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
             cache[idx] = { id: resolved, ts: Date.now() };
             shouldUpdate = true;
           }
-        } else if (type === 'action_in_menu') {
+        } else if (type === 'action_in_menu' || type === 'always_collapsed') {
           const currentCached = cache[idx]?.value;
           if (isValid && currentCached !== resolved) {
             cache[idx] = { value: resolved, ts: Date.now() };
@@ -940,40 +967,58 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._subscribeToTemplate(idx, 'vol', raw);
   }
 
-  // Ensure action in_menu templates are resolved and subscribed for the current entity context
-  _ensureResolvedActions() {
-    if (!this.hass || !this.config?.actions) return;
-    
-    // Clear old subscriptions if context changed to ensure context updates
-    const currentContext = JSON.stringify(this._getTemplateContext());
-    if (this._lastActionTemplateContextKey !== currentContext) {
-      this.config.actions.forEach((_, idx) => {
-        this._unsubscribeFromTemplate(idx, 'action_in_menu');
-        if (this._actionInMenuTemplateValues[idx]) delete this._actionInMenuTemplateValues[idx];
-        if (this._actionInMenuResolveCache[idx]) delete this._actionInMenuResolveCache[idx];
-      });
-      this._lastActionTemplateContextKey = currentContext;
+  // Unified helper for resolving and subscribing to UI templates
+  _syncTemplateSubscriptions(type, currentContext, rawConfigData) {
+    if (!this.hass) return;
+
+    let templateVals, cache, contextKeyName;
+    if (type === 'always_collapsed') {
+      templateVals = this._alwaysCollapsedTemplateValue;
+      cache = this._alwaysCollapsedResolveCache;
+      contextKeyName = '_lastAlwaysCollapsedContextKey';
+    } else if (type === 'action_in_menu') {
+      templateVals = this._actionInMenuTemplateValues;
+      cache = this._actionInMenuResolveCache;
+      contextKeyName = '_lastActionTemplateContextKey';
+    } else {
+      return;
     }
 
-    this.config.actions.forEach((act, idx) => {
-      const raw = act?.in_menu;
-      if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
-        this._subscribeToTemplate(idx, 'action_in_menu', raw);
-      } else {
-        this._unsubscribeFromTemplate(idx, 'action_in_menu');
-        if (this._actionInMenuTemplateValues[idx]) delete this._actionInMenuTemplateValues[idx];
-        delete this._actionInMenuResolveCache[idx];
-      }
-    });
+    const isContextChanged = this[contextKeyName] !== currentContext;
+    if (isContextChanged) {
+      this[contextKeyName] = currentContext;
+    }
 
-    // Clean up any stale subscriptions for indices beyond the current actions length
-    const currentLength = this.config.actions.length;
-    let checkIdx = currentLength;
-    while (this._templateSubscriptions[`${checkIdx}_action_in_menu`] || this._actionInMenuTemplateValues[checkIdx] || this._actionInMenuResolveCache[checkIdx]) {
-      this._unsubscribeFromTemplate(checkIdx, 'action_in_menu');
-      delete this._actionInMenuTemplateValues[checkIdx];
-      delete this._actionInMenuResolveCache[checkIdx];
-      checkIdx++;
+    const processItem = (idx, raw) => {
+      if (isContextChanged) {
+        this._unsubscribeFromTemplate(idx, type);
+        if (templateVals[idx]) delete templateVals[idx];
+        if (cache[idx]) delete cache[idx];
+      }
+
+      if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
+        this._subscribeToTemplate(idx, type, raw);
+      } else {
+        this._unsubscribeFromTemplate(idx, type);
+        if (templateVals[idx]) delete templateVals[idx];
+        delete cache[idx];
+      }
+    };
+
+    if (type === 'always_collapsed') {
+      processItem('card', rawConfigData);
+    } else if (type === 'action_in_menu') {
+      const actions = rawConfigData || [];
+      actions.forEach((act, idx) => processItem(idx, act?.in_menu));
+
+      // Clean up any stale subscriptions for indices beyond the current actions length
+      let checkIdx = actions.length;
+      while (this._templateSubscriptions[`${checkIdx}_${type}`] || templateVals[checkIdx] || cache[checkIdx]) {
+        this._unsubscribeFromTemplate(checkIdx, type);
+        delete templateVals[checkIdx];
+        delete cache[checkIdx];
+        checkIdx++;
+      }
     }
   }
 
@@ -4133,11 +4178,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._lastPlaying = null;
     this._lastActiveEntityId = null;
     const allowedFits = new Set(["cover", "contain", "fill", "scale-down", "none", "scaled-contain", "scaled-contain-alternate", "no_artwork"]);
-    let fit = allowedFits.has(config.artwork_object_fit) ? config.artwork_object_fit : "cover";
-    if (fit === "scaled-contain-alternate" && config.always_collapsed === true) {
-      fit = "scaled-contain";
-    }
-    this._artworkObjectFit = fit;
+    this._baseArtworkObjectFit = allowedFits.has(config.artwork_object_fit) ? config.artwork_object_fit : "cover";
     this._extendArtwork = config.extend_artwork === true;
     this._idleScreen = config.idle_screen || "default";
     this._idleScreenApplied = false;
@@ -4153,7 +4194,14 @@ class YetAnotherMediaPlayerCard extends LitElement {
     // Collapse card when idle
     this._collapseOnIdle = !!config.collapse_on_idle;
     // Force always-collapsed view
-    this._alwaysCollapsed = !!config.always_collapsed;
+    const rawAlwaysCollapsed = config.always_collapsed;
+    if (typeof rawAlwaysCollapsed === 'string' && (rawAlwaysCollapsed.includes('{{') || rawAlwaysCollapsed.includes('{%'))) {
+      this._subscribeToTemplate('card', 'always_collapsed', rawAlwaysCollapsed);
+    } else {
+      this._unsubscribeFromTemplate('card', 'always_collapsed');
+      if (this._alwaysCollapsedTemplateValue?.['card']) delete this._alwaysCollapsedTemplateValue['card'];
+      if (this._alwaysCollapsedResolveCache?.['card']) delete this._alwaysCollapsedResolveCache['card'];
+    }
     // Expand on search option (only available when always_collapsed is true)
     this._expandOnSearch = !!config.expand_on_search;
     // Alternate progress‑bar mode
@@ -4847,7 +4895,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         
         ${this._renderGroupingMenuOption()}
         
-        ${!this.config.always_collapsed ? html`
+        ${!this._alwaysCollapsed ? html`
           <button class="entity-options-item" @click=${() => {
           this._lyricsActive = !this._lyricsActive;
           if (!this._lyricsActive) {
@@ -5649,7 +5697,11 @@ class YetAnotherMediaPlayerCard extends LitElement {
         void this._resolveCardHeightTemplate();
       }
     }
-    this._ensureResolvedActions();
+    if (changedProps.has("hass") || changedProps.has("config")) {
+      const currentContext = JSON.stringify(this._getTemplateContext());
+      this._syncTemplateSubscriptions('action_in_menu', currentContext, this.config?.actions);
+      this._syncTemplateSubscriptions('always_collapsed', currentContext, this.config?.always_collapsed);
+    }
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
       void this._updateTransferQueueAvailability({ refresh: false });
     }
@@ -7146,7 +7198,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const collapsedBaselineHeight = this._collapsedBaselineHeight || 220;
 
     const hasSingleEntity = this.entityObjs.length === 1;
-    const isMinHeight = hasSingleEntity && this.config.always_collapsed === true && this.config.expand_on_search !== true;
+    const isMinHeight = hasSingleEntity && this._alwaysCollapsed && this.config.expand_on_search !== true;
     const effectivePinHeaders = this.config.pin_search_headers === true && !isMinHeight;
     const showSearchHeaders = !(this.config.hide_search_headers_on_idle === true && this._isIdle);
 
@@ -8004,20 +8056,22 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const appearance = this._appearance || "automatic";
     host.setAttribute("data-match-theme", String(config.match_theme === true));
     host.setAttribute("data-appearance", appearance);
-    host.setAttribute("data-always-collapsed", String(config.always_collapsed === true));
-    host.setAttribute("data-card-type", config.card_type || "default");
+    host.setAttribute("data-always-collapsed", String(this._alwaysCollapsed));
 
-    const forceHideMenuPlayer = config.always_collapsed === true &&
-      config.pin_search_headers === true &&
-      config.expand_on_search === true;
+    // Force hide menu player if always collapsed and no multiple entities/grouping mode
+    const hasMultipleEntities = (this.entityObjs || []).length > 1;
+    const forceHideMenuPlayer = this._alwaysCollapsed &&
+      !hasMultipleEntities &&
+      !this._showGrouping;
 
     host.setAttribute("data-hide-menu-player", String(config.hide_menu_player === true || forceHideMenuPlayer));
     host.setAttribute("data-extend-artwork", String(this._extendArtwork));
     host.setAttribute("data-control-layout", this._controlLayout || "classic");
     host.setAttribute("data-details-alignment", config.details_alignment || "left");
 
+    // Calculate if we're in absolute minimum height mode (64px)
     const hasSingleEntity = (this.entityObjs || []).length === 1;
-    const isMinHeight = hasSingleEntity && config.always_collapsed === true && config.expand_on_search !== true;
+    const isMinHeight = hasSingleEntity && this._alwaysCollapsed && config.expand_on_search !== true;
     const effectivePinHeaders = config.pin_search_headers === true && !isMinHeight;
     host.setAttribute("data-pin-search-headers", String(effectivePinHeaders));
 
@@ -8037,7 +8091,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
     const isActuallyPlaying = this._isCurrentEntityPlaying();
 
-    const collapsed = config.always_collapsed === true ||
+    const collapsed = this._alwaysCollapsed ||
       (this._isIdle && config.collapse_on_idle === true && !isActuallyPlaying);
 
     return { playbackStateObj, collapsed, forceIdleImage };

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -516,12 +516,27 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
   static styles = yampCardStyles;
 
+  get _controlLayout() {
+    const raw = this.config?.control_layout;
+    let val = raw;
+    if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
+      const resolved = this._controlLayoutResolveCache?.['card']?.value;
+      if (resolved !== undefined && resolved !== null && resolved !== "") {
+        val = resolved;
+      } else {
+        return "classic"; // Default until template resolves
+      }
+    }
+    const layoutPref = typeof val === "string" ? val.trim().toLowerCase() : "classic";
+    return layoutPref === "modern" ? "modern" : "classic";
+  }
+
   get _alwaysCollapsed() {
     const raw = this.config?.always_collapsed;
     if (typeof raw === 'string' && (raw.includes('{{') || raw.includes('{%'))) {
       const resolved = this._alwaysCollapsedResolveCache?.['card']?.value;
       if (resolved !== undefined && resolved !== null && resolved !== "") {
-        const lower = resolved.toLowerCase();
+        const lower = String(resolved).trim().toLowerCase();
         return lower === "true" || lower === "1" || lower === "on" || lower === "yes";
       }
       return false; // Default until template resolves
@@ -607,7 +622,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._latestManualShiftTime = 0;
     this._searchTimeoutHandle = null;
     this._swapPauseForStop = false;
-    this._controlLayout = "classic";
+    this._controlLayoutTemplateValue = {};
+    this._controlLayoutResolveCache = {};
     // Search hierarchy tracking
     this._searchHierarchy = []; // Array of {type: 'artist'|'album', name: string, query: string}
     this._searchBreadcrumb = ""; // Display string for current search context
@@ -807,6 +823,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
       currentCache = this._alwaysCollapsedTemplateValue[idx];
       templateVals = this._alwaysCollapsedTemplateValue;
       cache = this._alwaysCollapsedResolveCache;
+    } else if (type === 'control_layout') {
+      currentCache = this._controlLayoutTemplateValue[idx];
+      templateVals = this._controlLayoutTemplateValue;
+      cache = this._controlLayoutResolveCache;
     }
 
     // Check if there's already an active subscription for this exact template
@@ -844,7 +864,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
         if (type === 'ma' || type === 'vol') {
           isValid = resolved && /^([a-z0-9_]+)\.[a-zA-Z0-9_]+$/.test(resolved);
-        } else if (type === 'action_in_menu' || type === 'always_collapsed') {
+        } else if (type === 'action_in_menu' || type === 'always_collapsed' || type === 'control_layout') {
           isValid = true; // Any string result is valid
         }
 
@@ -860,7 +880,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
             cache[idx] = { id: resolved, ts: Date.now() };
             shouldUpdate = true;
           }
-        } else if (type === 'action_in_menu' || type === 'always_collapsed') {
+        } else if (type === 'action_in_menu' || type === 'always_collapsed' || type === 'control_layout') {
           const currentCached = cache[idx]?.value;
           if (isValid && currentCached !== resolved) {
             cache[idx] = { value: resolved, ts: Date.now() };
@@ -980,6 +1000,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
       templateVals = this._actionInMenuTemplateValues;
       cache = this._actionInMenuResolveCache;
       contextKeyName = '_lastActionTemplateContextKey';
+    } else if (type === 'control_layout') {
+      templateVals = this._controlLayoutTemplateValue;
+      cache = this._controlLayoutResolveCache;
+      contextKeyName = '_lastControlLayoutContextKey';
     } else {
       return;
     }
@@ -1005,7 +1029,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       }
     };
 
-    if (type === 'always_collapsed') {
+    if (type === 'always_collapsed' || type === 'control_layout') {
       processItem('card', rawConfigData);
     } else if (type === 'action_in_menu') {
       const actions = rawConfigData || [];
@@ -4160,8 +4184,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const templateBase = TEMPLATE_CONFIGS[templateName] || {};
     const config = { ...templateBase, ...rawConfig };
     this.config = config;
-    const layoutPref = typeof config.control_layout === "string" ? config.control_layout.toLowerCase() : "classic";
-    this._controlLayout = layoutPref === "modern" ? "modern" : "classic";
     this._swapPauseForStop = config.swap_pause_for_stop === true;
     this._holdToPin = !!config.hold_to_pin;
     this._disableSearchAutofocus = config.disable_autofocus === true;
@@ -4193,15 +4215,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._showVolumeOverlay = !!config.show_volume_overlay;
     // Collapse card when idle
     this._collapseOnIdle = !!config.collapse_on_idle;
-    // Force always-collapsed view
-    const rawAlwaysCollapsed = config.always_collapsed;
-    if (typeof rawAlwaysCollapsed === 'string' && (rawAlwaysCollapsed.includes('{{') || rawAlwaysCollapsed.includes('{%'))) {
-      this._subscribeToTemplate('card', 'always_collapsed', rawAlwaysCollapsed);
-    } else {
-      this._unsubscribeFromTemplate('card', 'always_collapsed');
-      if (this._alwaysCollapsedTemplateValue?.['card']) delete this._alwaysCollapsedTemplateValue['card'];
-      if (this._alwaysCollapsedResolveCache?.['card']) delete this._alwaysCollapsedResolveCache['card'];
-    }
     // Expand on search option (only available when always_collapsed is true)
     this._expandOnSearch = !!config.expand_on_search;
     // Alternate progress‑bar mode
@@ -5701,6 +5714,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       const currentContext = JSON.stringify(this._getTemplateContext());
       this._syncTemplateSubscriptions('action_in_menu', currentContext, this.config?.actions);
       this._syncTemplateSubscriptions('always_collapsed', currentContext, this.config?.always_collapsed);
+      this._syncTemplateSubscriptions('control_layout', currentContext, this.config?.control_layout);
     }
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
       void this._updateTransferQueueAvailability({ refresh: false });
@@ -7246,6 +7260,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         }
       }
       
+      if (typeof inMenuVal === "string") inMenuVal = inMenuVal.trim();
       if (inMenuVal === "true") inMenuVal = true;
       if (inMenuVal === "false") inMenuVal = false;
       if (inMenuVal === "hidden") return "hidden";


### PR DESCRIPTION
## Intent
This PR introduces Jinja2 template support for the `always_collapsed` and `control_layout` configuration options, enabling dynamic reactivity based on Home Assistant state and context variables.

## User-facing changes
- `always_collapsed` now supports templates (e.g. `always_collapsed: | {{ 'true' if is_playing else 'false' }}`).
- `control_layout` now supports templates (e.g. `control_layout: | {{ 'modern' if is_playing else 'classic' }}`).
- Both options are now evaluated through a unified `_syncTemplateSubscriptions` pipeline which ensures robust websocket subscriptions and context-aware teardown when variables like `is_playing` change.
- Whitespace is stripped from templated return strings to fix subtle parsing bugs, particularly affecting YAML multi-line blocks.
- Removed redundant initialization code in `setConfig` for `always_collapsed`.

## Verification
- Verified static analysis (`npm run lint` and `npm run format:check` pass).
- Verified template fallback strings effectively strip whitespace via `trim()`.
- Verified `always_collapsed` and `control_layout` template reactivity.