### PR TITLE
Fix remote control overlay visibility and refactor entity resolution

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -10020,8 +10020,27 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     if (obj?.remote_entity === false) return false;
 
+    if (obj?.remote_entity) {
+      const resolved = this._resolveEntity(obj.remote_entity, null, idx, 'remote') || resolveStringTemplateSync(this.hass, obj.remote_entity, this._getTemplateContext());
+      if (resolved && typeof resolved === "string" && resolved.trim() !== "") {
+        return true;
+      }
+    }
 
-    return !!this._getRemoteControlEntity();
+    const currentId = this.currentEntityId;
+    if (!currentId) return false;
+
+    if (currentId.startsWith("remote.")) return true;
+
+    if (currentId.startsWith("media_player.")) {
+      const name = currentId.replace("media_player.", "");
+      const candidate = `remote.${name}`;
+      if (this.hass?.states?.[candidate]) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   _getRemoteControlEntity() {

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -10020,30 +10020,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     if (obj?.remote_entity === false) return false;
 
-    if (obj?.remote_entity) {
-      const resolved = this._resolveEntity(obj.remote_entity, null, idx, 'remote') || resolveStringTemplateSync(this.hass, obj.remote_entity, this._getTemplateContext());
-      if (resolved && typeof resolved === "string" && resolved.trim() !== "") {
-        return true;
-      }
-    }
-
-    const currentId = this.currentEntityId;
-    if (!currentId) return false;
-
-    if (currentId.startsWith("remote.")) return true;
-
-    if (currentId.startsWith("media_player.")) {
-      const name = currentId.replace("media_player.", "");
-      const candidate = `remote.${name}`;
-      if (this.hass?.states?.[candidate]) {
-        return true;
-      }
-    }
-
-    return false;
+    return !!this._getRemoteControlEntity(true);
   }
 
-  _getRemoteControlEntity() {
+  _getRemoteControlEntity(strict = false) {
     const idx = this._selectedIndex;
     const obj = (this.entityObjs || [])[idx];
 
@@ -10065,7 +10045,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       }
     }
 
-    return currentId;
+    return strict ? null : currentId;
   }
 
   _sendRemoteCommand(command) {


### PR DESCRIPTION
This PR introduces two related changes to the remote overlay logic:

1. **Bug Fix**: Ensures the remote control overlay button is only visible when a valid remote candidate or explicitly configured remote entity exists. Previously, the fallback logic caused it to show for all `media_player` entities indiscriminately.
2. **Refactor**: Eliminates duplicated entity resolution logic between `_hasRemoteControlSupport` and `_getRemoteControlEntity` by introducing a `strict` flag to the getter, improving code maintainability.