### PR TITLE
Clean up pending timers on disconnect

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9274,6 +9274,32 @@ class YetAnotherMediaPlayerCard extends LitElement {
       clearTimeout(this._searchTimeoutHandle);
       this._searchTimeoutHandle = null;
     }
+
+    if (this._queueRefreshTimer) {
+      clearTimeout(this._queueRefreshTimer);
+      this._queueRefreshTimer = null;
+    }
+
+    if (this._gestureHoldTimer) {
+      clearTimeout(this._gestureHoldTimer);
+      this._gestureHoldTimer = null;
+    }
+
+    if (this._tapTimer) {
+      clearTimeout(this._tapTimer);
+      this._tapTimer = null;
+    }
+
+    if (this._successToastHandle) {
+      clearTimeout(this._successToastHandle);
+      this._successToastHandle = null;
+    }
+
+    if (this._transferQueueAutoCloseTimer) {
+      clearTimeout(this._transferQueueAutoCloseTimer);
+      this._transferQueueAutoCloseTimer = null;
+    }
+
     this._latestSearchToken = 0;
 
     this._removeSourceDropdownOutsideHandler();
@@ -9301,8 +9327,8 @@ class YetAnotherMediaPlayerCard extends LitElement {
     // Clear tracking properties
     this._lastPlayingEntityId = null;
     this._controlFocusEntityId = null;
-    this._teardownAdaptiveTextObserver();
   }
+
   // Helper method to apply closing animations
   _applyClosingAnimations() {
     const overlay = this.renderRoot.querySelector('.entity-options-overlay');


### PR DESCRIPTION
Clears additional pending timeout handlers when the card disconnects, including queue refresh, gesture, toast, and transfer queue timers. This prevents delayed callbacks from running against a disconnected card instance.