### PR TITLE
feat: Add Play Next dropzone to queue drag-and-drop

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4379,4 +4379,37 @@ export const lyricsStyles = css`
     border-radius: 12px;
     overflow: hidden;
   }
+
+  /* Positioning is set inline in yamp-queue-drag.js */
+  .queue-play-next-dropzone {
+    transition: background 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+  
+  @keyframes dropzoneFadeIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .queue-play-next-dropzone.is-active {
+    background: var(--custom-accent, var(--accent-color, rgba(255, 152, 0, 0.3))) !important;
+    border-style: solid !important;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  }
+
+  .queue-play-next-dropzone .dropzone-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: var(--primary-text-color);
+  }
+
+  .queue-play-next-dropzone ha-icon {
+    color: var(--custom-accent, var(--accent-color, #ff9800));
+  }
+
+  .queue-play-next-dropzone.is-active ha-icon {
+    color: var(--primary-text-color);
+  }
 `;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4391,13 +4391,6 @@ export const lyricsStyles = css`
     to { opacity: 1; transform: translateY(0); }
   }
 
-  .queue-play-next-dropzone.is-active {
-    background: var(--yamp-success-bg-medium, rgba(76, 175, 80, 0.4)) !important;
-    border-color: var(--yamp-success-color, #4caf50) !important;
-    border-style: solid !important;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
-  }
-
   .queue-play-next-dropzone .dropzone-content {
     display: flex;
     align-items: center;
@@ -4408,13 +4401,5 @@ export const lyricsStyles = css`
 
   .queue-play-next-dropzone ha-icon {
     color: var(--custom-accent, var(--accent-color, #ff9800));
-  }
-
-  .queue-play-next-dropzone.is-active ha-icon {
-    color: var(--yamp-success-color, #4caf50);
-  }
-
-  .queue-play-next-dropzone.is-active .dropzone-content {
-    color: var(--yamp-success-color, #4caf50);
   }
 `;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4392,7 +4392,8 @@ export const lyricsStyles = css`
   }
 
   .queue-play-next-dropzone.is-active {
-    background: var(--custom-accent, var(--accent-color, rgba(255, 152, 0, 0.3))) !important;
+    background: var(--yamp-success-bg-medium, rgba(76, 175, 80, 0.4)) !important;
+    border-color: var(--yamp-success-color, #4caf50) !important;
     border-style: solid !important;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
   }
@@ -4410,6 +4411,10 @@ export const lyricsStyles = css`
   }
 
   .queue-play-next-dropzone.is-active ha-icon {
-    color: var(--primary-text-color);
+    color: var(--yamp-success-color, #4caf50);
+  }
+
+  .queue-play-next-dropzone.is-active .dropzone-content {
+    color: var(--yamp-success-color, #4caf50);
   }
 `;

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -274,7 +274,7 @@ export const QueueDragMixin = (superClass) =>
             top: ${hostRect.top}px;
             left: ${hostRect.left}px;
             width: ${hostRect.width}px;
-            height: ${wrapperRect.height}px;
+            height: 56px;
             z-index: 99998;
             pointer-events: auto;
             box-sizing: border-box;

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -268,12 +268,13 @@ export const QueueDragMixin = (superClass) =>
           // Use the same proven pattern as the floating clone:
           // all positioning inline, position:fixed, appended to renderRoot
           const hostRect = this.getBoundingClientRect();
+          const dropZoneHeight = Math.max(56, Math.round(hostRect.height * 0.10));
           dropZoneEl.style.cssText = `
             position: fixed;
             top: ${hostRect.top}px;
             left: ${hostRect.left}px;
             width: ${hostRect.width}px;
-            height: 56px;
+            height: ${dropZoneHeight}px;
             z-index: 99998;
             pointer-events: auto;
             box-sizing: border-box;
@@ -360,7 +361,7 @@ export const QueueDragMixin = (superClass) =>
         isHoveringDropZone = false;
         if (dropZoneRect) {
           if (lastClientY >= dropZoneRect.top && lastClientY <= dropZoneRect.bottom &&
-              lastClientX >= dropZoneRect.left && lastClientX <= dropZoneRect.right) {
+            lastClientX >= dropZoneRect.left && lastClientX <= dropZoneRect.right) {
             isHoveringDropZone = true;
           }
         }
@@ -501,7 +502,7 @@ export const QueueDragMixin = (superClass) =>
           floatingClone.remove();
         }
         floatingClone = null;
-        
+
         // Remove the dropzone
         if (dropZoneEl && dropZoneEl.parentNode) {
           dropZoneEl.remove();

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -134,6 +134,10 @@ export const QueueDragMixin = (superClass) =>
       let scrollSpeed = 0;
       let scrollAnimationFrame = null;
       let dropZoneEl = null;
+      let dropZoneRect = null;
+      let dropZoneContentEl = null;
+      let dropZoneIconEl = null;
+      let isHoveringDropZone = false;
       let lastClientY = startY;
       let lastClientX = startX;
       let currentDropTargetIdx = null;
@@ -153,17 +157,14 @@ export const QueueDragMixin = (superClass) =>
 
         // Check if hovering over Play Next dropzone
         if (dropZoneEl) {
-          const rect = dropZoneEl.getBoundingClientRect();
-          if (clientY >= rect.top && clientY <= rect.bottom && clientX >= rect.left && clientX <= rect.right) {
+          if (isHoveringDropZone) {
             if (!dropZoneEl._isActive) {
               dropZoneEl._isActive = true;
               dropZoneEl.style.background = "rgba(76, 175, 80, 0.4)";
               dropZoneEl.style.borderColor = "#4caf50";
               dropZoneEl.style.borderStyle = "solid";
-              const contentEl = dropZoneEl.querySelector(".dropzone-content");
-              if (contentEl) contentEl.style.color = "#4caf50";
-              const iconEl = dropZoneEl.querySelector("ha-icon");
-              if (iconEl) iconEl.style.color = "#4caf50";
+              if (dropZoneContentEl) dropZoneContentEl.style.color = "#4caf50";
+              if (dropZoneIconEl) dropZoneIconEl.style.color = "#4caf50";
             }
             if (currentDropTargetIdx !== 0) {
               currentDropTargetIdx = 0;
@@ -176,10 +177,8 @@ export const QueueDragMixin = (superClass) =>
             dropZoneEl.style.background = "var(--ha-card-background, var(--card-background-color, #1c1c1c))";
             dropZoneEl.style.borderColor = "var(--custom-accent, var(--accent-color, #ff9800))";
             dropZoneEl.style.borderStyle = "dashed";
-            const contentEl = dropZoneEl.querySelector(".dropzone-content");
-            if (contentEl) contentEl.style.color = "";
-            const iconEl = dropZoneEl.querySelector("ha-icon");
-            if (iconEl) iconEl.style.color = "";
+            if (dropZoneContentEl) dropZoneContentEl.style.color = "";
+            if (dropZoneIconEl) dropZoneIconEl.style.color = "";
           }
         }
 
@@ -289,6 +288,9 @@ export const QueueDragMixin = (superClass) =>
             opacity: 0.95;
           `;
           this.renderRoot.appendChild(dropZoneEl);
+          dropZoneRect = dropZoneEl.getBoundingClientRect();
+          dropZoneContentEl = dropZoneEl.querySelector(".dropzone-content");
+          dropZoneIconEl = dropZoneEl.querySelector("ha-icon");
         }
 
         // Apply ghost class on the dragged item immediately via DOM
@@ -355,6 +357,14 @@ export const QueueDragMixin = (superClass) =>
         lastClientY = moveEvt.clientY;
         lastClientX = moveEvt.clientX;
 
+        isHoveringDropZone = false;
+        if (dropZoneRect) {
+          if (lastClientY >= dropZoneRect.top && lastClientY <= dropZoneRect.bottom &&
+              lastClientX >= dropZoneRect.left && lastClientX <= dropZoneRect.right) {
+            isHoveringDropZone = true;
+          }
+        }
+
         // Move the floating clone to follow the pointer
         if (floatingClone) {
           floatingClone.style.top = `${lastClientY - cloneOffsetY}px`;
@@ -363,16 +373,7 @@ export const QueueDragMixin = (superClass) =>
 
         // Calculate scroll speed based on pointer position relative to scroll container
         if (scrollContainer) {
-          let hoveringDropZone = false;
-          if (dropZoneEl) {
-            const rect = dropZoneEl.getBoundingClientRect();
-            if (lastClientY >= rect.top && lastClientY <= rect.bottom &&
-                lastClientX >= rect.left && lastClientX <= rect.right) {
-              hoveringDropZone = true;
-            }
-          }
-
-          if (hoveringDropZone) {
+          if (isHoveringDropZone) {
             scrollSpeed = 0;
           } else {
             const scrollRect = scrollContainer.getBoundingClientRect();
@@ -506,6 +507,9 @@ export const QueueDragMixin = (superClass) =>
           dropZoneEl.remove();
         }
         dropZoneEl = null;
+        dropZoneRect = null;
+        dropZoneContentEl = null;
+        dropZoneIconEl = null;
 
         this._activeDragCleanup = null;
       };

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -153,15 +153,31 @@ export const QueueDragMixin = (superClass) =>
         if (dropZoneEl) {
           const rect = dropZoneEl.getBoundingClientRect();
           if (clientY >= rect.top && clientY <= rect.bottom && clientX >= rect.left && clientX <= rect.right) {
-            dropZoneEl.classList.add("is-active");
+            if (!dropZoneEl._isActive) {
+              dropZoneEl._isActive = true;
+              dropZoneEl.style.background = "rgba(76, 175, 80, 0.4)";
+              dropZoneEl.style.borderColor = "#4caf50";
+              dropZoneEl.style.borderStyle = "solid";
+              const contentEl = dropZoneEl.querySelector(".dropzone-content");
+              if (contentEl) contentEl.style.color = "#4caf50";
+              const iconEl = dropZoneEl.querySelector("ha-icon");
+              if (iconEl) iconEl.style.color = "#4caf50";
+            }
             if (currentDropTargetIdx !== 0) {
               currentDropTargetIdx = 0;
               this._queueDropTargetIdx = 0;
               this._applyQueueDragVisuals(dragIdx, dragItemHeight, 0);
             }
             return; // Skip finding closest row
-          } else {
-            dropZoneEl.classList.remove("is-active");
+          } else if (dropZoneEl._isActive) {
+            dropZoneEl._isActive = false;
+            dropZoneEl.style.background = "var(--ha-card-background, var(--card-background-color, #1c1c1c))";
+            dropZoneEl.style.borderColor = "var(--custom-accent, var(--accent-color, #ff9800))";
+            dropZoneEl.style.borderStyle = "dashed";
+            const contentEl = dropZoneEl.querySelector(".dropzone-content");
+            if (contentEl) contentEl.style.color = "";
+            const iconEl = dropZoneEl.querySelector("ha-icon");
+            if (iconEl) iconEl.style.color = "";
           }
         }
 

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -363,17 +363,30 @@ export const QueueDragMixin = (superClass) =>
 
         // Calculate scroll speed based on pointer position relative to scroll container
         if (scrollContainer) {
-          const scrollRect = scrollContainer.getBoundingClientRect();
-          const topDiff = lastClientY - scrollRect.top;
-          const bottomDiff = scrollRect.bottom - lastClientY;
-          const threshold = 60;
+          let hoveringDropZone = false;
+          if (dropZoneEl) {
+            const rect = dropZoneEl.getBoundingClientRect();
+            if (lastClientY >= rect.top && lastClientY <= rect.bottom &&
+                lastClientX >= rect.left && lastClientX <= rect.right) {
+              hoveringDropZone = true;
+            }
+          }
 
-          if (topDiff < threshold && topDiff > -50) {
-            scrollSpeed = -Math.max(2, (threshold - topDiff) * 0.3);
-          } else if (bottomDiff < threshold && bottomDiff > -50) {
-            scrollSpeed = Math.max(2, (threshold - bottomDiff) * 0.3);
-          } else {
+          if (hoveringDropZone) {
             scrollSpeed = 0;
+          } else {
+            const scrollRect = scrollContainer.getBoundingClientRect();
+            const topDiff = lastClientY - scrollRect.top;
+            const bottomDiff = scrollRect.bottom - lastClientY;
+            const threshold = 60;
+
+            if (topDiff < threshold && topDiff > -50) {
+              scrollSpeed = -Math.max(2, (threshold - topDiff) * 0.3);
+            } else if (bottomDiff < threshold && bottomDiff > -50) {
+              scrollSpeed = Math.max(2, (threshold - bottomDiff) * 0.3);
+            } else {
+              scrollSpeed = 0;
+            }
           }
         }
 

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -131,6 +131,7 @@ export const QueueDragMixin = (superClass) =>
       let scrollContainer = null;
       let scrollSpeed = 0;
       let scrollAnimationFrame = null;
+      let dropZoneEl = null;
       let lastClientY = startY;
       let lastClientX = startX;
       let currentDropTargetIdx = null;
@@ -147,6 +148,22 @@ export const QueueDragMixin = (superClass) =>
 
       const updateDropTarget = (clientX, clientY) => {
         if (!cachedPositions) return;
+
+        // Check if hovering over Play Next dropzone
+        if (dropZoneEl) {
+          const rect = dropZoneEl.getBoundingClientRect();
+          if (clientY >= rect.top && clientY <= rect.bottom && clientX >= rect.left && clientX <= rect.right) {
+            dropZoneEl.classList.add("is-active");
+            if (currentDropTargetIdx !== 0) {
+              currentDropTargetIdx = 0;
+              this._queueDropTargetIdx = 0;
+              this._applyQueueDragVisuals(dragIdx, dragItemHeight, 0);
+            }
+            return; // Skip finding closest row
+          } else {
+            dropZoneEl.classList.remove("is-active");
+          }
+        }
 
         const scrollDiff = scrollContainer ? scrollContainer.scrollTop - startScrollTop : 0;
         let closestIdx = null;
@@ -220,6 +237,40 @@ export const QueueDragMixin = (superClass) =>
               });
             }
           }
+
+          // Create the Play Next dropzone — fixed overlay at the top of the card
+          dropZoneEl = document.createElement("div");
+          dropZoneEl.className = "queue-play-next-dropzone";
+          dropZoneEl.innerHTML = `
+            <div class="dropzone-content">
+              <ha-icon icon="mdi:playlist-play"></ha-icon>
+              <span>Play Next</span>
+            </div>
+          `;
+
+          // Use the same proven pattern as the floating clone:
+          // all positioning inline, position:fixed, appended to renderRoot
+          const hostRect = this.getBoundingClientRect();
+          dropZoneEl.style.cssText = `
+            position: fixed;
+            top: ${hostRect.top}px;
+            left: ${hostRect.left}px;
+            width: ${hostRect.width}px;
+            height: ${wrapperRect.height}px;
+            z-index: 99998;
+            pointer-events: auto;
+            box-sizing: border-box;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: var(--ha-card-background, var(--card-background-color, #1c1c1c));
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            border: 2px dashed var(--custom-accent, var(--accent-color, #ff9800));
+            border-radius: var(--border-radius, 16px) var(--border-radius, 16px) 0 0;
+            opacity: 0.95;
+          `;
+          this.renderRoot.appendChild(dropZoneEl);
         }
 
         // Apply ghost class on the dragged item immediately via DOM
@@ -418,6 +469,13 @@ export const QueueDragMixin = (superClass) =>
           floatingClone.remove();
         }
         floatingClone = null;
+        
+        // Remove the dropzone
+        if (dropZoneEl && dropZoneEl.parentNode) {
+          dropZoneEl.remove();
+        }
+        dropZoneEl = null;
+
         this._activeDragCleanup = null;
       };
 

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -2,6 +2,8 @@
  * Mixin to handle custom pointer-event logic for dragging and dropping items in the Mass Queue.
  * Extracts the complex pointer math and visual DOM manipulations out of the main component.
  */
+import { localize } from "./localize/localize.js";
+
 export const QueueDragMixin = (superClass) =>
   class extends superClass {
     _findScrollParent(el) {
@@ -260,7 +262,7 @@ export const QueueDragMixin = (superClass) =>
           dropZoneEl.innerHTML = `
             <div class="dropzone-content">
               <ha-icon icon="mdi:playlist-play"></ha-icon>
-              <span>Play Next</span>
+              <span>${localize("search.play_next")}</span>
             </div>
           `;
 


### PR DESCRIPTION
## Overview
This PR implements a new fixed "Play Next" dropzone overlay at the top of the Up Next queue to make it easier to drag items from the bottom of the list directly to the top.

## Changes
- **Play Next Dropzone**: Adds a localized dropzone at the top of the queue sortable container with a fixed height of 56px.
- **Scroll Handling**: Prevents automatic container scrolling when the user hovers a dragged item over the dropzone.
- **Performance**: Caches the dropzone DOM elements and bounding rect to avoid reflows during the high-frequency `pointermove` drag loop.
- **Styling**: Utilizes shadow DOM inline active styling for reliable visual feedback and removes unused duplicate CSS classes.