### PR TITLE
Fix: gracefully fallback lyrics fetching for non-admin users

### DIFF
--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -491,6 +491,8 @@ export default {
     none_found: "Kein Songtext gefunden",
     not_available: "Songtext nicht verfügbar",
     instrumental: "Instrumental-Titel",
+    admin_only_mass: "Das Abrufen von Songtexten über Music Assistant ist nur für Administratoren verfügbar. Es wird empfohlen, in der Kartenkonfiguration auf lrclib zu wechseln.",
+    fallback_to_lrclib_non_admin: "Kein Administratorbenutzer erkannt. Rückgriff auf lrclib für den Abruf von Songtexten.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Fallback zu LRCLIB)",

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -516,6 +516,8 @@ export default {
     none_found: "No lyrics found",
     not_available: "Lyrics not available",
     instrumental: "Instrumental Track",
+    admin_only_mass: "Music Assistant lyrics fetch is for admin users only. It is recommended to switch to lrclib in the card configuration.",
+    fallback_to_lrclib_non_admin: "Non-admin user detected. Falling back to lrclib for lyrics fetch.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Fallback to LRCLIB)",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -478,6 +478,8 @@ export default {
     none_found: "No se encontró letra",
     not_available: "Letra no disponible",
     instrumental: "Pista instrumental",
+    admin_only_mass: "La obtención de letras de Music Assistant es solo para usuarios administradores. Se recomienda cambiar a lrclib en la configuración de la tarjeta.",
+    fallback_to_lrclib_non_admin: "Usuario no administrador detectado. Se utilizará lrclib como respaldo para obtener las letras.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Respaldo en LRCLIB)",

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -483,6 +483,8 @@ export default {
     none_found: "Aucune parole trouvée",
     not_available: "Paroles non disponibles",
     instrumental: "Piste instrumentale",
+    admin_only_mass: "La récupération des paroles via Music Assistant est réservée aux administrateurs. Il est recommandé de passer à lrclib dans la configuration de la carte.",
+    fallback_to_lrclib_non_admin: "Utilisateur non administrateur détecté. Utilisation de lrclib pour la récupération des paroles.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Repli sur LRCLIB)",

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -475,7 +475,9 @@ export default {
     finding: "Ricerca testi...",
     none_found: "Nessun testo trovato",
     not_available: "Testi non disponibili",
-    instrumental: "Brano strumentale",
+    instrumental: "Traccia strumentale",
+    admin_only_mass: "Il recupero dei testi tramite Music Assistant è riservato agli utenti amministratori. Si consiglia di passare a lrclib nella configurazione della scheda.",
+    fallback_to_lrclib_non_admin: "Rilevato utente non amministratore. Passaggio a lrclib per il recupero dei testi.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Fallback su LRCLIB)",

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -501,7 +501,9 @@ export default {
     finding: "Songteksten zoeken...",
     none_found: "Geen songteksten gevonden",
     not_available: "Songtekst niet beschikbaar",
-    instrumental: "Instrumentaal nummer",
+    instrumental: "Instrumentale Track",
+    admin_only_mass: "Songteksten ophalen via Music Assistant is alleen voor beheerders. Het wordt aanbevolen om in de kaartconfiguratie over te schakelen naar lrclib.",
+    fallback_to_lrclib_non_admin: "Niet-beheerder gebruiker gedetecteerd. Terugvallen op lrclib voor het ophalen van songteksten.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Terugval naar LRCLIB)",

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -476,7 +476,9 @@ export default {
     finding: "Procurando letra...",
     none_found: "Nenhuma letra encontrada",
     not_available: "Letra não disponível",
-    instrumental: "Faixa instrumental",
+    instrumental: "Faixa Instrumental",
+    admin_only_mass: "A busca de letras pelo Music Assistant é apenas para usuários administradores. Recomenda-se mudar para lrclib na configuração do cartão.",
+    fallback_to_lrclib_non_admin: "Usuário não administrador detectado. Usando lrclib como alternativa para buscar as letras.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Alternativa para LRCLIB)",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -493,6 +493,8 @@ export default {
     none_found: "Žiadny text piesne sa nenašiel",
     not_available: "Text piesne nie je k dispozícii",
     instrumental: "Inštrumentálna skladba",
+    admin_only_mass: "Získavanie textov piesní cez Music Assistant je dostupné len pre administrátorov. Odporúča sa prepnúť na lrclib v konfigurácii karty.",
+    fallback_to_lrclib_non_admin: "Zistený neadministrátorský používateľ. Prechod na lrclib pre získanie textov piesní.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Záloha na LRCLIB)",

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -475,6 +475,8 @@ export default {
     none_found: "Besedila ni bilo mogoče najti",
     not_available: "Besedilo ni na voljo",
     instrumental: "Instrumentalna skladba",
+    admin_only_mass: "Pridobivanje besedil preko Music Assistant je na voljo samo administratorjem. Priporočljivo je, da v konfiguraciji kartice preklopite na lrclib.",
+    fallback_to_lrclib_non_admin: "Zaznan je ne-administratorski uporabnik. Preklop na lrclib za pridobivanje besedil.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Rezerva na LRCLIB)",

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -164,7 +164,23 @@ export async function getMassQueueConfigEntryId(hass, targetEntityId = null) {
       return null;
     }
 
-    const resolvedId = _resolveIntegrationId(hass, targetEntityId, ["mass_queue"]);
+    if (hass.user && hass.user.is_admin) {
+      try {
+        const configEntries = await hass.connection.sendMessagePromise({
+          type: "config_entries/get",
+          domain: "mass_queue",
+        });
+        if (configEntries && configEntries.length > 0) {
+          cachedMassQueueEntryId = configEntries[0].entry_id;
+          cachedMassQueueEntryTs = now;
+          return cachedMassQueueEntryId;
+        }
+      } catch (e) {
+        // Ignored: WebSocket call failed
+      }
+    }
+
+    const resolvedId = _resolveIntegrationId(hass, null, ["mass_queue"]);
 
     cachedMassQueueEntryId = resolvedId || "auto";
     cachedMassQueueEntryTs = now;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5854,7 +5854,26 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
 
     this._lyricsError = false;
-    const configSource = this.config.lyrics_source || "mass_lrclib";
+    let configSource = this.config.lyrics_source || "mass_lrclib";
+
+    const isAdmin = this.hass?.user?.is_admin === true;
+    if (!isAdmin && configSource !== "lrclib") {
+      if (configSource === "mass") {
+        console.warn(`YAMP: ${this.localize('lyrics.admin_only_mass')}`);
+
+        const event = new Event("hass-notification", { bubbles: true, composed: true });
+        event.detail = { message: this.localize('lyrics.admin_only_mass') };
+        this.dispatchEvent(event);
+
+        this._fetchingLyrics = false;
+        this._lyricsError = true;
+        this.requestUpdate();
+        return;
+      } else {
+        console.log(`YAMP: ${this.localize('lyrics.fallback_to_lrclib_non_admin')}`);
+        configSource = "lrclib";
+      }
+    }
 
     const activeState = this.metadataStateObj || this.currentActivePlaybackStateObj || this.currentPlaybackStateObj || this.currentStateObj;
     if (!activeState) {


### PR DESCRIPTION
## Summary
Resolves an issue where non-admin users experience backend authentication errors when `mass_queue` attempts to fetch lyrics via Music Assistant.

## Changes
* Restricts Music Assistant lyrics fetching (`_getMassLyrics`) to users with admin privileges.
* Bypasses `config_entries/get` WebSocket calls for non-admins to prevent console errors.
* Implements a graceful fallback to `lrclib` for non-admin users when configured with hybrid lyrics sources (e.g. `mass_lrclib` or `lrclib_mass`).
* Adds a localized toast notification specifically instructing non-admin users to configure `lrclib` if they explicitly try to use Music Assistant-only lyrics (`lyrics_source: mass`).
* Includes language translation updates for the new localization keys.