### PR TITLE
feat: adaptive lyrics scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ adaptive_text_targets:
   - details        # now playing title/artist
   - menu           # menu + search sheets
   - action_chips   # action chips on the card
+  - lyrics         # lyrics font size
 ```
 
 ### Card Mod Examples

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -492,8 +492,10 @@ export default {
     none_found: "Kein Songtext gefunden",
     not_available: "Songtext nicht verfügbar",
     instrumental: "Instrumental-Titel",
-    admin_only_mass: "Das Abrufen von Songtexten über Music Assistant ist nur für Administratoren verfügbar. Es wird empfohlen, in der Kartenkonfiguration auf lrclib zu wechseln.",
-    fallback_to_lrclib_non_admin: "Kein Administratorbenutzer erkannt. Rückgriff auf lrclib für den Abruf von Songtexten.",
+    admin_only_mass:
+      "Das Abrufen von Songtexten über Music Assistant ist nur für Administratoren verfügbar. Es wird empfohlen, in der Kartenkonfiguration auf lrclib zu wechseln.",
+    fallback_to_lrclib_non_admin:
+      "Kein Administratorbenutzer erkannt. Rückgriff auf lrclib für den Abruf von Songtexten.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Fallback zu LRCLIB)",

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -383,6 +383,7 @@ export default {
       details: "Details zur Wiedergabe",
       menu: "Menü & Suchblätter",
       action_chips: "Aktions-Chips",
+      lyrics: "Songtext",
     },
     media_controls: {
       shuffle: "Zufall",

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -517,8 +517,10 @@ export default {
     none_found: "No lyrics found",
     not_available: "Lyrics not available",
     instrumental: "Instrumental Track",
-    admin_only_mass: "Music Assistant lyrics fetch is for admin users only. It is recommended to switch to lrclib in the card configuration.",
-    fallback_to_lrclib_non_admin: "Non-admin user detected. Falling back to lrclib for lyrics fetch.",
+    admin_only_mass:
+      "Music Assistant lyrics fetch is for admin users only. It is recommended to switch to lrclib in the card configuration.",
+    fallback_to_lrclib_non_admin:
+      "Non-admin user detected. Falling back to lrclib for lyrics fetch.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Fallback to LRCLIB)",

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -410,6 +410,7 @@ export default {
       details: "Now Playing Details",
       menu: "Menu & Search Sheets",
       action_chips: "Action Chips",
+      lyrics: "Lyrics",
     },
     media_controls: {
       shuffle: "Shuffle",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -479,8 +479,10 @@ export default {
     none_found: "No se encontró letra",
     not_available: "Letra no disponible",
     instrumental: "Pista instrumental",
-    admin_only_mass: "La obtención de letras de Music Assistant es solo para usuarios administradores. Se recomienda cambiar a lrclib en la configuración de la tarjeta.",
-    fallback_to_lrclib_non_admin: "Usuario no administrador detectado. Se utilizará lrclib como respaldo para obtener las letras.",
+    admin_only_mass:
+      "La obtención de letras de Music Assistant es solo para usuarios administradores. Se recomienda cambiar a lrclib en la configuración de la tarjeta.",
+    fallback_to_lrclib_non_admin:
+      "Usuario no administrador detectado. Se utilizará lrclib como respaldo para obtener las letras.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Respaldo en LRCLIB)",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -370,6 +370,7 @@ export default {
       details: "Detalles de reproducción",
       menu: "Menú y Búsqueda",
       action_chips: "Chips de acción",
+      lyrics: "Letra",
     },
     media_controls: {
       shuffle: "Aleatorio",

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -375,6 +375,7 @@ export default {
       details: "Détails lecture",
       menu: "Menu & Recherche",
       action_chips: "Jetons d'action",
+      lyrics: "Paroles",
     },
     media_controls: {
       shuffle: "Aléatoire",

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -484,8 +484,10 @@ export default {
     none_found: "Aucune parole trouvée",
     not_available: "Paroles non disponibles",
     instrumental: "Piste instrumentale",
-    admin_only_mass: "La récupération des paroles via Music Assistant est réservée aux administrateurs. Il est recommandé de passer à lrclib dans la configuration de la carte.",
-    fallback_to_lrclib_non_admin: "Utilisateur non administrateur détecté. Utilisation de lrclib pour la récupération des paroles.",
+    admin_only_mass:
+      "La récupération des paroles via Music Assistant est réservée aux administrateurs. Il est recommandé de passer à lrclib dans la configuration de la carte.",
+    fallback_to_lrclib_non_admin:
+      "Utilisateur non administrateur détecté. Utilisation de lrclib pour la récupération des paroles.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Repli sur LRCLIB)",

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -477,8 +477,10 @@ export default {
     none_found: "Nessun testo trovato",
     not_available: "Testi non disponibili",
     instrumental: "Traccia strumentale",
-    admin_only_mass: "Il recupero dei testi tramite Music Assistant è riservato agli utenti amministratori. Si consiglia di passare a lrclib nella configurazione della scheda.",
-    fallback_to_lrclib_non_admin: "Rilevato utente non amministratore. Passaggio a lrclib per il recupero dei testi.",
+    admin_only_mass:
+      "Il recupero dei testi tramite Music Assistant è riservato agli utenti amministratori. Si consiglia di passare a lrclib nella configurazione della scheda.",
+    fallback_to_lrclib_non_admin:
+      "Rilevato utente non amministratore. Passaggio a lrclib per il recupero dei testi.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Fallback su LRCLIB)",

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -368,6 +368,7 @@ export default {
       details: "Dettagli riproduzione",
       menu: "Menu e Ricerca",
       action_chips: "Chip azione",
+      lyrics: "Testi",
     },
     media_controls: {
       shuffle: "Casuale",

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -503,8 +503,10 @@ export default {
     none_found: "Geen songteksten gevonden",
     not_available: "Songtekst niet beschikbaar",
     instrumental: "Instrumentale Track",
-    admin_only_mass: "Songteksten ophalen via Music Assistant is alleen voor beheerders. Het wordt aanbevolen om in de kaartconfiguratie over te schakelen naar lrclib.",
-    fallback_to_lrclib_non_admin: "Niet-beheerder gebruiker gedetecteerd. Terugvallen op lrclib voor het ophalen van songteksten.",
+    admin_only_mass:
+      "Songteksten ophalen via Music Assistant is alleen voor beheerders. Het wordt aanbevolen om in de kaartconfiguratie over te schakelen naar lrclib.",
+    fallback_to_lrclib_non_admin:
+      "Niet-beheerder gebruiker gedetecteerd. Terugvallen op lrclib voor het ophalen van songteksten.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Terugval naar LRCLIB)",

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -394,6 +394,7 @@ export default {
       details: "Details van 'Nu Spelen'",
       menu: "Menu & Zoekschermen",
       action_chips: "Actie Chips",
+      lyrics: "Songtekst",
     },
     media_controls: {
       shuffle: "Shuffle",

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -478,8 +478,10 @@ export default {
     none_found: "Nenhuma letra encontrada",
     not_available: "Letra não disponível",
     instrumental: "Faixa Instrumental",
-    admin_only_mass: "A busca de letras pelo Music Assistant é apenas para usuários administradores. Recomenda-se mudar para lrclib na configuração do cartão.",
-    fallback_to_lrclib_non_admin: "Usuário não administrador detectado. Usando lrclib como alternativa para buscar as letras.",
+    admin_only_mass:
+      "A busca de letras pelo Music Assistant é apenas para usuários administradores. Recomenda-se mudar para lrclib na configuração do cartão.",
+    fallback_to_lrclib_non_admin:
+      "Usuário não administrador detectado. Usando lrclib como alternativa para buscar as letras.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Alternativa para LRCLIB)",

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -369,6 +369,7 @@ export default {
       details: "Detalhes de reprodução",
       menu: "Menu e Procura",
       action_chips: "Chips de ação",
+      lyrics: "Letras",
     },
     media_controls: {
       shuffle: "Aleatório",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -494,8 +494,10 @@ export default {
     none_found: "Žiadny text piesne sa nenašiel",
     not_available: "Text piesne nie je k dispozícii",
     instrumental: "Inštrumentálna skladba",
-    admin_only_mass: "Získavanie textov piesní cez Music Assistant je dostupné len pre administrátorov. Odporúča sa prepnúť na lrclib v konfigurácii karty.",
-    fallback_to_lrclib_non_admin: "Zistený neadministrátorský používateľ. Prechod na lrclib pre získanie textov piesní.",
+    admin_only_mass:
+      "Získavanie textov piesní cez Music Assistant je dostupné len pre administrátorov. Odporúča sa prepnúť na lrclib v konfigurácii karty.",
+    fallback_to_lrclib_non_admin:
+      "Zistený neadministrátorský používateľ. Prechod na lrclib pre získanie textov piesní.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Záloha na LRCLIB)",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -385,6 +385,7 @@ export default {
       details: "Detaily prehrávania",
       menu: "Menu a vyhľadávanie",
       action_chips: "Akčné čipy",
+      lyrics: "Texty piesní",
     },
     media_controls: {
       shuffle: "Náhodne",

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -367,6 +367,7 @@ export default {
       details: "Podrobnosti predvajanja",
       menu: "Meni in iskanje",
       action_chips: "Čipi dejanj",
+      lyrics: "Besedilo",
     },
     media_controls: {
       shuffle: "Naključno",

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -476,8 +476,10 @@ export default {
     none_found: "Besedila ni bilo mogoče najti",
     not_available: "Besedilo ni na voljo",
     instrumental: "Instrumentalna skladba",
-    admin_only_mass: "Pridobivanje besedil preko Music Assistant je na voljo samo administratorjem. Priporočljivo je, da v konfiguraciji kartice preklopite na lrclib.",
-    fallback_to_lrclib_non_admin: "Zaznan je ne-administratorski uporabnik. Preklop na lrclib za pridobivanje besedil.",
+    admin_only_mass:
+      "Pridobivanje besedil preko Music Assistant je na voljo samo administratorjem. Priporočljivo je, da v konfiguraciji kartice preklopite na lrclib.",
+    fallback_to_lrclib_non_admin:
+      "Zaznan je ne-administratorski uporabnik. Preklop na lrclib za pridobivanje besedil.",
   },
   lyrics_sources: {
     mass_lrclib: "Music Assistant (Rezerva na LRCLIB)",

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4258,7 +4258,10 @@ export const lyricsStyles = css`
     opacity: 1;
     filter: blur(0);
     color: var(--yamp-lyrics-active-color, inherit);
-    font-size: calc(var(--yamp-lyrics-active-font-size, var(--yamp-lyrics-font-size, 1.6rem)) * var(--yamp-text-scale-lyrics, 1));
+    font-size: calc(
+      var(--yamp-lyrics-active-font-size, var(--yamp-lyrics-font-size, 1.6rem)) *
+        var(--yamp-text-scale-lyrics, 1)
+    );
     text-shadow: var(--yamp-overlay-text-shadow, none);
   }
 
@@ -4270,7 +4273,9 @@ export const lyricsStyles = css`
   }
 
   .lyric-line.unsynced {
-    font-size: calc(var(--yamp-lyrics-unsynced-font-size, 1.1rem) * var(--yamp-text-scale-lyrics, 1));
+    font-size: calc(
+      var(--yamp-lyrics-unsynced-font-size, 1.1rem) * var(--yamp-text-scale-lyrics, 1)
+    );
     opacity: 0.8;
     margin-bottom: 12px;
     filter: none;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4239,7 +4239,7 @@ export const lyricsStyles = css`
   }
 
   .lyric-line {
-    font-size: var(--yamp-lyrics-font-size, 1.6rem);
+    font-size: calc(var(--yamp-lyrics-font-size, 1.6rem) * var(--yamp-text-scale-lyrics, 1));
     font-weight: 700;
     line-height: 1.3;
     margin-bottom: 24px;
@@ -4258,7 +4258,7 @@ export const lyricsStyles = css`
     opacity: 1;
     filter: blur(0);
     color: var(--yamp-lyrics-active-color, inherit);
-    font-size: var(--yamp-lyrics-active-font-size, var(--yamp-lyrics-font-size, 1.6rem));
+    font-size: calc(var(--yamp-lyrics-active-font-size, var(--yamp-lyrics-font-size, 1.6rem)) * var(--yamp-text-scale-lyrics, 1));
     text-shadow: var(--yamp-overlay-text-shadow, none);
   }
 
@@ -4270,7 +4270,7 @@ export const lyricsStyles = css`
   }
 
   .lyric-line.unsynced {
-    font-size: var(--yamp-lyrics-unsynced-font-size, 1.1rem);
+    font-size: calc(var(--yamp-lyrics-unsynced-font-size, 1.1rem) * var(--yamp-text-scale-lyrics, 1));
     opacity: 0.8;
     margin-bottom: 12px;
     filter: none;

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -10,6 +10,7 @@ const ADAPTIVE_TEXT_SELECTOR_OPTIONS = Object.freeze([
   { value: "details", label: localize("card.sections.details") },
   { value: "menu", label: localize("card.sections.menu") },
   { value: "action_chips", label: localize("card.sections.action_chips") },
+  { value: "lyrics", label: localize("card.sections.lyrics") },
 ]);
 const ADAPTIVE_TEXT_SELECTOR_VALUES = ADAPTIVE_TEXT_SELECTOR_OPTIONS.map((opt) => opt.value);
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -60,7 +60,7 @@ const PLAYLIST_FETCH_LIMIT = 500;
 const SUCCESS_MESSAGE_TIMEOUT_MS = 3000;
 const MAX_LYRICS_CACHE_SIZE = 30;
 
-const ADAPTIVE_TEXT_TARGETS = Object.freeze(["details", "menu", "action_chips"]);
+const ADAPTIVE_TEXT_TARGETS = Object.freeze(["details", "menu", "action_chips", "lyrics"]);
 const DEFAULT_ADAPTIVE_TEXT_TARGETS = Object.freeze([...ADAPTIVE_TEXT_TARGETS]);
 const ADAPTIVE_TEXT_VAR_MAP = Object.freeze({
   details: "--yamp-text-scale-details",
@@ -4092,6 +4092,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this.style.setProperty("--yamp-details-line-height", detailLineHeight.toFixed(2));
     const detailMaxLines = detailActive ? (safeDetailsScale >= 2 ? 3 : safeDetailsScale >= 1.3 ? 2 : 1) : 3;
     this.style.setProperty("--yamp-details-max-lines", detailMaxLines.toString());
+    const lyricsActive = !!targetSet?.has("lyrics");
+    this.style.setProperty("--yamp-text-scale-lyrics", lyricsActive ? safeDetailsScale.toFixed(2) : "1");
   }
 
   _updateAdaptiveTextObserverState() {


### PR DESCRIPTION
This PR introduces a new `lyrics` target for the `adaptive_text_targets` configuration. 

By adding `lyrics` to the adaptive text targets, the lyrics overlay font sizes will intelligently scale proportionally with the card height, utilizing the same scaling logic used for the *Details* (Title/Artist) section. This allows lyrics to scale beautifully up to 3.25x their base size on dashboards with large vertical layouts.

### User-Facing Changes
- Adds a new `lyrics` option to `adaptive_text_targets`.
- Lyrics font size automatically scales dynamically based on the card layout when configured.
- Translations added for the new Lyrics section across all supported languages.
- Documentation updated in README.md.