### PR TITLE
feat: Add Up Next and Remote Control dedicated card modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Below you will find a list of all configuration options.
 |----------------------------|--------------|--------------|-------------|-------------------------------------------------------------------------------------------------|
 | **Entities**               |              |              |             |                                                                                                 |
 | `type`                     | string       | Yes          | —           | `custom:yet-another-media-player`                                                               |
-| `card_type`               | choice       | No           | `default`   | Card interface mode: `default` for the standard player, `search` for a dedicated search card, or `group_players` for a dedicated group management card |
+| `card_type`               | choice       | No           | `default`   | Card interface mode: `default` for standard player, `search` for search card, `group_players` for group management, `up_next` for upcoming queue, or `remote_control` for remote pad |
 | `entities`                 | string/array | Yes          | —           | List of your media player entities                                                              |
 | `volume_entity`            | string       | No           | —           | Separate entity for volume control ([Supports Templates](#template-support)) |
 | `follow_active_volume`     | boolean      | No           | `false`     | Make volume entity follow the active playback entity                                            |
@@ -585,6 +585,14 @@ Set `card_type: group_players` to lock YAMP to the group players menu.
 **Dedicated Mode Behavior:**
 - **Permanent View**: The Group Players menu is always visible as the primary view.
 - **Auto-Sync**: Quickly join or unjoin players and adjust individual volumes from a single, persistent screen.
+
+### Dedicated Up Next Mode
+
+Set `card_type: up_next` to turn YAMP into a permanent upcoming tracks queue card.
+
+### Dedicated Remote Control Mode
+
+Set `card_type: remote_control` to lock YAMP to the remote control pad.
 
 # Look and Feel
 

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -345,6 +345,8 @@ export default {
       default: "Standard",
       search: "Suche",
       group_players: "Player gruppieren",
+      up_next: "Als Nächstes",
+      remote_control: "Fernbedienung",
     },
     appearance_options: {
       automatic: "Automatisch",
@@ -392,6 +394,8 @@ export default {
       transfer_queue: "Warteschlange übertragen",
       main_menu: "Hauptmenü",
       group_players: "Player gruppieren",
+      up_next: "Als Nächstes",
+      remote_control: "Fernbedienung",
       select_entity: "Entität für mehr Info wählen",
       transfer_to: "Warteschlange übertragen zu",
       no_players: "Keine anderen Music Assistant Player verfügbar.",

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -368,6 +368,8 @@ export default {
       default: "Default",
       search: "Search",
       group_players: "Group Players",
+      up_next: "Up Next",
+      remote_control: "Remote Control",
     },
     queue_controls_style_options: {
       drag_handle: "Drag Handle",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -332,6 +332,8 @@ export default {
       default: "Por defecto",
       search: "Buscar",
       group_players: "Agrupar",
+      up_next: "A continuación",
+      remote_control: "Control remoto",
     },
     appearance_options: {
       automatic: "Automático",
@@ -379,6 +381,8 @@ export default {
       transfer_queue: "Transferir cola",
       main_menu: "Menú Principal",
       group_players: "Agrupar",
+      up_next: "A continuación",
+      remote_control: "Control remoto",
       select_entity: "Seleccionar",
       transfer_to: "Transferir a",
       no_players: "Sin reproductores MA.",

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -337,6 +337,8 @@ export default {
       default: "Par défaut",
       search: "Rechercher",
       group_players: "Grouper les lecteurs",
+      up_next: "À suivre",
+      remote_control: "Télécommande",
     },
     appearance_options: {
       automatic: "Automatique",
@@ -384,6 +386,8 @@ export default {
       transfer_queue: "Transférer la file",
       main_menu: "Menu Principal",
       group_players: "Grouper les lecteurs",
+      up_next: "À suivre",
+      remote_control: "Télécommande",
       select_entity: "Choisir pour plus d'infos",
       transfer_to: "Transférer vers",
       no_players: "Aucun lecteur MA disponible.",

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -330,6 +330,8 @@ export default {
       default: "Predefinito",
       search: "Cerca",
       group_players: "Raggruppa i lettori",
+      up_next: "In coda",
+      remote_control: "Telecomando",
     },
     appearance_options: {
       automatic: "Automatico",
@@ -377,6 +379,8 @@ export default {
       transfer_queue: "Trasferisci coda",
       main_menu: "Menu Principale",
       group_players: "Raggruppa",
+      up_next: "In coda",
+      remote_control: "Telecomando",
       select_entity: "Seleziona",
       transfer_to: "Trasferisci a",
       no_players: "Senza lettori MA.",

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -356,6 +356,8 @@ export default {
       default: "Standaard",
       search: "Zoeken",
       group_players: "Spelers groeperen",
+      up_next: "Hierna",
+      remote_control: "Afstandsbediening",
     },
     appearance_options: {
       automatic: "Automatisch",
@@ -403,6 +405,8 @@ export default {
       transfer_queue: "Wachtrij Overdragen",
       main_menu: "Hoofdmenu",
       group_players: "Spelers Groeperen",
+      up_next: "Hierna",
+      remote_control: "Afstandsbediening",
       select_entity: "Selecteer Entiteit voor Meer Info",
       transfer_to: "Wachtrij Overdragen Naar",
       no_players: "Geen andere Music Assistant spelers beschikbaar.",

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -331,6 +331,8 @@ export default {
       default: "Padrão",
       search: "Procurar",
       group_players: "Agrupar",
+      up_next: "A seguir",
+      remote_control: "Controle Remoto",
     },
     appearance_options: {
       automatic: "Automático",
@@ -378,6 +380,8 @@ export default {
       transfer_queue: "Transferir fila",
       main_menu: "Menu Principal",
       group_players: "Agrupar",
+      up_next: "A seguir",
+      remote_control: "Controle Remoto",
       select_entity: "Selecionar",
       transfer_to: "Transferir para",
       no_players: "Sem leitores MA.",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -347,6 +347,8 @@ export default {
       default: "Predvolené",
       search: "Hľadať",
       group_players: "Zoskupiť prehrávače",
+      up_next: "Nasleduje",
+      remote_control: "Diaľkové ovládanie",
     },
     appearance_options: {
       automatic: "Automaticky",
@@ -394,6 +396,8 @@ export default {
       transfer_queue: "Presunúť frontu",
       main_menu: "Hlavné menu",
       group_players: "Zoskupiť prehrávače",
+      up_next: "Nasleduje",
+      remote_control: "Diaľkové ovládanie",
       select_entity: "Vyberte entitu pre viac info",
       transfer_to: "Presunúť frontu do",
       no_players: "Žiadne iné prehrávače Music Assistant nie sú k dispozícii.",

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -329,6 +329,8 @@ export default {
       default: "Privzeto",
       search: "Iskanje",
       group_players: "Zoskupi predvajalnike",
+      up_next: "Sledi",
+      remote_control: "Daljinski upravljalnik",
     },
     appearance_options: {
       automatic: "Samodejno",
@@ -376,6 +378,8 @@ export default {
       transfer_queue: "Prenesi čakalno vrsto",
       main_menu: "Glavni meni",
       group_players: "Združi predvajalnike",
+      up_next: "Sledi",
+      remote_control: "Daljinski upravljalnik",
       select_entity: "Izberi entiteto za več informacij",
       transfer_to: "Prenesi čakalno vrsto na",
       no_players: "Ni drugih razpoložljivih predvajalnikov Music Assistant.",

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -2129,6 +2129,8 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                     value: "group_players",
                     label: localize("editor.card_type_options.group_players"),
                   },
+                  { value: "up_next", label: localize("editor.card_type_options.up_next") },
+                  { value: "remote_control", label: localize("editor.card_type_options.remote_control") },
                 ],
               },
             }}

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -2130,7 +2130,10 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                     label: localize("editor.card_type_options.group_players"),
                   },
                   { value: "up_next", label: localize("editor.card_type_options.up_next") },
-                  { value: "remote_control", label: localize("editor.card_type_options.remote_control") },
+                  {
+                    value: "remote_control",
+                    label: localize("editor.card_type_options.remote_control"),
+                  },
                 ],
               },
             }}

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -717,6 +717,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       }
       if (this._cardType === "remote_control") {
         // Dedicated remote control mode
+        this._showEntityOptions = true;
         this._showRemoteControl = true;
         this._setIdleState(false);
         this.requestUpdate();
@@ -10249,12 +10250,14 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           pointer-events: none !important;
         }
       </style>
-      <div class="entity-options-header">
-        <button class="entity-options-item close-item" @click=${() => this._closeRemoteControl()}>
-          ${localize('common.back')}
-        </button>
-      </div>
-      <div class="entity-options-divider"></div>
+      ${this._cardType !== 'remote_control' ? html`
+        <div class="entity-options-header">
+          <button class="entity-options-item close-item" @click=${() => this._closeRemoteControl()}>
+            ${localize('common.back')}
+          </button>
+        </div>
+        <div class="entity-options-divider"></div>
+      ` : nothing}
       <div class="entity-options-scroll remote-control-container">
         <!-- D-Pad Directional Pad -->
         <div class="remote-dpad-wrapper">

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -707,6 +707,21 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         this.requestUpdate();
         return;
       }
+      if (this._cardType === "up_next") {
+        // Dedicated up next mode: auto-open search filtered to up next
+        this._showEntityOptions = true;
+        this._setIdleState(false);
+        this._showSearchSheetInOptions("next-up");
+        this.requestUpdate();
+        return;
+      }
+      if (this._cardType === "remote_control") {
+        // Dedicated remote control mode
+        this._showRemoteControl = true;
+        this._setIdleState(false);
+        this.requestUpdate();
+        return;
+      }
       if (this._cardType === "group_players") {
         // Dedicated group players mode: auto-open grouping as the primary view
         this._showEntityOptions = true;
@@ -1534,7 +1549,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
   _hideSearchSheetInOptions() {
     // In dedicated search mode, never close the search
-    if (this._cardType === "search") return;
+    if (this._cardType === "search" || this._cardType === "up_next") return;
     this._showSearchInSheet = false;
     this._searchError = "";
     this._searchResults = [];
@@ -5542,7 +5557,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     if (!groupedAny && (!activeIsGroupCapable || activeIsBusy)) {
       return html`
         <div class="entity-options-header">
-          ${this._cardType !== "group_players" ? html`
+          ${this._cardType !== "group_players" && this._cardType !== "remote_control" ? html`
             <button class="entity-options-item close-item" @click=${() => { if (this._quickMenuInvoke) { this._dismissWithAnimation(); } else { this._closeGrouping(); } }}>
               ${localize('common.back')}
             </button>
@@ -5570,7 +5585,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     return html`
       <div class="entity-options-header grouping-header group-list-header">
-        ${this._cardType !== "group_players" ? html`
+        ${this._cardType !== "group_players" && this._cardType !== "remote_control" ? html`
           <button class="entity-options-item close-item" @click=${() => { if (this._quickMenuInvoke) { this._dismissWithAnimation(); } else { this._closeGrouping(); } }}>
             ${localize('common.back')}
           </button>
@@ -8430,11 +8445,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             ` : nothing}
               ${(!this._showGrouping && !this._showSourceList && !this._showSearchInSheet && !this._showResolvedEntities && !this._showTransferQueue && !this._showRemoteControl) ? this._renderMainMenu(sourceList, menuOnlyActions, showChipsInMenu) :
           this._showRemoteControl ? this._renderRemoteControlSheet() :
-          this._showGrouping ? this._renderGroupingSheet() :
-            this._showTransferQueue ? this._renderTransferQueueSheet() :
-              this._showResolvedEntities ? this._renderResolvedEntitiesSheet() :
-                this._showSearchInSheet ? this._renderSearchInOptions(showSearchHeaders, effectivePinHeaders) :
-                  this._renderSourceListSheet(sourceList, sourceLetters, availableSourceFirstLetters)}
+            this._showGrouping ? this._renderGroupingSheet() :
+              this._showTransferQueue ? this._renderTransferQueueSheet() :
+                this._showResolvedEntities ? this._renderResolvedEntitiesSheet() :
+                  this._showSearchInSheet ? this._renderSearchInOptions(showSearchHeaders, effectivePinHeaders) :
+                    this._renderSourceListSheet(sourceList, sourceLetters, availableSourceFirstLetters)}
               </div>
             </div>
             <!-- Persistent Media Controls Section - Outside Scrollable Area -->
@@ -8722,6 +8737,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     return html`
       <div class="search-sub-filters" style="display: flex; align-items: center; margin-bottom: 2px; margin-top: 4px; padding-left: 3px; width: 100%; gap: 8px;">
         <div style="display: flex; align-items: center; flex-wrap: wrap; flex: 1; min-width: 0;">
+          ${this._cardType !== 'up_next' ? html`
           <button
             class="button${this._initialFavoritesLoaded || this._favoritesFilterActive ? ' active' : ''}"
             style="
@@ -8737,8 +8753,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               opacity: ${this._searchAttempted ? '1' : '0.5'};
             "
             @click=${this._searchAttempted ? () => {
-        this._toggleFavoritesFilter();
-      } : () => { }}
+          this._toggleFavoritesFilter();
+        } : () => { }}
             title="${localize('search.favorites')}"
           >
             <ha-icon .icon=${this._initialFavoritesLoaded || this._favoritesFilterActive ? 'mdi:cards-heart' : 'mdi:cards-heart-outline'}></ha-icon>
@@ -8763,8 +8779,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               opacity: ${this._searchAttempted ? '1' : '0.5'};
             "
             @click=${this._searchAttempted ? () => {
-        this._toggleRecentlyPlayedFilter();
-      } : () => { }}
+          this._toggleRecentlyPlayedFilter();
+        } : () => { }}
             title="${localize('search.recently_played')}"
           >
             <ha-icon .icon=${this._recentlyPlayedFilterActive ? 'mdi:clock' : 'mdi:clock-outline'}></ha-icon>
@@ -8790,8 +8806,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 opacity: ${this._searchAttempted ? '1' : '0.5'};
               "
               @click=${this._searchAttempted ? () => {
-          this._toggleUpcomingFilter();
-        } : () => { }}
+            this._toggleUpcomingFilter();
+          } : () => { }}
               title="${localize('search.next_up')}"
             >
               <ha-icon .icon=${this._upcomingFilterActive ? 'mdi:playlist-music' : 'mdi:playlist-music-outline'}></ha-icon>
@@ -8817,8 +8833,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                   opacity: ${this._searchAttempted ? '1' : '0.5'};
                 "
                 @click=${this._searchAttempted ? () => {
-            this._toggleRecommendationsFilter();
-          } : () => { }}
+              this._toggleRecommendationsFilter();
+            } : () => { }}
                 title="${localize('search.recommendations')}"
               >
                 <ha-icon .icon=${this._recommendationsFilterActive ? 'mdi:creation' : 'mdi:creation-outline'}></ha-icon>
@@ -8858,8 +8874,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               <ha-icon .icon=${this._getSearchSortToggleIcon()}></ha-icon>
             </button>
           ` : nothing}
+          ` : nothing}
           ${this._shouldShowSearchResultsCount() ? html`
-            <span class="search-results-count">
+            <span class="search-results-count" style="${this._cardType === 'up_next' ? 'padding-top: 15px; display: inline-block;' : ''}">
               ${this._getSearchResultsCountLabel()}
             </span>
           ` : nothing}
@@ -8870,7 +8887,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
   _renderSearchInOptions(showSearchHeaders, pinSearchHeaders = false) {
     return html`
-      <div class="entity-options-search" style="margin-top:12px;">
+      <div class="entity-options-search" style="margin-top:${this._cardType === 'up_next' ? '0' : '12px'};">
         ${this._searchHierarchy.length > 0 ? html`
             <button class="entity-options-item close-item" @click=${() => this._goBackInSearch()}>
               ${localize('common.back')}
@@ -8887,9 +8904,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 </button>
               ` : nothing}
             </div>
-          ` : (showSearchHeaders ? html`<div class="entity-options-search-skeleton"></div>` : nothing)
+          ` : (showSearchHeaders && this._cardType !== 'up_next' ? html`<div class="entity-options-search-skeleton"></div>` : nothing)
       }
-        ${showSearchHeaders ? html`
+        ${showSearchHeaders && this._cardType !== 'up_next' ? html`
           <div class="entity-options-search-row">
             <div class="search-input-wrapper">
               <input
@@ -8926,7 +8943,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               ?disabled=${this._searchLoading}>
               <ha-icon icon="mdi:magnify"></ha-icon>
             </button>
-            ${this._cardType !== "search" ? html`
+            ${this._cardType !== "search" && this._cardType !== "up_next" ? html`
             <button
               class="entity-options-item icon-only"
               style="min-width:48px; padding: 0;"
@@ -8939,7 +8956,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           </div>
         ` : nothing}
         <!--FILTER CHIPS-->
-        ${showSearchHeaders ? (() => {
+        ${showSearchHeaders && this._cardType !== 'up_next' ? (() => {
         const classes = this._getVisibleSearchFilterClasses();
         const filter = this._searchMediaClassFilter || "all";
 
@@ -9217,7 +9234,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
   _handleIdleTimeoutCallback() {
     // In search card mode: reset drill-down instead of going idle
-    if (this._cardType === "search") {
+    if (this._cardType === "search" || this._cardType === "up_next") {
       this._idleTimeout = null;
       if (this._searchHierarchy.length > 0) {
         this._searchHierarchy = [];
@@ -9760,7 +9777,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   // Helper method for immediate dismissals with animation
   _dismissWithAnimation() {
     // In dedicated search mode, don't dismiss the search — just close other menus
-    if (this._cardType === "search") {
+    if (this._cardType === "search" || this._cardType === "up_next") {
       this._showGrouping = false;
       this._showSourceList = false;
       this._showResolvedEntities = false;
@@ -9803,7 +9820,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       return;
     }
     // In dedicated search mode, don't close the entity options / search
-    if (this._cardType === "search") {
+    if (this._cardType === "search" || this._cardType === "up_next") {
       // Just close any sub-menus that might be open
       this._showGrouping = false;
       this._showSourceList = false;
@@ -9846,7 +9863,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         this._showSourceList = false;
         this._showSearchInSheet = false;
         this._showResolvedEntities = false;
-        this._showRemoteControl = false;
+        if (this._cardType !== "remote_control") {
+          this._showRemoteControl = false;
+        }
         this._searchInputAutoFocused = false;
         this._searchHierarchy = [];
         this._searchBreadcrumb = "";
@@ -10027,6 +10046,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _closeRemoteControl() {
+    if (this._cardType === "remote_control") return;
     this._showRemoteControl = false;
     this.requestUpdate();
   }
@@ -10035,11 +10055,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const idx = this._selectedIndex;
     const obj = (this.entityObjs || [])[idx];
     let raw = obj?.hide_remote_buttons ?? this.config.hide_remote_buttons;
-    
+
     if (typeof raw === "string" && (raw.includes("{{") || raw.includes("{%") || raw.includes("[[["))) {
-       raw = resolveStringTemplateSync(this.hass, raw);
+      raw = resolveStringTemplateSync(this.hass, raw);
     }
-    
+
     if (typeof raw === "string") {
       try {
         raw = JSON.parse(raw.replace(/'/g, '"'));

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -6090,6 +6090,14 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._syncEntityTemplateSubscriptions('ma', currentContext);
     this._syncEntityTemplateSubscriptions('vol', currentContext);
     this._syncEntityTemplateSubscriptions('hidden_controls', currentContext);
+    if (changedProps.has("_selectedIndex")) {
+      this._lastMediaTitle = null;
+      this._searchResultsByType = {};
+      if (this._upcomingFilterActive) {
+        this._searchResults = [];
+        this._refreshQueue({ delayMs: 50 });
+      }
+    }
     if (changedProps.has("_selectedIndex") || changedProps.has("hass")) {
       void this._updateTransferQueueAvailability({ refresh: false });
     }
@@ -6124,9 +6132,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           const currentState = this.hass.states[metadataEntityId];
           const currentMediaTitle = currentState?.attributes?.media_title;
           if (currentMediaTitle && currentMediaTitle !== this._lastMediaTitle) {
+            const isEntitySwitch = changedProps.has("_selectedIndex");
             this._lastMediaTitle = currentMediaTitle;
             // Shift UI immediately if we're looking at the queue and haven't already
-            if (this._upcomingFilterActive) {
+            if (this._upcomingFilterActive && !isEntitySwitch) {
               // Check if we already advanced the UI manually (indicated by _latestManualShiftTime)
               const now = Date.now();
               // Increase tolerance to 4s to handle slow HA updates


### PR DESCRIPTION
## Overview
Introduces two new dedicated card interfaces to Yet Another Media Player: `up_next` and `remote_control`. These modes lock the card to their respective specialized views, providing a cleaner, more focused UI without the distraction of the standard player elements.

## User-Facing Changes
- **Up Next Mode** (`card_type: up_next`): Forces the card to display the "Up Next" queue permanently. Hides search input, category chips, and search history, but retains the results count perfectly padded at the top.
- **Remote Control Mode** (`card_type: remote_control`): Forces the card to display the remote control directional pad and media actions permanently. The "Back" button and its divider are hidden to provide a clean, standalone appearance.
- **Documentation**: Updated `README.md` to document `up_next` and `remote_control` in the configuration options and added dedicated mode sections.
- **Localization**: Added and translated localization strings for both new modes across all 9 supported languages.

## Technical Details
- Added conditional checks for `this._cardType === "up_next"` and `"remote_control"` throughout rendering and lifecycle methods (`_renderSearchInOptions`, `_handleIdleTimeoutCallback`, `_dismissWithAnimation`, `_closeEntityOptions`, `connectedCallback`).
- Resolved a race condition where switching entities while the queue was visible caused false track advancements. We now explicitly block queue shifts during entity switches (`isEntitySwitch`) to protect the background fetch timer.
- Handled state resetting (`_searchResults = []` and cache clearing) to prevent UI flickering between queues when toggling active media players.