### PR TITLE
feat: add configuration search

### DIFF
--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Artwork",
       actions: "Aktionen",
     },
+    search_placeholder: "Konfigurationsoptionen suchen...",
     placeholders: {
       search: "Musik suchen...",
     },

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Artwork",
       actions: "Actions",
     },
+    search_placeholder: "Search configuration options...",
     template_label: "Card Template",
     templates: {
       custom: {

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Portada",
       actions: "Acciones",
     },
+    search_placeholder: "Buscar opciones de configuración...",
     placeholders: {
       search: "Buscar música...",
     },

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Illustrations",
       actions: "Actions",
     },
+    search_placeholder: "Rechercher des options de configuration...",
     placeholders: {
       search: "Rechercher de la musique...",
     },

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Copertina",
       actions: "Azioni",
     },
+    search_placeholder: "Cerca opzioni di configurazione...",
     placeholders: {
       search: "Cerca musica...",
     },

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Artwork",
       actions: "Acties",
     },
+    search_placeholder: "Configuratieopties zoeken...",
     placeholders: {
       search: "Zoek muziek...",
     },

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Capa",
       actions: "Ações",
     },
+    search_placeholder: "Pesquisar opções de configuração...",
     placeholders: {
       search: "Procurar música...",
     },

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Grafika",
       actions: "Akcie",
     },
+    search_placeholder: "Vyhľadať možnosti konfigurácie...",
     placeholders: {
       search: "Hľadať hudbu...",
     },

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -34,6 +34,7 @@ export default {
       artwork: "Grafika",
       actions: "Dejanja",
     },
+    search_placeholder: "Iskanje možnosti konfiguracije...",
     placeholders: {
       search: "Išči glasbo...",
     },

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -598,37 +598,8 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         }
         /* reduced padding for entity selection subrows */
         .entity-row {
-          padding-top: 4px;
-          padding-bottom: 4px;
+          padding: 6px;
         }
-        .search-input-wrapper {
-          position: relative;
-          flex: 1;
-        }
-        .search-input-clear {
-          position: absolute;
-          right: 12px;
-          top: 50%;
-          transform: translateY(-10%);
-          background: none;
-          border: none;
-          color: var(--secondary-text-color, #888);
-          cursor: pointer;
-          padding: 4px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          z-index: 2;
-        }
-        .search-input-clear:hover {
-          color: var(--primary-text-color, #fff);
-        }
-        .search-input-clear ha-icon {
-          width: 18px;
-          height: 18px;
-        }
-
-
         /* visually isolate grouped controls */
         .config-section,
         .entity-group,
@@ -986,25 +957,16 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
               ${localize(`editor.templates.${currentTemplate}.description`)}
             </div>
           </div>
-          <div class="search-input-wrapper">
+          <div>
             <ha-selector
               .hass=${this.hass}
               .selector=${{ text: { type: "search" } }}
               .value=${this._searchTerm || ""}
-              .required=${false}
               @value-changed=${(e) => {
                 this._searchTerm = e.detail.value;
               }}
               label="${localize("editor.search_placeholder") || "Search configuration options..."}"
             ></ha-selector>
-            ${this._searchTerm ? html`
-              <button
-                class="search-input-clear"
-                @click=${() => { this._searchTerm = ""; }}
-                title="${localize('common.clear') || 'Clear'}">
-                <ha-icon icon="mdi:close"></ha-icon>
-              </button>
-            ` : ""}
           </div>
         </div>
       </div>

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -957,7 +957,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
               ${localize(`editor.templates.${currentTemplate}.description`)}
             </div>
           </div>
-          <div>
+          <div style="position: relative;">
             <ha-selector
               .hass=${this.hass}
               .selector=${{ text: { type: "search" } }}
@@ -967,6 +967,17 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
               }}
               label="${localize("editor.search_placeholder") || "Search configuration options..."}"
             ></ha-selector>
+            ${this._searchTerm
+              ? html`
+                  <ha-icon
+                    icon="mdi:close"
+                    @click=${() => {
+                      this._searchTerm = "";
+                    }}
+                    style="position: absolute; right: 12px; top: 28px; transform: translateY(-50%); cursor: pointer; color: var(--secondary-text-color);"
+                  ></ha-icon>
+                `
+              : nothing}
           </div>
         </div>
       </div>

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -959,6 +959,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           </div>
           <div style="position: relative;">
             <ha-selector
+              .required=${false}
               .hass=${this.hass}
               .selector=${{ text: { type: "search" } }}
               .value=${this._searchTerm || ""}

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -36,6 +36,8 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     this._activeTab = "entities";
     this._entityEditorIndex = null;
     this._actionEditorIndex = null;
+    this._tempEntityIndex = null;
+    this._tempActionIndex = null;
 
     this._yamlDraft = "";
     this._parsedYaml = null;
@@ -49,6 +51,32 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
   firstUpdated() {
     this._serviceItems = this._getServiceItems();
+    this.addEventListener("value-changed", (e) => this._captureEditorIndex(e), true);
+    this.addEventListener("change", (e) => this._captureEditorIndex(e), true);
+    this.addEventListener("click", (e) => this._captureEditorIndex(e), true);
+  }
+
+  _captureEditorIndex(e) {
+    const path = e.composedPath();
+    const entityGroup = path.find((el) => el.classList?.contains?.("entity-group"));
+    if (entityGroup) {
+      const idx = Number(entityGroup.getAttribute("data-index"));
+      if (Number.isInteger(idx)) {
+        this._tempEntityIndex = idx;
+        return;
+      }
+    }
+    this._tempEntityIndex = null;
+
+    const actionGroup = path.find((el) => el.classList?.contains?.("action-group"));
+    if (actionGroup) {
+      const idx = Number(actionGroup.getAttribute("data-index"));
+      if (Number.isInteger(idx)) {
+        this._tempActionIndex = idx;
+        return;
+      }
+    }
+    this._tempActionIndex = null;
   }
 
   updated(changedProperties) {
@@ -58,7 +86,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         this._serviceItems = this._getServiceItems();
       }
     }
-    if (changedProperties.has("_searchTerm")) {
+    if (changedProperties.has("_searchTerm") || this._searchTerm) {
       this._applySearchFilter();
     }
   }
@@ -453,7 +481,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
   _updateEntityProperty(key, value) {
     const entities = [...(this._config.entities ?? [])];
-    const idx = this._entityEditorIndex;
+    const idx = this._tempEntityIndex !== null ? this._tempEntityIndex : this._entityEditorIndex;
     if (entities[idx]) {
       entities[idx] = { ...entities[idx], [key]: value };
       this._updateConfig("entities", entities);
@@ -462,7 +490,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
   _updateActionProperty(key, value) {
     const actions = [...(this._config.actions ?? [])];
-    const idx = this._actionEditorIndex;
+    const idx = this._tempActionIndex !== null ? this._tempActionIndex : this._actionEditorIndex;
     if (actions[idx]) {
       // Enforce single trigger per gesture (Tap, Hold, Double Tap)
       if (key === "card_trigger" && value && value !== "none") {
@@ -936,7 +964,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
     return html`
       <div class="config-section" style="margin-top: 0; margin-bottom: 12px;">
-        <div class="form-row" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px;">
+        <div
+          class="form-row"
+          style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px;"
+        >
           <div>
             <ha-selector
               .hass=${this.hass}
@@ -982,37 +1013,43 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           </div>
         </div>
       </div>
-      ${this._searchTerm ? this._renderActiveTab() : html`
-        <div class="tabs">
-        ${["entities", "behavior", "look_and_feel", "artwork", "actions"].map((key) => {
-          const name = localize(`editor.tabs.${key}`);
-          return html`
-            <button
-              class="tab"
-              ${this._activeTab === key ? "selected" : ""}
-              @click=${() => {
-                this._activeTab = key;
-                // Exit any sub-editor when switching tabs
-                this._entityEditorIndex = null;
-                this._actionEditorIndex = null;
-                this._useTemplate = null;
-                this._useVolTemplate = null;
-              }}
-              ?selected=${this._activeTab === key}
-            >
-              ${name}
-            </button>
-          `;
-        })}
-      </div>
-      <div class="tab-content">
-        ${editingEntity
-          ? this._renderEntityEditor(this._config.entities?.[this._entityEditorIndex])
-          : editingAction
-            ? this._renderActionEditor(this._config.actions?.[this._actionEditorIndex])
-            : this._renderActiveTab()}
-      </div>
-      `}
+      ${this._searchTerm && !editingEntity && !editingAction
+        ? this._renderActiveTab()
+        : html`
+            ${this._searchTerm
+              ? nothing
+              : html`
+                  <div class="tabs">
+                    ${["entities", "behavior", "look_and_feel", "artwork", "actions"].map((key) => {
+                      const name = localize(`editor.tabs.${key}`);
+                      return html`
+                        <button
+                          class="tab"
+                          ${this._activeTab === key ? "selected" : ""}
+                          @click=${() => {
+                            this._activeTab = key;
+                            // Exit any sub-editor when switching tabs
+                            this._entityEditorIndex = null;
+                            this._actionEditorIndex = null;
+                            this._useTemplate = null;
+                            this._useVolTemplate = null;
+                          }}
+                          ?selected=${this._activeTab === key}
+                        >
+                          ${name}
+                        </button>
+                      `;
+                    })}
+                  </div>
+                `}
+            <div class="tab-content">
+              ${editingEntity
+                ? this._renderEntityEditor(this._config.entities?.[this._entityEditorIndex])
+                : editingAction
+                  ? this._renderActionEditor(this._config.actions?.[this._actionEditorIndex])
+                  : this._renderActiveTab()}
+            </div>
+          `}
     `;
   }
 
@@ -1458,61 +1495,135 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
   _applySearchFilter() {
     if (!this.shadowRoot) return;
     const term = (this._searchTerm || "").toLowerCase().trim();
-    
-    const container = this.shadowRoot.querySelector('.search-results');
+
+    const container = this.shadowRoot.querySelector(".search-results, .tab-content");
     if (!container) return;
 
-    const sections = container.querySelectorAll('.config-section, .entity-group, .action-group');
-    
-    sections.forEach(section => {
-      let sectionHasMatch = false;
-      const rows = section.querySelectorAll('.form-row, .artwork-row, .entity-row-inner, .action-row-inner');
-      rows.forEach(row => {
-        let text = row.innerText.toLowerCase();
-        // Include the config property name itself in the searchable text
-        // (e.g., 'idle_timeout_ms' -> 'idle timeout ms')
-        const searchKeys = row.getAttribute('data-search-keys');
-        if (searchKeys) {
-          text += ' ' + searchKeys.toLowerCase().replace(/_/g, ' ');
-        }
-        
-        // Dynamically include dropdown/selector options if present
-        const selectors = row.querySelectorAll('ha-selector');
-        selectors.forEach(sel => {
-          const options = sel.selector?.select?.options;
-          if (Array.isArray(options)) {
-            options.forEach(opt => {
-              if (opt.label) text += ' ' + String(opt.label).toLowerCase();
-              if (opt.value) text += ' ' + String(opt.value).toLowerCase();
-            });
+    const isSubEditor = this._entityEditorIndex !== null || this._actionEditorIndex !== null;
+
+    const ENTITY_SUB_EDITOR_KEYS = [
+      "name",
+      "hidden controls",
+      "music assistant entity",
+      "ma entity",
+      "ma template",
+      "hidden search filter chips",
+      "hidden chips",
+      "prefer music assistant metadata",
+      "prefer ma metadata",
+      "disable auto select",
+      "group volume",
+      "volume entity follows active entity",
+      "volume entity",
+      "sync power",
+    ];
+
+    const ACTION_SUB_EDITOR_KEYS = [
+      "name",
+      "icon",
+      "in menu",
+      "card trigger",
+      "action type",
+      "menu item",
+      "navigation path",
+      "navigation new tab",
+      "sync entity helper",
+      "sync entity type",
+      "service",
+      "script variable",
+    ];
+
+    const filterRow = (row) => {
+      let text = row.textContent.toLowerCase();
+
+      // If we are in the main editor and filtering entity/action rows,
+      // also match if the search term matches any option inside their sub-editors
+      if (!isSubEditor) {
+        if (row.classList.contains("entity-row-inner")) {
+          const hasSubEditorMatch = ENTITY_SUB_EDITOR_KEYS.some((key) => key.includes(term));
+          if (hasSubEditorMatch) {
+            row.style.display = "";
+            return true;
           }
-        });
-        
-        if (text.includes(term)) {
-          row.style.display = '';
-          sectionHasMatch = true;
-        } else {
-          row.style.display = 'none';
+        } else if (row.classList.contains("action-row-inner")) {
+          const hasSubEditorMatch = ACTION_SUB_EDITOR_KEYS.some((key) => key.includes(term));
+          if (hasSubEditorMatch) {
+            row.style.display = "";
+            return true;
+          }
+        }
+      }
+
+      // Include the config property name itself in the searchable text
+      // (e.g., 'idle_timeout_ms' -> 'idle timeout ms')
+      const searchKeys = row.getAttribute("data-search-keys");
+      if (searchKeys) {
+        text += " " + searchKeys.toLowerCase().replace(/_/g, " ");
+      }
+
+      // Dynamically include dropdown/selector options if present
+      const selectors = row.querySelectorAll("ha-selector");
+      selectors.forEach((sel) => {
+        const options = sel.selector?.select?.options;
+        if (Array.isArray(options) && options.length <= 15) {
+          options.forEach((opt) => {
+            if (opt.label) text += " " + String(opt.label).toLowerCase();
+            if (opt.value) text += " " + String(opt.value).toLowerCase();
+          });
         }
       });
-      
-      if (sectionHasMatch) {
-        section.style.display = '';
-      } else {
-        section.style.display = 'none';
-      }
-    });
+
+      const match = text.includes(term);
+      row.style.display = match ? "" : "none";
+      return match;
+    };
+
+    if (isSubEditor) {
+      // Sub-editor: rows are flat, filter them directly
+      const rows = container.querySelectorAll(
+        ".form-row, .artwork-row, .entity-row-inner, .action-row-inner"
+      );
+      rows.forEach(filterRow);
+    } else {
+      // Main tabs search: filter sections and their nested rows
+      const sections = container.querySelectorAll(".config-section, .entity-group, .action-group");
+      sections.forEach((section) => {
+        let sectionHasMatch = false;
+        const rows = section.querySelectorAll(
+          ".form-row, .artwork-row, .entity-row-inner, .action-row-inner"
+        );
+        rows.forEach((row) => {
+          if (filterRow(row)) {
+            sectionHasMatch = true;
+          }
+        });
+        section.style.display = sectionHasMatch ? "" : "none";
+      });
+    }
   }
 
   _renderActiveTab() {
     if (this._searchTerm) {
+      const entities = this._config?.entities ?? [];
+      const actions = this._config?.actions ?? [];
+
       return html`
         <div class="search-results is-searching" style="padding-top: 4px;">
-          ${this._renderEntitiesTab()}
-          ${this._renderBehaviorTab()}
-          ${this._renderVisualTab()}
-          ${this._renderArtworkTab()}
-          ${this._renderActionsTab()}
+          ${this._renderBehaviorTab()} ${this._renderVisualTab()} ${this._renderArtworkTab()}
+          ${entities.map(
+            (ent, idx) => html`
+              <div class="entity-group" data-index="${idx}">
+                ${this._renderEntityEditor(ent, idx, true)}
+              </div>
+            `
+          )}
+          ${actions.map(
+            (act, idx) => html`
+              <div class="action-group config-section" data-index="${idx}">
+                ${this._renderActionEditor(act, idx, true)}
+              </div>
+            `
+          )}
         </div>
       `;
     }
@@ -1776,7 +1887,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           <div class="config-subtitle">${localize("editor.subtitles.close_search_on_play")}</div>
         </div>
 
-        <div data-search-keys="always_collapsed expand_on_search pin_search_headers" class="form-row form-row-multi-column">
+        <div
+          data-search-keys="always_collapsed expand_on_search pin_search_headers"
+          class="form-row form-row-multi-column"
+        >
           <div
             style="${this._config.entities?.length === 1 &&
             this._config.always_collapsed === true &&
@@ -2024,7 +2138,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
             ${localize("editor.sections.look_and_feel.theme_layout.description")}
           </div>
         </div>
-        <div data-search-keys="match_theme alternate_progress_bar" class="form-row form-row-multi-column">
+        <div
+          data-search-keys="match_theme alternate_progress_bar"
+          class="form-row form-row-multi-column"
+        >
           <div>
             <ha-switch
               id="match-theme-toggle"
@@ -2079,7 +2196,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
             @value-changed=${(e) => this._updateConfig("appearance", e.detail.value)}
           ></ha-selector>
         </div>
-        <div data-search-keys="alternate_progress_bar always_collapsed display_timestamps" class="form-row form-row-multi-column">
+        <div
+          data-search-keys="alternate_progress_bar always_collapsed display_timestamps"
+          class="form-row form-row-multi-column"
+        >
           <div
             title=${this._config.alternate_progress_bar || this._config.always_collapsed
               ? localize("editor.subtitles.not_available_alt_collapsed")
@@ -2381,7 +2501,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
             ${localize("editor.sections.look_and_feel.collapsed_idle.description")}
           </div>
         </div>
-        <div data-search-keys="collapse_on_idle always_collapsed hide_menu_player pin_search_headers expand_on_search" class="form-row form-row-multi-column">
+        <div
+          data-search-keys="collapse_on_idle always_collapsed hide_menu_player pin_search_headers expand_on_search"
+          class="form-row form-row-multi-column"
+        >
           <div>
             <ha-switch
               id="collapse-on-idle-toggle"
@@ -2438,7 +2561,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
               </div>
             `
           : html`
-              <div data-search-keys="always_collapsed expand_on_search" class="form-row form-row-multi-column">
+              <div
+                data-search-keys="always_collapsed expand_on_search"
+                class="form-row form-row-multi-column"
+              >
                 <div style="display: flex; align-items: center; gap: 8px;">
                   <ha-switch
                     id="always-collapsed-toggle"
@@ -2615,7 +2741,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     `;
   }
 
-  _renderEntityEditor(entity) {
+  _renderEntityEditor(entity, idx = this._entityEditorIndex, isSearch = false) {
     const stateObj = this.hass?.states?.[entity?.entity_id];
     let showGroupVolume = this._isGroupCapable(stateObj);
     if (!showGroupVolume && entity?.music_assistant_entity) {
@@ -2631,15 +2757,35 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     }
 
     return html`
-        <div class="entity-editor-header">
-          <ha-icon
-            class="icon-button"
-            icon="mdi:chevron-left"
-            title="${localize("common.back")}"
-            @click=${this._onBackFromEntityEditor}>
-          </ha-icon>
-          <div class="entity-editor-title">${localize("editor.titles.edit_entity")}</div>
-        </div>
+        ${
+          isSearch
+            ? html`
+                <div
+                  class="entity-group-header section-header"
+                  style="padding-top: 16px; border-top: 1px solid var(--divider-color);"
+                >
+                  <div
+                    class="entity-group-title section-title"
+                    style="color: var(--custom-accent, var(--accent-color, #ff9800));"
+                  >
+                    ${entity?.name || this._entityValueRenderer(entity?.entity_id) || "Entity"}
+                    (${entity?.entity_id || "No ID"})
+                  </div>
+                </div>
+              `
+            : html`
+                <div class="entity-editor-header">
+                  <ha-icon
+                    class="icon-button"
+                    icon="mdi:chevron-left"
+                    title="${localize("common.back")}"
+                    @click=${this._onBackFromEntityEditor}
+                  >
+                  </ha-icon>
+                  <div class="entity-editor-title">${localize("editor.titles.edit_entity")}</div>
+                </div>
+              `
+        }
 
         <div class="form-row">
           <ha-selector
@@ -2975,18 +3121,37 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
       `;
   }
 
-  _renderActionEditor(action) {
+  _renderActionEditor(action, idx = this._actionEditorIndex, isSearch = false) {
     const actionMode = this._actionMode ?? this._deriveActionMode(action);
 
     return html`
-        <div class="action-editor-header">
-          <ha-icon
-            class="icon-button"
-            icon="mdi:chevron-left"
-            @click=${this._onBackFromActionEditor}>
-          </ha-icon>
-          <div class="action-editor-title">${localize("editor.titles.edit_action")}</div>
-        </div>
+        ${
+          isSearch
+            ? html`
+                <div
+                  class="action-group-header section-header"
+                  style="padding-top: 16px; border-top: 1px solid var(--divider-color);"
+                >
+                  <div
+                    class="action-group-title section-title"
+                    style="color: var(--custom-accent, var(--accent-color, #ff9800));"
+                  >
+                    Action: ${action?.name || `Action #${idx + 1}`}
+                  </div>
+                </div>
+              `
+            : html`
+                <div class="action-editor-header">
+                  <ha-icon
+                    class="icon-button"
+                    icon="mdi:chevron-left"
+                    @click=${this._onBackFromActionEditor}
+                  >
+                  </ha-icon>
+                  <div class="action-editor-title">${localize("editor.titles.edit_action")}</div>
+                </div>
+              `
+        }
 
         <div data-search-keys="name" class="form-row">
           <ha-selector
@@ -3423,7 +3588,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
                 ${typeof action.service === "string" && action.service.startsWith("script.")
                   ? html`
-                      <div data-search-keys="script_variable" class="form-row form-row-multi-column">
+                      <div
+                        data-search-keys="script_variable"
+                        class="form-row form-row-multi-column"
+                      >
                         <div>
                           <ha-switch
                             id="script-variable-toggle"

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -89,7 +89,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     if (changedProperties.has("_searchTerm") || this._searchTerm) {
       this._applySearchFilter();
     }
-
   }
 
   _supportsFeature(stateObj, featureBit) {
@@ -965,7 +964,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
     return html`
       <div class="config-section" style="margin-top: 0; margin-bottom: 12px;">
-
         <div
           class="form-row"
           style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px;"
@@ -1052,7 +1050,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                   : this._renderActiveTab()}
             </div>
           `}
-
     `;
   }
 
@@ -1495,7 +1492,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
       `;
   }
 
-
   _applySearchFilter() {
     if (!this.shadowRoot) return;
     const term = (this._searchTerm || "").toLowerCase().trim();
@@ -1631,7 +1627,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         </div>
       `;
     }
-
 
     switch (this._activeTab) {
       case "entities":
@@ -1892,12 +1887,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           <div class="config-subtitle">${localize("editor.subtitles.close_search_on_play")}</div>
         </div>
 
-
         <div
           data-search-keys="always_collapsed expand_on_search pin_search_headers"
           class="form-row form-row-multi-column"
         >
-
           <div
             style="${this._config.entities?.length === 1 &&
             this._config.always_collapsed === true &&
@@ -2150,7 +2143,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           data-search-keys="match_theme alternate_progress_bar"
           class="form-row form-row-multi-column"
         >
-
           <div>
             <ha-switch
               id="match-theme-toggle"
@@ -2210,7 +2202,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           data-search-keys="alternate_progress_bar always_collapsed display_timestamps"
           class="form-row form-row-multi-column"
         >
-
           <div
             title=${this._config.alternate_progress_bar || this._config.always_collapsed
               ? localize("editor.subtitles.not_available_alt_collapsed")
@@ -2517,7 +2508,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           data-search-keys="collapse_on_idle always_collapsed hide_menu_player pin_search_headers expand_on_search"
           class="form-row form-row-multi-column"
         >
-
           <div>
             <ha-switch
               id="collapse-on-idle-toggle"
@@ -2574,12 +2564,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
               </div>
             `
           : html`
-
               <div
                 data-search-keys="always_collapsed expand_on_search"
                 class="form-row form-row-multi-column"
               >
-
                 <div style="display: flex; align-items: center; gap: 8px;">
                   <ha-switch
                     id="always-collapsed-toggle"
@@ -3603,12 +3591,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
                 ${typeof action.service === "string" && action.service.startsWith("script.")
                   ? html`
-
                       <div
                         data-search-keys="script_variable"
                         class="form-row form-row-multi-column"
                       >
-
                         <div>
                           <ha-switch
                             id="script-variable-toggle"


### PR DESCRIPTION
## Summary
This PR adds a new search filter input at the top of the YAMP Card Configuration Editor. When a search query is active, the editor automatically combines all main settings tabs and filters down rows matching the search term. It also introduces inline search results for entity and action sub-editor options, grouping them under their respective parent labels.

## User-Facing Changes
- **Configuration Search Input**: A new search input box in the editor header with a clear (`mdi:close`) button.
- **Inline Sub-Editor Search Results**: Searching now filters and renders sub-editor configuration options (like Music Assistant Entity, volume follow settings, and custom action options) directly inline, grouped under their respective entity/action labels.
- **Improved Filter Persistence**: Active search filters persist dynamically across editor DOM re-renders (such as when toggling options or updating Home Assistant states).
- **Multi-Language Support**: Added localization keys for the search placeholder across all supported languages (`de`, `en`, `es`, `fr`, `it`, `nl`, `pt`, `sk`, `sl`).

## Technical Details
- Replaced style-aware `innerText` matching with `textContent` in the search filter to ensure hidden elements (`display: none`) remain searchable when refining or backspacing queries.
- Added capture-phase event listeners to dynamically track and capture the correct active entity/action index when interacting with inline search result options.
- Restricted selector dropdown option indexing to lists with 15 or fewer options to avoid false matches from system-wide service or entity pickers.