### PR TITLE
Fix adaptive text scaling and volume row visibility logic

### DIFF
--- a/src/volume-row.js
+++ b/src/volume-row.js
@@ -38,7 +38,12 @@ export function renderVolumeRow({
   };
 
   return html`
-    <div class="volume-row ${showSlider && !isRemoteVolumeEntity ? "has-slider" : ""}">
+    <div
+      class="volume-row ${showSlider && !isRemoteVolumeEntity ? "has-slider" : ""}"
+      style="${hideVolume && !moreInfoMenu && !hasLeadingControl && !showRightPlaceholder
+        ? "display: none !important;"
+        : ""}"
+    >
       <div class="volume-left">
         ${hasLeadingControl
           ? leadingControlTemplate

--- a/src/volume-row.js
+++ b/src/volume-row.js
@@ -40,7 +40,7 @@ export function renderVolumeRow({
   return html`
     <div
       class="volume-row ${showSlider && !isRemoteVolumeEntity ? "has-slider" : ""}"
-      style="${hideVolume && !moreInfoMenu && !hasLeadingControl && !showRightPlaceholder
+      style="${hideVolume && moreInfoMenu === nothing && !hasLeadingControl && !showRightPlaceholder
         ? "display: none !important;"
         : ""}"
     >

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -945,7 +945,7 @@ export const yampCardStyles = css`
   }
 
   .details .title {
-    font-size: calc(1.1em * var(--yamp-details-scale, 1));
+    font-size: 1.1em;
     font-weight: 600;
     line-height: var(--yamp-details-line-height, 1.2);
     white-space: normal;
@@ -962,7 +962,7 @@ export const yampCardStyles = css`
   }
 
   .details .artist {
-    font-size: calc(1em * var(--yamp-details-scale, 1));
+    font-size: 1em;
     line-height: var(--yamp-details-line-height, 1.2);
     padding-bottom: calc(4px * var(--yamp-details-scale, 1));
     margin-bottom: calc(-4px * var(--yamp-details-scale, 1));
@@ -1042,6 +1042,21 @@ export const yampCardStyles = css`
   :host([data-details-alignment="right"]) .details {
     align-items: flex-end;
     text-align: right;
+  }
+
+  :host([data-has-custom-height="true"]) .details {
+    margin-top: calc(4px * var(--yamp-details-scale, 1));
+    padding-bottom: calc(6px * var(--yamp-details-scale, 1));
+    gap: calc(4px * var(--yamp-details-scale, 1));
+  }
+
+  :host([data-has-custom-height="true"]) .details .title {
+    padding-top: calc(4px * var(--yamp-details-scale, 1));
+  }
+
+  :host([data-has-custom-height="true"]) .controls-row {
+    padding-top: 2px;
+    padding-bottom: 2px;
   }
 
   :host([data-details-alignment="center"]) .track-options-row {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -941,6 +941,7 @@ export const yampCardStyles = css`
     margin-top: calc(8px * var(--yamp-details-scale, 1));
     min-height: calc(48px * var(--yamp-details-scale, 1));
     font-size: calc(1em * var(--yamp-details-scale, 1));
+    flex-shrink: 0;
   }
 
   .details .title {
@@ -956,11 +957,15 @@ export const yampCardStyles = css`
     -webkit-line-clamp: var(--yamp-details-max-lines, 3);
     overflow: hidden;
     padding-top: calc(8px * var(--yamp-details-scale, 1));
+    padding-bottom: calc(4px * var(--yamp-details-scale, 1));
+    margin-bottom: calc(-4px * var(--yamp-details-scale, 1));
   }
 
   .details .artist {
     font-size: calc(1em * var(--yamp-details-scale, 1));
     line-height: var(--yamp-details-line-height, 1.2);
+    padding-bottom: calc(4px * var(--yamp-details-scale, 1));
+    margin-bottom: calc(-4px * var(--yamp-details-scale, 1));
   }
 
   .track-options-row {

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7689,8 +7689,14 @@ class YetAnotherMediaPlayerCard extends LitElement {
       this.config.volume_mode === "hidden" ||
       (hasCustomCardHeight && customCardHeight < 260 && collapsed && !this._showEntityOptions);
 
+    const hasMoreInfoMenu = (!this._showEntityOptions && !isCompactVolume);
+    const hasRightPlaceholder = this._controlLayout === "modern";
+    const hasLeadingControl = leadingVolumeControl !== nothing && leadingVolumeControl !== undefined && leadingVolumeControl !== null;
+
+    const volumeRowWillCollapse = isVolumeHidden && !hasMoreInfoMenu && !hasLeadingControl && !hasRightPlaceholder;
+
     this._lastSpacerRendered = !!(showCollapsedPlaceholder || (!collapsed && hasSpacerContent));
-    this._lastVolumeRendered = !isVolumeHidden;
+    this._lastVolumeRendered = !volumeRowWillCollapse;
 
     return html`
         <ha-card class="yamp-card" style=${(hasCustomCardHeight && (!collapsed || this._alwaysCollapsed)) ? `height:${customCardHeight}px;` : nothing}>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -3850,23 +3850,36 @@ class YetAnotherMediaPlayerCard extends LitElement {
       this._currentTextScale = scale;
       this._currentDetailsScale = detailScale;
       this._setAdaptiveTextVars(scale, undefined, detailScale);
+      this.requestUpdate();
     }
   }
 
   _calculateDetailsScale(width, height, fallbackScale = 1) {
     const targetSet = this._adaptiveTextTargets;
     if (!targetSet?.has("details")) return 1;
-    const widthFactor = Math.min(Math.max(1, width / 360), 3.2);
-    const heightFactor = Math.max(1, Math.min(height / 330, 2.4));
-    const dominant = Math.max(widthFactor * 0.7 + heightFactor * 0.3, heightFactor);
-    const maxScale = Math.min(3.25, 1 + (heightFactor - 1) * 1.35);
-    const requested = Math.max(fallbackScale, dominant * 1.18);
-    const baseScale = Math.max(1, Math.min(requested, maxScale));
+    
+    // Width is the primary driver of text size because text expands horizontally.
+    const widthFactor = width / 360;
+    const desiredScale = Math.min(3.25, Math.max(1, widthFactor * 0.85 + 0.15));
+    
+    // Height acts as a physical constraint so the scaled text doesn't push the layout out of bounds.
+    // At scale 1.0, the UI needs ~190px of vertical height.
+    // Every additional 1.0 scale adds about 170px of required height 
+    // due to padding, line-height, and font-size scaling.
+    const maxHeightScale = Math.max(1, 1 + (height - 190) / 170);
+    const maxScaleByHeight = Math.min(3.25, maxHeightScale);
+    
+    // The base scale must satisfy BOTH physical dimensions (width and height)
+    const baseScale = Math.min(desiredScale, maxScaleByHeight);
+    
     const titleLength = this._lastTitleLength || 0;
     const lengthClamp = titleLength > 0
       ? Math.max(0.62, Math.min(1, 30 / Math.min(titleLength, 72)))
       : 1;
-    return 1 + (baseScale - 1) * lengthClamp;
+      
+    // Apply length clamp
+    const clampedScale = 1 + (baseScale - 1) * lengthClamp;
+    return Math.max(1, clampedScale);
   }
 
   _calculateDetailsLineHeight(scale) {
@@ -7561,7 +7574,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const collapsedDetailsMinHeight = effectiveExtraSpace > 0
       ? Math.round(baseDetailsMinHeight + detailGrowth)
       : (effectiveExtraSpace < -20 ? 36 : baseDetailsMinHeight);
-    const detailsMinHeight = collapsed ? collapsedDetailsMinHeight : baseDetailsMinHeight;
+    const detailsScale = (this._adaptiveTextTargets?.has("details")) ? (this._currentDetailsScale || 1) : 1;
+    const detailsMinHeight = Math.round((collapsed ? collapsedDetailsMinHeight : baseDetailsMinHeight) * detailsScale);
     let showCollapsedPlaceholder;
     const expandedHeightBaseline = 350;
     const resolvedCollapsedHeight = collapsed
@@ -7689,7 +7703,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         }
         styles.push(`min-height: ${collapsed
           ? (hideControlsNow ? `${this._collapsedBaselineHeight || 220}px` : '0px')
-          : (hideControlsNow ? '350px' : '350px')}`);
+          : (hasCustomCardHeight ? `${customCardHeight}px` : '350px')}`);
         styles.push('transition: min-height 0.4s cubic-bezier(0.6,0,0.4,1), background 0.4s');
         return styles.join('; ');
       })()}"
@@ -7699,7 +7713,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         if (!hideControlsNow) return '';
         return collapsed
           ? `min-height: ${this._collapsedBaselineHeight || 220}px;`
-          : 'min-height: 350px;';
+          : `min-height: ${hasCustomCardHeight ? `${customCardHeight}px` : '350px'};`;
       })()}">
                 ${collapsed && artworkUrl && collapsedArtworkSize > 0 && this._isValidArtworkUrl(artworkUrl) ? html`
                   <div

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -590,6 +590,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     this._transferQueueAutoCloseTimer = null;
     // Alternate progress‑bar mode
     this._alternateProgressBar = false;
+    this._lastSpacerRendered = true;
+    this._lastVolumeRendered = true;
     // Group base volume for group gain logic
     this._groupBaseVolume = null;
     // Search sheet state variables
@@ -3838,7 +3840,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const width = rect?.width || 0;
     if (!width) return;
     const baselineHeight = this._getAdaptiveBaselineHeight(this._lastRenderedCollapsed || false);
-    const height = baselineHeight || rect?.height || width;
+    const height = rect?.height && rect.height > 0 ? rect.height : (baselineHeight || width);
     const widthFactor = width / 360;
     const heightFactor = height / 360;
     const blended = (widthFactor * 0.8) + (heightFactor * 0.2);
@@ -3863,10 +3865,22 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const desiredScale = Math.min(3.25, Math.max(1, widthFactor * 0.85 + 0.15));
     
     // Height acts as a physical constraint so the scaled text doesn't push the layout out of bounds.
-    // At scale 1.0, the UI needs ~190px of vertical height.
-    // Every additional 1.0 scale adds about 170px of required height 
-    // due to padding, line-height, and font-size scaling.
-    const maxHeightScale = Math.max(1, 1 + (height - 190) / 170);
+    // We compute baseline height requirements dynamically based on what is rendered:
+    // Spacer: 48px if rendered.
+    // Volume row: 72px if rendered.
+    // Controls: 56px.
+    // Details baseline: 82px (approx space needed at scale 1.0).
+    const isSpacerRendered = this._lastSpacerRendered !== false;
+    const isVolumeRendered = this._lastVolumeRendered !== false;
+    let baselineNeeded = 56 + 82; // Controls + Details baseline
+    if (isSpacerRendered) baselineNeeded += 48;
+    if (isVolumeRendered) baselineNeeded += 72;
+
+    // Scale cost represents extra pixels needed per 1.0 scale factor
+    // Details layout (margins, font size, gap, line height) scales by ~82px per 1.0 scale
+    const scaleCost = 82;
+
+    const maxHeightScale = Math.max(1, 1 + (height - baselineNeeded) / scaleCost);
     const maxScaleByHeight = Math.min(3.25, maxHeightScale);
     
     // The base scale must satisfy BOTH physical dimensions (width and height)
@@ -7628,6 +7642,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const activeArtworkFit = artworkObjectFit || this._artworkObjectFit;
     const isAlternateFit = activeArtworkFit === "scaled-contain-alternate";
     const useInsetArtwork = (activeArtworkFit === "scaled-contain" || isAlternateFit) && !collapsed && !this._alwaysCollapsed;
+    const hasSpacerContent =
+      (useInsetArtwork && artworkUrl) ||
+      (!useInsetArtwork && !artworkUrl && !idleImageUrl) ||
+      (this._lyricsActive && !this._isIdle);
     // Add top padding to artwork spacer when scaled-contain and chips are not shown inline
     const needsArtworkTopPadding = (activeArtworkFit === "scaled-contain" || isAlternateFit) &&
       (showChipRow === "in_menu" || (hasSingleEntity && showChipRow !== "always"));
@@ -7665,6 +7683,14 @@ class YetAnotherMediaPlayerCard extends LitElement {
     ].join('; ');
 
 
+
+    const isVolumeHidden =
+      shouldHideVolumeControls ||
+      this.config.volume_mode === "hidden" ||
+      (hasCustomCardHeight && customCardHeight < 260 && collapsed && !this._showEntityOptions);
+
+    this._lastSpacerRendered = !!(showCollapsedPlaceholder || (!collapsed && hasSpacerContent));
+    this._lastVolumeRendered = !isVolumeHidden;
 
     return html`
         <ha-card class="yamp-card" style=${(hasCustomCardHeight && (!collapsed || this._alwaysCollapsed)) ? `height:${customCardHeight}px;` : nothing}>
@@ -7740,7 +7766,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
                       onerror="this.style.display='none'" />
                   </div>
                 ` : nothing}
-                ${(showCollapsedPlaceholder || !collapsed) ? html`
+                ${(showCollapsedPlaceholder || (!collapsed && hasSpacerContent)) ? html`
                   <div class="card-artwork-spacer${showCollapsedPlaceholder ? ' show-placeholder' : ''}"
                     @pointerdown=${(e) => this._onTapAreaPointerDown(e)}
                     @pointermove=${(e) => this._onTapAreaPointerMove(e)}
@@ -7905,7 +7931,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
         reserveLeadingControlSpace: this._controlLayout === "modern",
         showRightPlaceholder: this._controlLayout === "modern",
         rightSlotTemplate: shouldHideVolumeControls ? (rightSlotTemplate !== nothing ? html`<div style="visibility:hidden; opacity:0; pointer-events:none;">${rightSlotTemplate}</div>` : nothing) : rightSlotTemplate,
-        hideVolume: shouldHideVolumeControls || this.config.volume_mode === "hidden" || (hasCustomCardHeight && customCardHeight < 260 && collapsed && !this._showEntityOptions),
+        hideVolume: isVolumeHidden,
         moreInfoMenu: (!this._showEntityOptions && !isCompactVolume) ? html`
           <div class="more-info-menu">
             <button class="more-info-btn" @click=${async () => await this._openEntityOptions()}>


### PR DESCRIPTION
### Description
This PR fixes two critical layout bugs related to volume row visibility and adaptive text scaling:

- **Volume Row Collapse**: Corrects a bug preventing the volume row from fully collapsing when hidden by explicitly evaluating Lit's `nothing` sentinel for the `moreInfoMenu` property.
- **Adaptive Text Scaling**: Synchronizes the text scaling algorithm's baseline height calculations with the true physical footprint of the volume row, preventing details text from overflowing the container boundaries.
- **CSS Improvements**: Refactors title and artist text styling to rely on parent `em` inheritance for cleaner rulesets.

### User-Facing Changes
- The text in the details section will no longer overflow or get cut off when the volume row is hidden but kept alive by other layout placeholders.
- The volume row correctly collapses and yields vertical space when fully empty.