### PR TITLE
Fix stale grouped entity sorting cache

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -205,9 +205,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
   _hoveredSourceLetterIndex = null;
   // Stores the last grouping master id for group chip selection
   _lastGroupingMasterId = null;
-  _groupedSortedCache = null;
   _cardTriggers = { tap: null, hold: null, double_tap: null, swipe_left: null, swipe_right: null };
-  _lastHassVersion = null;
   _debouncedVolumeTimer = null;
   _supportsFeature(stateObj, featureBit) {
     if (!stateObj || typeof stateObj.attributes.supported_features !== "number") return false;
@@ -428,11 +426,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
     const idList = this.entityIds;
     if (!idList || !Array.isArray(idList)) return [];
 
-    // Check if we can use the cache
-    if (this._groupedSortedCache && this.hass === this._lastHassVersion) {
-      return this._groupedSortedCache;
-    }
-
     const idSet = new Set(idList);
     const map = {};
     for (let i = 0; i < idList.length; i++) {
@@ -460,8 +453,6 @@ class YetAnotherMediaPlayerCard extends LitElement {
       })   // sort groups by recency
       .map(g => g.ids.sort());       // sort ids alphabetically inside each group
 
-    this._groupedSortedCache = result;
-    this._lastHassVersion = this.hass;
     return result;
   }
   static properties = {


### PR DESCRIPTION
Removes the grouped entity cache because it can return stale group ordering when quick grouping, play timestamps, or group membership change without a new hass object reference.