### PR TITLE
feat: convert service dropdown to native searchable combobox

### DIFF
--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -2863,7 +2863,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
       entity.volume_entity !== entity.entity_id &&
       !(entity?.follow_active_volume ?? false);
 
-
     return html`
         ${
           isSearch
@@ -3287,9 +3286,9 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                       icon="mdi:restore"
                       title="${localize("common.reset_default")}"
                       @click=${() => {
-                              this._updateEntityProperty("entity_volume_mode", undefined);
-                              this._updateEntityProperty("entity_volume_step", undefined);
-                            }}
+                        this._updateEntityProperty("entity_volume_mode", undefined);
+                        this._updateEntityProperty("entity_volume_step", undefined);
+                      }}
                     ></ha-icon>
                   `
                 : nothing
@@ -3308,17 +3307,17 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                 ></ha-selector>
               </div>
               ${
-                      entity?.entity_volume_step !== undefined
-                        ? html`
-                            <ha-icon
-                              class="icon-button"
-                              icon="mdi:restore"
-                              title="${localize("common.reset_default")}"
-                              @click=${() => this._updateEntityProperty("entity_volume_step", undefined)}
-                            ></ha-icon>
-                          `
-                        : nothing
-                    }
+                entity?.entity_volume_step !== undefined
+                  ? html`
+                      <ha-icon
+                        class="icon-button"
+                        icon="mdi:restore"
+                        title="${localize("common.reset_default")}"
+                        @click=${() => this._updateEntityProperty("entity_volume_step", undefined)}
+                      ></ha-icon>
+                    `
+                  : nothing
+              }
             </div>
           `}
         `}
@@ -3808,7 +3807,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                     .selector=${{
                       select: {
                         mode: "dropdown",
-                        filterable: true,
+                        custom_value: true,
                         options: this._serviceItems || [],
                       },
                     }}


### PR DESCRIPTION
## Overview
This PR improves the service selection dropdown in the Action Editor by converting the standard dropdown into a natively searchable combobox.

## Changes Made
- Added `custom_value: true` to the `ha-selector` within `src/yamp-editor.js`, which forces the Home Assistant frontend to render the element as an `ha-combo-box`.
- This enables users to natively filter and search services by typing directly into the dropdown menu.
- Formatted and linted code according to project standards.