### PR TITLE
Fix grab scroll handler cleanup

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9210,7 +9210,10 @@ class YetAnotherMediaPlayerCard extends LitElement {
 
   _removeGrabScrollHandlers() {
     // Remove grab scroll handlers from all elements
-    const elements = this.renderRoot.querySelectorAll('[data-grab-scroll]');
+    const elements = this.renderRoot.querySelectorAll(
+      '.chip-row, .action-chip-row, .floating-source-index'
+    );
+
     elements.forEach(el => {
       if (el._grabScrollHandlers) {
         const handlers = el._grabScrollHandlers;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9211,7 +9211,7 @@ class YetAnotherMediaPlayerCard extends LitElement {
   _removeGrabScrollHandlers() {
     // Remove grab scroll handlers from all elements
     const elements = this.renderRoot.querySelectorAll(
-      '.chip-row, .action-chip-row, .floating-source-index'
+      '.chip-row, .action-chip-row, .floating-source-index, .search-filter-chips'
     );
 
     elements.forEach(el => {


### PR DESCRIPTION
Fixes grab-scroll cleanup by selecting the same elements that receive grab-scroll handlers.

Previously the cleanup looked for a data attribute that is not rendered, so the event listeners were not removed on disconnect.