### PR TITLE
feat: add custom User-Agent header to LRCLIB requests

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5731,12 +5731,16 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const cleanAlbum = album ? this._cleanTrackMetadata(album) : "";
 
     try {
+      const headers = {
+        "User-Agent": "yet-another-media-player (https://github.com/jianyu-li/yet-another-media-player)"
+      };
+
       // 1. Try precise get first
       let url = `https://lrclib.net/api/get?artist_name=${encodeURIComponent(cleanArtist)}&track_name=${encodeURIComponent(cleanTitle)}`;
       if (cleanAlbum) url += `&album_name=${encodeURIComponent(cleanAlbum)}`;
       if (duration) url += `&duration=${Math.round(duration)}`;
 
-      let response = await fetch(url);
+      let response = await fetch(url, { headers });
       if (this._currentFetchToken !== fetchToken) return [];
 
       if (!response.ok && response.status !== 404) {
@@ -5749,7 +5753,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
       } else {
         // 2. Try search fallback if precise get failed
         const searchUrl = `https://lrclib.net/api/search?artist_name=${encodeURIComponent(cleanArtist)}&track_name=${encodeURIComponent(cleanTitle)}`;
-        const searchRes = await fetch(searchUrl);
+        const searchRes = await fetch(searchUrl, { headers });
         if (this._currentFetchToken !== fetchToken) return [];
 
         if (searchRes.ok) {


### PR DESCRIPTION
### Summary
This PR adds a custom `User-Agent` header to all `fetch` requests targeting `lrclib.net` to identify the client and provide the project link, complying with LRCLIB API best practices and guidelines.

### Changes
- Updated `_getLrclibLyrics()` in `src/yet-another-media-player.js` to define a custom `User-Agent` header (`yet-another-media-player (https://github.com/jianyu-li/yet-another-media-player)`).
- Included the headers object in the `fetch()` call for the precise `/api/get` endpoint.
- Included the headers object in the `fetch()` call for the `/api/search` fallback endpoint.

### Testing
- Ran build (`npm run build`) and verified the output bundle is built correctly.
- Ran project linter and formatting checks (`npm run lint && npm run format:check`), passing cleanly.
- Deployed locally to verification setup.