### PR TITLE
feat: log card version in browser console on load

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1,3 +1,4 @@
+/* global __VERSION__ */
 import { LitElement, html, nothing } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { virtualize } from "@lit-labs/virtualizer/virtualize.js";
@@ -91,6 +92,12 @@ if (!window.customCards.some(card => card.type === "yet-another-media-player")) 
     },
   });
 }
+
+console.info(
+  `%c YET-ANOTHER-MEDIA-PLAYER %c ${__VERSION__} `,
+  "color: white; background: #ff9800; font-weight: bold; border-radius: 4px 0 0 4px; padding: 1px 5px;",
+  "color: #ff9800; background: white; font-weight: bold; border-radius: 0 4px 4px 0; padding: 1px 5px; border: 1px solid #ff9800; border-left: none;"
+);
 
 class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 


### PR DESCRIPTION
## Summary
Logs the currently installed version of the Yet Another Media Player card to the browser console when it loads. 

## Changes
- Declared the `__VERSION__` constant as global for ESLint in `src/yet-another-media-player.js`.
- Added a styled `console.info` call that prints the card's version.