### PR TITLE
fix: apply artwork hostname to search result thumbnails

### DIFF
--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -1,5 +1,5 @@
 import { html, nothing } from "lit";
-import { isMusicAssistantEntity } from "./yamp-utils.js";
+import { isMusicAssistantEntity, applyHostnameToUrl } from "./yamp-utils.js";
 import { localize } from "./localize/localize.js";
 
 const playOptions = [
@@ -484,6 +484,7 @@ export function renderSearchResultItem({
   isMusicAssistant = false,
   isValidArtwork = (url) => !!url,
   getClickTitle = (item) => "",
+  artworkHostname = "",
 }) {
   if (!item) {
     return html`<div class="yamp-search-result placeholder"></div>`;
@@ -519,7 +520,7 @@ export function renderSearchResultItem({
             ? html`
                 <img
                   class="yamp-search-result-thumb"
-                  src=${item.thumbnail}
+                  src=${applyHostnameToUrl(item.thumbnail, artworkHostname)}
                   alt=${item.title}
                   onerror="this.style.display='none'"
                 />

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -3842,7 +3842,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                           ${localize("editor.subtitles.entity_current_hint")}
                         </div>
                         <div class="form-row">
-
                           <div
                             class=${
                               this._yamlError && this._yamlDraft?.trim() !== ""

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -522,24 +522,33 @@ export function getArtworkUrl(
     }
   }
 
+  artworkUrl = applyHostnameToUrl(artworkUrl, hostname);
+
+  return { url: artworkUrl, sizePercentage, objectFit };
+}
+
+/**
+ * Applies a hostname prefix to a relative URL.
+ * @param {string} url - The artwork URL
+ * @param {string} hostname - The hostname to prepend
+ * @returns {string|null} The modified URL or null if invalid
+ */
+export function applyHostnameToUrl(url, hostname) {
+  let finalUrl = url;
+
   // Apply hostname prefix if configured and artwork URL is relative
-  if (
-    artworkUrl &&
-    hostname &&
-    !/^https?:\/\//i.test(artworkUrl) &&
-    !artworkUrl.startsWith("data:")
-  ) {
+  if (finalUrl && hostname && !/^https?:\/\//i.test(finalUrl) && !finalUrl.startsWith("data:")) {
     const cleanHost = hostname.endsWith("/") ? hostname.slice(0, -1) : hostname;
-    const cleanUrl = artworkUrl.startsWith("/") ? artworkUrl : `/${artworkUrl}`;
-    artworkUrl = cleanHost + cleanUrl;
+    const cleanUrl = finalUrl.startsWith("/") ? finalUrl : `/${finalUrl}`;
+    finalUrl = cleanHost + cleanUrl;
   }
 
   // Validate artwork URL to prevent proxy errors (e.g. containing undefined/null)
-  if (artworkUrl && !isValidArtworkUrl(artworkUrl)) {
-    artworkUrl = null;
+  if (finalUrl && !isValidArtworkUrl(finalUrl)) {
+    return null;
   }
 
-  return { url: artworkUrl, sizePercentage, objectFit };
+  return finalUrl;
 }
 
 /**

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -36,7 +36,8 @@ import {
   getSearchResultClickTitle,
   isMusicAssistantEntity,
   getArtworkUrl,
-  isValidArtworkUrl
+  isValidArtworkUrl,
+  applyHostnameToUrl
 } from "./yamp-utils.js";
 import { localize } from "./localize/localize.js";
 
@@ -8853,7 +8854,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           onRemove: (it) => this._removeQueueItem(it.queue_item_id),
           isMusicAssistant: this._isMusicAssistantEntity(),
           isValidArtwork: (url) => isValidArtworkUrl(url),
-          getClickTitle: (it) => this._getSearchResultClickTitle(it)
+          getClickTitle: (it) => this._getSearchResultClickTitle(it),
+          artworkHostname: this.config?.artwork_hostname || ""
         });
 
         if (this._searchAttempted && currentResults.length === 0 && !this._searchLoading) {


### PR DESCRIPTION
### Summary of Intent
Extract the absolute/relative URL prefixing logic into a reusable helper `applyHostnameToUrl` in `src/yamp-utils.js` and use it to correctly prefix relative artwork thumbnail URLs in both the main search sheet and the embedded search menu card.

### User-facing Changes
- Relative thumbnail URLs in search results now correctly respect and apply the configured `artwork_hostname` prefix (such as Home Assistant's local external URL), resolving issue where thumbnails would fail to load when casting to external devices.

### Technical Details
- Added `applyHostnameToUrl` utility in [yamp-utils.js](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/yamp-utils.js) that handles slashes, relative detection, data URIs, and validation.
- Re-used `applyHostnameToUrl` in `getArtworkUrl`.
- Updated `renderSearchResultItem` in [search-sheet.js](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/search-sheet.js) to accept `artworkHostname` and apply it to `item.thumbnail`.
- Passed `artwork_hostname` configuration to `renderSearchResultItem` in the embedded search card menu of [yet-another-media-player.js](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/yet-another-media-player.js).