### PR TITLE
Fix: Secure integration ID resolution for non-admin users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yet-another-media-player",
-  "version": "2026.8.0",
+  "version": "2026.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yet-another-media-player",
-      "version": "2026.8.0",
+      "version": "2026.9.0",
       "license": "ISC",
       "dependencies": {
         "@lit-labs/virtualizer": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yet-another-media-player",
-  "version": "2026.8.0",
+  "version": "2026.9.0",
   "description": "Home Assistant media card for controlling multiple entities with customizable actions.",
   "main": "rollup.config.js",
   "type": "module",

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -80,7 +80,7 @@ const MUSIC_ASSISTANT_CONFIG_TTL_MS = 30000;
 let cachedMusicAssistantEntryId = null;
 let cachedMusicAssistantEntryTs = 0;
 
-export async function getMusicAssistantConfigEntryId(hass) {
+export async function getMusicAssistantConfigEntryId(hass, targetEntityId = null) {
   if (!hass) return null;
   const now = Date.now();
   if (
@@ -101,11 +101,26 @@ export async function getMusicAssistantConfigEntryId(hass) {
     let resolvedId = null;
     if (hass.entities && typeof hass.entities === "object") {
       const entities = Object.values(hass.entities);
-      const maEntity = entities.find(
-        (e) => e && e.platform === "music_assistant" && e.config_entry_id
-      );
-      if (maEntity) {
-        resolvedId = maEntity.config_entry_id;
+      if (targetEntityId && hass.entities[targetEntityId] && hass.entities[targetEntityId].device_id) {
+        const deviceId = hass.entities[targetEntityId].device_id;
+        if (hass.devices && hass.devices[deviceId] && hass.devices[deviceId].config_entries && hass.devices[deviceId].config_entries.length > 0) {
+          resolvedId = hass.devices[deviceId].config_entries[0];
+        }
+      }
+      if (!resolvedId) {
+        const maEntity = entities.find(
+          (e) => e && (e.platform === "music_assistant" || e.platform === "mass")
+        );
+        if (maEntity) {
+          if (maEntity.config_entry_id) {
+            resolvedId = maEntity.config_entry_id;
+          } else if (maEntity.device_id && hass.devices && hass.devices[maEntity.device_id]) {
+            const device = hass.devices[maEntity.device_id];
+            if (device.config_entries && device.config_entries.length > 0) {
+              resolvedId = device.config_entries[0];
+            }
+          }
+        }
       }
     }
 
@@ -122,7 +137,7 @@ export async function getMusicAssistantConfigEntryId(hass) {
 let cachedMassQueueEntryId = null;
 let cachedMassQueueEntryTs = 0;
 
-export async function getMassQueueConfigEntryId(hass) {
+export async function getMassQueueConfigEntryId(hass, targetEntityId = null) {
   if (!hass) return null;
   const now = Date.now();
   if (cachedMassQueueEntryId && now - cachedMassQueueEntryTs < MUSIC_ASSISTANT_CONFIG_TTL_MS) {
@@ -140,11 +155,26 @@ export async function getMassQueueConfigEntryId(hass) {
     let resolvedId = null;
     if (hass.entities && typeof hass.entities === "object") {
       const entities = Object.values(hass.entities);
-      const mqEntity = entities.find(
-        (e) => e && e.platform === "mass_queue" && e.config_entry_id
-      );
-      if (mqEntity) {
-        resolvedId = mqEntity.config_entry_id;
+      if (targetEntityId && hass.entities[targetEntityId] && hass.entities[targetEntityId].device_id) {
+        const deviceId = hass.entities[targetEntityId].device_id;
+        if (hass.devices && hass.devices[deviceId] && hass.devices[deviceId].config_entries && hass.devices[deviceId].config_entries.length > 0) {
+          resolvedId = hass.devices[deviceId].config_entries[0];
+        }
+      }
+      if (!resolvedId) {
+        const mqEntity = entities.find(
+          (e) => e && e.platform === "mass_queue"
+        );
+        if (mqEntity) {
+          if (mqEntity.config_entry_id) {
+            resolvedId = mqEntity.config_entry_id;
+          } else if (mqEntity.device_id && hass.devices && hass.devices[mqEntity.device_id]) {
+            const device = hass.devices[mqEntity.device_id];
+            if (device.config_entries && device.config_entries.length > 0) {
+              resolvedId = device.config_entries[0];
+            }
+          }
+        }
       }
     }
 
@@ -779,7 +809,7 @@ export async function searchMedia(
   searchParams = {},
   searchResultsLimit = 20
 ) {
-  const configEntryId = await getMusicAssistantConfigEntryId(hass);
+  const configEntryId = await getMusicAssistantConfigEntryId(hass, entityId);
   // Try Music Assistant search if we have a config entry
   if (configEntryId) {
     try {
@@ -956,7 +986,7 @@ export async function getRecentlyPlayed(
   searchResultsLimit = 20,
   options = {}
 ) {
-  const configEntryId = await getMusicAssistantConfigEntryId(hass);
+  const configEntryId = await getMusicAssistantConfigEntryId(hass, entityId);
   if (!configEntryId) {
     return { results: [], usedMusicAssistant: false };
   }
@@ -1017,7 +1047,7 @@ export async function getFavorites(
   searchResultsLimit = 20,
   options = {}
 ) {
-  const configEntryId = await getMusicAssistantConfigEntryId(hass);
+  const configEntryId = await getMusicAssistantConfigEntryId(hass, entityId);
   if (!configEntryId) {
     return { results: [], usedMusicAssistant: false };
   }
@@ -1134,7 +1164,7 @@ export async function isTrackFavorited(
   }
 
   try {
-    const configEntryId = await getMusicAssistantConfigEntryId(hass);
+    const configEntryId = await getMusicAssistantConfigEntryId(hass, entityId);
     if (!configEntryId) {
       return false;
     }

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -81,6 +81,7 @@ let cachedMusicAssistantEntryId = null;
 let cachedMusicAssistantEntryTs = 0;
 
 export async function getMusicAssistantConfigEntryId(hass) {
+  if (!hass) return null;
   const now = Date.now();
   if (
     cachedMusicAssistantEntryId &&
@@ -89,15 +90,29 @@ export async function getMusicAssistantConfigEntryId(hass) {
     return cachedMusicAssistantEntryId;
   }
   try {
-    const entries = await hass.callApi("GET", "config/config_entries/entry");
-    const maEntry = entries.find(
-      (entry) => entry.domain === "music_assistant" && entry.state === "loaded"
-    );
-    cachedMusicAssistantEntryId = maEntry?.entry_id || null;
+    const services = hass.services || {};
+    const hasMaService = Boolean(services.music_assistant);
+    if (!hasMaService) {
+      cachedMusicAssistantEntryId = null;
+      cachedMusicAssistantEntryTs = now;
+      return null;
+    }
+
+    let resolvedId = null;
+    if (hass.entities && typeof hass.entities === "object") {
+      const entities = Object.values(hass.entities);
+      const maEntity = entities.find(
+        (e) => e && e.platform === "music_assistant" && e.config_entry_id
+      );
+      if (maEntity) {
+        resolvedId = maEntity.config_entry_id;
+      }
+    }
+
+    cachedMusicAssistantEntryId = resolvedId || "auto";
     cachedMusicAssistantEntryTs = now;
     return cachedMusicAssistantEntryId;
   } catch (error) {
-    console.error("yamp: Failed to resolve Music Assistant config entry", error);
     cachedMusicAssistantEntryId = null;
     cachedMusicAssistantEntryTs = now;
     return null;
@@ -108,20 +123,35 @@ let cachedMassQueueEntryId = null;
 let cachedMassQueueEntryTs = 0;
 
 export async function getMassQueueConfigEntryId(hass) {
+  if (!hass) return null;
   const now = Date.now();
   if (cachedMassQueueEntryId && now - cachedMassQueueEntryTs < MUSIC_ASSISTANT_CONFIG_TTL_MS) {
     return cachedMassQueueEntryId;
   }
   try {
-    const entries = await hass.callApi("GET", "config/config_entries/entry");
-    const mqEntry = entries.find(
-      (entry) => entry.domain === "mass_queue" && entry.state === "loaded"
-    );
-    cachedMassQueueEntryId = mqEntry?.entry_id || null;
+    const services = hass.services || {};
+    const hasMqService = Boolean(services.mass_queue);
+    if (!hasMqService) {
+      cachedMassQueueEntryId = null;
+      cachedMassQueueEntryTs = now;
+      return null;
+    }
+
+    let resolvedId = null;
+    if (hass.entities && typeof hass.entities === "object") {
+      const entities = Object.values(hass.entities);
+      const mqEntity = entities.find(
+        (e) => e && e.platform === "mass_queue" && e.config_entry_id
+      );
+      if (mqEntity) {
+        resolvedId = mqEntity.config_entry_id;
+      }
+    }
+
+    cachedMassQueueEntryId = resolvedId || "auto";
     cachedMassQueueEntryTs = now;
     return cachedMassQueueEntryId;
   } catch (error) {
-    console.error("yamp: Failed to resolve mass_queue config entry", error);
     cachedMassQueueEntryId = null;
     cachedMassQueueEntryTs = now;
     return null;
@@ -765,7 +795,7 @@ export async function searchMedia(
                 domain: "music_assistant",
                 service: "get_library",
                 service_data: {
-                  config_entry_id: configEntryId,
+                  ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
                   media_type: mt,
                   favorite: true,
                   search: query,
@@ -817,7 +847,7 @@ export async function searchMedia(
             domain: "music_assistant",
             service: "get_library",
             service_data: {
-              config_entry_id: configEntryId,
+              ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
               media_type: mediaType,
               // favorite param omitted to get ALL items
             },
@@ -853,7 +883,7 @@ export async function searchMedia(
 
       const serviceData = {
         name: query,
-        config_entry_id: configEntryId,
+        ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
       };
       const searchLimit = resolveLimitValue(searchResultsLimit, {
         cap: mediaType === "all" ? 8 : undefined,
@@ -937,7 +967,7 @@ export async function getRecentlyPlayed(
       domain: "music_assistant",
       service: "get_library",
       service_data: {
-        config_entry_id: configEntryId,
+        ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
         media_type: mt,
         order_by: "last_played_desc",
       },
@@ -999,7 +1029,7 @@ export async function getFavorites(
       domain: "music_assistant",
       service: "get_library",
       service_data: {
-        config_entry_id: configEntryId,
+        ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
         media_type: type,
         favorite: true,
       },
@@ -1129,7 +1159,7 @@ export async function isTrackFavorited(
       try {
         const serviceData = {
           name: trackName || artistName,
-          config_entry_id: configEntryId,
+          ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
           media_type: "track",
         };
         const searchLimit = resolveLimitValue(searchResultsLimit);
@@ -1184,7 +1214,7 @@ export async function isTrackFavorited(
             domain: "music_assistant",
             service: "get_library",
             service_data: {
-              config_entry_id: configEntryId,
+              ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
               media_type: "track",
               favorite: true,
               search: trackName.trim(),

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -80,6 +80,33 @@ const MUSIC_ASSISTANT_CONFIG_TTL_MS = 30000;
 let cachedMusicAssistantEntryId = null;
 let cachedMusicAssistantEntryTs = 0;
 
+function _resolveIntegrationId(hass, targetEntityId, platforms) {
+  let resolvedId = null;
+  if (hass.entities && typeof hass.entities === "object") {
+    const entities = Object.values(hass.entities);
+    if (targetEntityId && hass.entities[targetEntityId] && hass.entities[targetEntityId].device_id) {
+      const deviceId = hass.entities[targetEntityId].device_id;
+      if (hass.devices && hass.devices[deviceId] && hass.devices[deviceId].config_entries && hass.devices[deviceId].config_entries.length > 0) {
+        resolvedId = hass.devices[deviceId].config_entries[0];
+      }
+    }
+    if (!resolvedId) {
+      const entity = entities.find((e) => e && platforms.includes(e.platform));
+      if (entity) {
+        if (entity.config_entry_id) {
+          resolvedId = entity.config_entry_id;
+        } else if (entity.device_id && hass.devices && hass.devices[entity.device_id]) {
+          const device = hass.devices[entity.device_id];
+          if (device.config_entries && device.config_entries.length > 0) {
+            resolvedId = device.config_entries[0];
+          }
+        }
+      }
+    }
+  }
+  return resolvedId;
+}
+
 export async function getMusicAssistantConfigEntryId(hass, targetEntityId = null) {
   if (!hass) return null;
   const now = Date.now();
@@ -98,31 +125,7 @@ export async function getMusicAssistantConfigEntryId(hass, targetEntityId = null
       return null;
     }
 
-    let resolvedId = null;
-    if (hass.entities && typeof hass.entities === "object") {
-      const entities = Object.values(hass.entities);
-      if (targetEntityId && hass.entities[targetEntityId] && hass.entities[targetEntityId].device_id) {
-        const deviceId = hass.entities[targetEntityId].device_id;
-        if (hass.devices && hass.devices[deviceId] && hass.devices[deviceId].config_entries && hass.devices[deviceId].config_entries.length > 0) {
-          resolvedId = hass.devices[deviceId].config_entries[0];
-        }
-      }
-      if (!resolvedId) {
-        const maEntity = entities.find(
-          (e) => e && (e.platform === "music_assistant" || e.platform === "mass")
-        );
-        if (maEntity) {
-          if (maEntity.config_entry_id) {
-            resolvedId = maEntity.config_entry_id;
-          } else if (maEntity.device_id && hass.devices && hass.devices[maEntity.device_id]) {
-            const device = hass.devices[maEntity.device_id];
-            if (device.config_entries && device.config_entries.length > 0) {
-              resolvedId = device.config_entries[0];
-            }
-          }
-        }
-      }
-    }
+    const resolvedId = _resolveIntegrationId(hass, targetEntityId, ["music_assistant", "mass"]);
 
     cachedMusicAssistantEntryId = resolvedId || "auto";
     cachedMusicAssistantEntryTs = now;
@@ -152,31 +155,7 @@ export async function getMassQueueConfigEntryId(hass, targetEntityId = null) {
       return null;
     }
 
-    let resolvedId = null;
-    if (hass.entities && typeof hass.entities === "object") {
-      const entities = Object.values(hass.entities);
-      if (targetEntityId && hass.entities[targetEntityId] && hass.entities[targetEntityId].device_id) {
-        const deviceId = hass.entities[targetEntityId].device_id;
-        if (hass.devices && hass.devices[deviceId] && hass.devices[deviceId].config_entries && hass.devices[deviceId].config_entries.length > 0) {
-          resolvedId = hass.devices[deviceId].config_entries[0];
-        }
-      }
-      if (!resolvedId) {
-        const mqEntity = entities.find(
-          (e) => e && e.platform === "mass_queue"
-        );
-        if (mqEntity) {
-          if (mqEntity.config_entry_id) {
-            resolvedId = mqEntity.config_entry_id;
-          } else if (mqEntity.device_id && hass.devices && hass.devices[mqEntity.device_id]) {
-            const device = hass.devices[mqEntity.device_id];
-            if (device.config_entries && device.config_entries.length > 0) {
-              resolvedId = device.config_entries[0];
-            }
-          }
-        }
-      }
-    }
+    const resolvedId = _resolveIntegrationId(hass, targetEntityId, ["mass_queue"]);
 
     cachedMassQueueEntryId = resolvedId || "auto";
     cachedMassQueueEntryTs = now;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1805,7 +1805,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       if (this._addToPlaylistTarget && mediaType === 'playlist' && this._massQueueAvailable) {
         this._initialFavoritesLoaded = false;
         try {
-          const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, this.config.entity);
+          const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, searchEntityId);
           if (mqConfigEntryId) {
             // Fetch a generous amount so we don't truncate before filtering
             const apiData = { limit: PLAYLIST_FETCH_LIMIT };
@@ -3766,7 +3766,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       this.requestUpdate();
 
       try {
-        const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, this.config.entity);
+        const searchEntityIdTemplate = this._getSearchEntityId(this._selectedIndex);
+        const searchEntityId = await this._resolveTemplateAtActionTime(searchEntityIdTemplate, this.currentEntityId);
+        const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, searchEntityId);
         if (mqConfigEntryId) {
           const playlistId = item.item_id || item.media_content_id?.split('/').pop();
           const servicePayload = {
@@ -5934,7 +5936,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
 
     try {
-      const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, this.config.entity);
+      const searchEntityIdTemplate = this._getSearchEntityId(this._selectedIndex);
+      const searchEntityId = await this._resolveTemplateAtActionTime(searchEntityIdTemplate, this.currentEntityId);
+      const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, searchEntityId);
       if (!mqConfigEntryId) return [];
 
       const trackUri = activeState.attributes.media_content_id;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1822,7 +1822,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               domain: "mass_queue",
               service: "send_command",
               service_data: {
-                config_entry_id: mqConfigEntryId,
+                ...(mqConfigEntryId && mqConfigEntryId !== "auto" && { config_entry_id: mqConfigEntryId }),
                 command: "music/playlists/library_items",
                 data: apiData
               },
@@ -3769,14 +3769,17 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass);
         if (mqConfigEntryId) {
           const playlistId = item.item_id || item.media_content_id?.split('/').pop();
-          await this.hass.callService("mass_queue", "send_command", {
+          const servicePayload = {
             command: "music/playlists/add_playlist_tracks",
             data: {
               db_playlist_id: playlistId,
               uris: [this._addToPlaylistTarget.media_content_id]
-            },
-            config_entry_id: mqConfigEntryId
-          });
+            }
+          };
+          if (mqConfigEntryId && mqConfigEntryId !== "auto") {
+            servicePayload.config_entry_id = mqConfigEntryId;
+          }
+          await this.hass.callService("mass_queue", "send_command", servicePayload);
 
           this._showSearchSuccessToast(item.media_content_id, 'playlist');
         }
@@ -3945,7 +3948,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             domain: "mass_queue",
             service: serviceName,
             service_data: {
-              config_entry_id: configEntryId,
+              ...(configEntryId && configEntryId !== "auto" && { config_entry_id: configEntryId }),
               uri: uri
             },
             return_response: true,
@@ -5944,7 +5947,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         service_data: {
           command: "music/item_by_uri",
           data: { uri: trackUri },
-          config_entry_id: mqConfigEntryId
+          ...(mqConfigEntryId && mqConfigEntryId !== "auto" && { config_entry_id: mqConfigEntryId })
         },
         return_response: true
       };

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1805,7 +1805,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       if (this._addToPlaylistTarget && mediaType === 'playlist' && this._massQueueAvailable) {
         this._initialFavoritesLoaded = false;
         try {
-          const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass);
+          const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, this.config.entity);
           if (mqConfigEntryId) {
             // Fetch a generous amount so we don't truncate before filtering
             const apiData = { limit: PLAYLIST_FETCH_LIMIT };
@@ -3766,7 +3766,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       this.requestUpdate();
 
       try {
-        const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass);
+        const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, this.config.entity);
         if (mqConfigEntryId) {
           const playlistId = item.item_id || item.media_content_id?.split('/').pop();
           const servicePayload = {
@@ -5934,7 +5934,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
 
     try {
-      const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass);
+      const mqConfigEntryId = await getMassQueueConfigEntryId(this.hass, this.config.entity);
       if (!mqConfigEntryId) return [];
 
       const trackUri = activeState.attributes.media_content_id;
@@ -5965,7 +5965,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         service_data: {
           command: "metadata/get_track_lyrics",
           data: { track: validTrack },
-          config_entry_id: mqConfigEntryId
+          ...(mqConfigEntryId && mqConfigEntryId !== "auto" && { config_entry_id: mqConfigEntryId })
         },
         return_response: true
       };


### PR DESCRIPTION
### Intent
This PR fixes an issue where non-admin users lost card functionality (like search and queue management) due to missing `config_entry_id`s. Previously, the card attempted to resolve integration IDs using an admin-only REST API, resulting in security warnings and silent failures when omitted from payloads.

### User-facing Changes
- **Search Fixes**: Search functionality and "Up Next" queue filters have been restored for non-admin users.
- **Log Spam Reduction**: The card no longer produces `Login attempt or request with invalid authentication` warnings in the Home Assistant logs when a non-admin user loads a dashboard containing the card.
- **Improved Resolution**: The card now correctly detects configured `music_assistant_entity` mappings, routing actions directly to the appropriate backend without fallback scanning.

*(Note: Bumps version to 2026.9.0)*