### PR TITLE
feat: per-entity volume mode and step overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,28 @@ entities:
     name: Kitchen
     follow_active_volume: true
   - entity_id: media_player.office_homepod
-    name: Office
-    music_assistant_entity: media_player.office_homepod_2
-    group_volume: false  # Office volume will not change when Kitchen volume is adjusted
+    group_volume: false
 ```
+
+### Volume Mode & Step Overrides (Per-Entity)
+
+You can override the global `volume_mode` and `volume_step` settings for specific entities using `entity_volume_mode` and `entity_volume_step`.
+
+- `entity_volume_mode`: Can be set to `slider`, `stepper`, or `hidden`. If omitted, it falls back to the global `volume_mode`.
+- `entity_volume_step`: The step size for the stepper (e.g., `0.05`). This is only applicable when the entity's effective volume mode is `stepper`. If omitted, it falls back to the global `volume_step`.
+
+```yaml
+type: custom:yet-another-media-player
+volume_mode: slider
+entities:
+  - entity_id: media_player.kitchen_homepod
+    name: Kitchen
+    entity_volume_mode: stepper
+    entity_volume_step: 0.1
+  - entity_id: media_player.office_homepod
+    name: Office
+```
+
 
 
 ### Group Players

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Below you will find a list of all configuration options.
 | `hidden_controls`          | array/template| No           | `[]`        | Array of control names to hide for this specific entity (Supports Templates) |
 | `hidden_filter_chips`      | array        | No           | `[]`        | Hide specific search filter chips for this entity (UI only; does not change search results) |
 | `disable_auto_select`      | boolean      | No           | `false`     | Prevents the card from automatically switching to this entity when playback starts, even if it is a group master |
+| `entity_volume_mode`       | choice       | No           | —           | Override global `volume_mode` for this entity (`slider`, `stepper`, `hidden`) |
+| `entity_volume_step`       | number       | No           | —           | Override global `volume_step` for this entity when its volume mode is `stepper` |
 |                                                                                                 |
 | **Behavior**               |              |              |             |                                                                                                 |
 | `collapse_on_idle`         | boolean      | No           | `false`     | Collapse the card when nothing is playing                                                       |

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -13,6 +13,21 @@ const ADAPTIVE_TEXT_SELECTOR_OPTIONS = Object.freeze([
 ]);
 const ADAPTIVE_TEXT_SELECTOR_VALUES = ADAPTIVE_TEXT_SELECTOR_OPTIONS.map((opt) => opt.value);
 
+const VOLUME_MODE_SELECTOR = Object.freeze({
+  select: {
+    mode: "dropdown",
+    options: [
+      { value: "slider", label: "Slider" },
+      { value: "stepper", label: "Stepper" },
+      { value: "hidden", label: "Hidden" },
+    ],
+  },
+});
+
+const VOLUME_STEP_SELECTOR = Object.freeze({
+  number: { min: 0.01, max: 1, step: 0.01, unit_of_measurement: "", mode: "box" },
+});
+
 export class YetAnotherMediaPlayerEditor extends LitElement {
   static get properties() {
     return {
@@ -2160,31 +2175,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
   }
 
   _renderVisualTab() {
-    const renderVolumeStep =
-      this._config.volume_mode === "stepper"
-        ? html`
-            <div class="form-row form-row-multi-column">
-              <div class="grow-children">
-                <ha-selector
-                  .hass=${this.hass}
-                  .selector=${{
-                    number: { min: 0.01, max: 1, step: 0.01, unit_of_measurement: "", mode: "box" },
-                  }}
-                  .value=${this._config.volume_step ?? 0.05}
-                  label="${localize("editor.fields.vol_step")}"
-                  @value-changed=${(e) => this._updateConfig("volume_step", e.detail.value)}
-                ></ha-selector>
-              </div>
-              <ha-icon
-                class="icon-button"
-                icon="mdi:restore"
-                title="${localize("common.reset_default")}"
-                @click=${() => this._updateConfig("volume_step", 0.05)}
-              ></ha-icon>
-            </div>
-          `
-        : nothing;
-
     return html`
       <div class="config-section">
         <div class="section-header">
@@ -2369,22 +2359,17 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
             @value-changed=${(e) => this._updateConfig("search_view", e.detail.value)}
           ></ha-selector>
         </div>
-        ${
-          this._config.search_view === "card" || this._config.search_view === "card_minimal"
-            ? html`
-                <div class="form-row">
-                  <ha-selector
-                    .hass=${this.hass}
-                    .selector=${{ number: { min: 1, max: 12, step: 1, mode: "box" } }}
-                    .value=${this._config.search_card_columns ?? 4}
-                    label="${localize("editor.fields.search_card_columns")}"
-                    helper="${localize("editor.subtitles.search_card_columns")}"
-                    @value-changed=${(e) => this._updateConfig("search_card_columns", e.detail.value)}
-                  ></ha-selector>
-                </div>
-              `
-            : nothing
-        }
+        <div class="form-row">
+          <ha-selector
+            .hass=${this.hass}
+            .selector=${{ number: { min: 1, max: 12, step: 1, mode: "box" } }}
+            .value=${this._config.search_card_columns ?? 4}
+            .disabled=${this._config.search_view !== "card" && this._config.search_view !== "card_minimal"}
+            label="${localize("editor.fields.search_card_columns")}"
+            helper="${localize("editor.subtitles.search_card_columns")}"
+            @value-changed=${(e) => this._updateConfig("search_card_columns", e.detail.value)}
+          ></ha-selector>
+        </div>
         <div class="form-row">
           <ha-selector
             .hass=${this.hass}
@@ -2571,22 +2556,32 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         <div class="form-row">
           <ha-selector
             .hass=${this.hass}
-            .selector=${{
-              select: {
-                mode: "dropdown",
-                options: [
-                  { value: "slider", label: "Slider" },
-                  { value: "stepper", label: "Stepper" },
-                  { value: "hidden", label: "Hidden" },
-                ],
-              },
-            }}
+            .selector=${VOLUME_MODE_SELECTOR}
             .value=${this._config.volume_mode ?? "slider"}
             label="${localize("editor.fields.volume_mode")}"
             @value-changed=${(e) => this._updateConfig("volume_mode", e.detail.value)}
           ></ha-selector>
         </div>
-        ${renderVolumeStep}
+        ${html`
+          <div class="form-row form-row-multi-column">
+            <div class="grow-children">
+              <ha-selector
+                .hass=${this.hass}
+                .selector=${VOLUME_STEP_SELECTOR}
+                .value=${this._config.volume_step ?? 0.05}
+                .disabled=${this._config.volume_mode !== "stepper"}
+                label="${localize("editor.fields.vol_step")}"
+                @value-changed=${(e) => this._updateConfig("volume_step", e.detail.value)}
+              ></ha-selector>
+            </div>
+            <ha-icon
+              class="icon-button"
+              icon="mdi:restore"
+              title="${localize("common.reset_default")}"
+              @click=${() => this._updateConfig("volume_step", 0.05)}
+            ></ha-icon>
+          </div>
+        `}
       </div>
 
       <div class="config-section">
@@ -2860,19 +2855,14 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
   }
 
   _renderEntityEditor(entity, idx = this._entityEditorIndex, isSearch = false) {
-    const stateObj = this.hass?.states?.[entity?.entity_id];
-    let showGroupVolume = this._isGroupCapable(stateObj);
-    if (!showGroupVolume && entity?.music_assistant_entity) {
-      const mae = entity.music_assistant_entity;
-      if (this._looksLikeTemplate(mae)) {
-        showGroupVolume = true;
-      } else {
-        const maStateObj = this.hass?.states?.[mae];
-        if (maStateObj && this._isGroupCapable(maStateObj)) {
-          showGroupVolume = true;
-        }
-      }
+    if (typeof entity === "string") {
+      entity = { entity_id: entity };
     }
+    const canSyncPower =
+      entity?.volume_entity &&
+      entity.volume_entity !== entity.entity_id &&
+      !(entity?.follow_active_volume ?? false);
+
 
     return html`
         ${
@@ -3136,20 +3126,15 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           <div class="config-subtitle">${localize("editor.subtitles.disable_auto_select")}</div>
         </div>
 
-        ${
-          showGroupVolume
-            ? html`
-                <div class="form-row">
-                  <ha-switch
-                    id="group-volume-toggle"
-                    .checked=${entity?.group_volume ?? true}
-                    @change=${(e) => this._updateEntityProperty("group_volume", e.target.checked)}
-                  ></ha-switch>
-                  <label for="group-volume-toggle">Group Volume</label>
-                </div>
-              `
-            : nothing
-        }
+        <div class="form-row">
+          <ha-switch
+            id="group-volume-toggle"
+            .checked=${entity?.group_volume ?? true}
+            .disabled=${!entity?.music_assistant_entity}
+            @change=${(e) => this._updateEntityProperty("group_volume", e.target.checked)}
+          ></ha-switch>
+          <label for="group-volume-toggle">Group Volume</label>
+        </div>
 
         <div class="form-row form-row-multi-column">
           <div>
@@ -3264,24 +3249,79 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
             : nothing
         }
 
-        ${
-          entity?.volume_entity &&
-          entity.volume_entity !== entity.entity_id &&
-          !(entity?.follow_active_volume ?? false)
-            ? html`
-                <div class="form-row form-row-multi-column">
-                  <div>
-                    <ha-switch
-                      id="sync-power-toggle"
-                      .checked=${entity?.sync_power ?? false}
-                      @change=${(e) => this._updateEntityProperty("sync_power", e.target.checked)}
-                    ></ha-switch>
-                    <label for="sync-power-toggle">Sync Power</label>
-                  </div>
-                </div>
-              `
-            : nothing
-        }
+        ${html`
+          <div class="form-row form-row-multi-column">
+            <div>
+              <ha-switch
+                id="sync-power-toggle"
+                .checked=${entity?.sync_power ?? false}
+                .disabled=${!canSyncPower}
+                @change=${(e) => this._updateEntityProperty("sync_power", e.target.checked)}
+              ></ha-switch>
+              <label for="sync-power-toggle">Sync Power</label>
+            </div>
+          </div>
+        `}
+        ${html`
+          <div class="form-row form-row-multi-column">
+            <div class="grow-children">
+              <ha-selector
+                .hass=${this.hass}
+                .selector=${VOLUME_MODE_SELECTOR}
+                .value=${entity?.entity_volume_mode ?? this._config.volume_mode ?? "slider"}
+                label="${localize("editor.fields.volume_mode")}"
+                @value-changed=${(e) => {
+                  const val = e.detail.value;
+                  this._updateEntityProperty("entity_volume_mode", val || undefined);
+                  if (val !== "stepper") {
+                    this._updateEntityProperty("entity_volume_step", undefined);
+                  }
+                }}
+              ></ha-selector>
+            </div>
+            ${
+              entity?.entity_volume_mode
+                ? html`
+                    <ha-icon
+                      class="icon-button"
+                      icon="mdi:restore"
+                      title="${localize("common.reset_default")}"
+                      @click=${() => {
+                              this._updateEntityProperty("entity_volume_mode", undefined);
+                              this._updateEntityProperty("entity_volume_step", undefined);
+                            }}
+                    ></ha-icon>
+                  `
+                : nothing
+            }
+          </div>
+          ${html`
+            <div class="form-row form-row-multi-column">
+              <div class="grow-children">
+                <ha-selector
+                  .hass=${this.hass}
+                  .selector=${VOLUME_STEP_SELECTOR}
+                  .value=${entity?.entity_volume_step ?? this._config.volume_step ?? 0.05}
+                  .disabled=${(entity?.entity_volume_mode ?? this._config.volume_mode ?? "slider") !== "stepper"}
+                  label="${localize("editor.fields.vol_step")}"
+                  @value-changed=${(e) => this._updateEntityProperty("entity_volume_step", e.detail.value)}
+                ></ha-selector>
+              </div>
+              ${
+                      entity?.entity_volume_step !== undefined
+                        ? html`
+                            <ha-icon
+                              class="icon-button"
+                              icon="mdi:restore"
+                              title="${localize("common.reset_default")}"
+                              @click=${() => this._updateEntityProperty("entity_volume_step", undefined)}
+                            ></ha-icon>
+                          `
+                        : nothing
+                    }
+            </div>
+          `}
+        `}
 
         ${
           entity?.follow_active_volume

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -4542,6 +4542,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       }
     }
     this._volumeStep = typeof config.volume_step === "number" ? config.volume_step : 0.05;
+    this._volumeMode = config.volume_mode ?? "slider";
     if (config.always_show_lyrics === true) {
       this._lyricsActive = true;
     }
@@ -4576,6 +4577,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         }
       }
 
+      const entity_volume_mode = typeof e === "string" ? undefined : e.entity_volume_mode;
+      const entity_volume_step = typeof e === "string" ? undefined : e.entity_volume_step;
+
       return {
         entity_id,
         name,
@@ -4587,7 +4591,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         hidden_filter_chips: typeof e === "string" ? undefined : e.hidden_filter_chips,
         disable_auto_select: this._isAutoSelectDisabled(index),
         prefer_ma_metadata: typeof e === "string" ? false : !!e.prefer_ma_metadata,
-        ...(typeof group_volume !== "undefined" ? { group_volume } : {})
+        ...(typeof group_volume !== "undefined" ? { group_volume } : {}),
+        ...(entity_volume_mode ? { entity_volume_mode } : {}),
+        ...(typeof entity_volume_step === "number" ? { entity_volume_step } : {})
       };
     });
   }
@@ -4731,6 +4737,18 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   // Legacy methods for backward compatibility
   _getVolumeEntity(idx) {
     return this._getEntityForPurpose(idx, 'volume_control');
+  }
+
+  // Returns the effective volume mode for the active entity, preferring per-entity override
+  _getEffectiveVolumeMode() {
+    const obj = this.entityObjs?.[this._selectedIndex];
+    return obj?.entity_volume_mode || this._volumeMode;
+  }
+
+  // Returns the effective volume step for the active entity, preferring per-entity override
+  _getEffectiveVolumeStep() {
+    const obj = this.entityObjs?.[this._selectedIndex];
+    return typeof obj?.entity_volume_step === "number" ? obj.entity_volume_step : this._volumeStep;
   }
 
   // Resolve a grouping member ID to its configured entity index (synchronous and cache-based)
@@ -7088,7 +7106,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       const mainEntity = this.entityObjs[idx].entity_id;
       const targets = [...new Set([mainEntity, ...state.attributes.group_members])];
       // Use configurable step size
-      const step = this._volumeStep * direction;
+      const step = this._getEffectiveVolumeStep() * direction;
       // Deduplicate resolved volume targets to prevent redundant service calls
       const seen = new Set();
       for (const t of targets) {
@@ -7113,7 +7131,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     } else {
       // Not grouped, set directly
       let current = Number(stateObj.attributes.volume_level || 0);
-      current += this._volumeStep * direction;
+      current += this._getEffectiveVolumeStep() * direction;
       current = Math.max(0, Math.min(1, current));
       // Round to 4 decimal places to prevent floating point precision errors
       current = Math.round(current * 10000) / 10000;
@@ -7811,7 +7829,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     // Volume
     const vol = Number(this.currentVolumeStateObj?.attributes.volume_level || 0);
-    const showSlider = this.config.volume_mode !== "stepper";
+    const showSlider = this._getEffectiveVolumeMode() !== "stepper";
 
     // Collapse artwork/details on idle if configured and/or always_collapsed
     // If expand on search is enabled and search is open, force expanded state
@@ -7968,7 +7986,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     const isVolumeHidden =
       shouldHideVolumeControls ||
-      this.config.volume_mode === "hidden" ||
+      this._getEffectiveVolumeMode() === "hidden" ||
       (hasCustomCardHeight && customCardHeight < 260 && collapsed && !this._showEntityOptions);
 
     const hasMoreInfoMenu = (!this._showEntityOptions && !isCompactVolume);
@@ -8303,7 +8321,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             const volumeLevel = Number(volumeState?.attributes?.volume_level ?? 0);
             const percentLabel = !isRemote ? `${Math.round((volumeLevel || 0) * 100)}%` : null;
 
-            if (this.config.volume_mode === "hidden") return nothing;
+            if (this._getEffectiveVolumeMode() === "hidden") return nothing;
 
             return html`
                     <div class="persistent-volume-stepper">
@@ -8471,7 +8489,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const artistScale = isCompact ? 0.85 : Math.min(1.5, Math.max(heightScale * 0.92, widthScale * 0.92));
 
     const isCompactVolume = hasCustomCardHeight && customCardHeight < 320 && !this._alwaysCollapsed;
-    const hideVolume = config.volume_mode === "hidden" || isCompactVolume || (hasCustomCardHeight && customCardHeight < 260 && collapsed && !this._showEntityOptions);
+    const hideVolume = this._getEffectiveVolumeMode() === "hidden" || isCompactVolume || (hasCustomCardHeight && customCardHeight < 260 && collapsed && !this._showEntityOptions);
     const artworkClearance = hideVolume ? 54 : 100;
 
     if (collapsedExtraSpace !== 0 || isCompact) {


### PR DESCRIPTION
### Description
This PR introduces per-entity overrides for `volume_mode` and `volume_step`, allowing users to customize the volume controls for specific entities independently from the global defaults.

### User-facing Changes
- **Per-Entity Volume Mode**: Added `entity_volume_mode` config option (`slider`, `stepper`, `hidden`) for individual entities. If omitted, it gracefully falls back to the global `volume_mode`.
- **Per-Entity Volume Step**: Added `entity_volume_step` config option to control the stepper size on a per-entity basis. If omitted, it falls back to the global `volume_step`.
- **Editor UI Improvements**: 
  - Improved discoverability by displaying unsupported fields (such as `volume_step` when mode is slider, or `sync_power` when volume isn't delegated) as disabled rather than completely hidden.
  - Resolved a Lit reactivity bug where updating a global setting failed to update the visual fallback value for entity-level selectors.
- **Documentation**: Updated the `README.md` to document the new per-entity volume configurations.