### PR TITLE
style: standardize volume row button sizes and custom action icon scaling

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1393,8 +1393,6 @@ export const yampCardStyles = css`
   }
 
   .volume-icon-btn ha-icon {
-    font-size: 1.2em;
-    --mdc-icon-size: 20px;
     color: #fff;
   }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1392,8 +1392,26 @@ export const yampCardStyles = css`
     }
   }
 
-  .volume-icon-btn ha-icon {
+  .volume-icon-btn ha-icon,
+  .custom-bottom-action ha-icon,
+  .vol-stepper .button ha-icon {
+    font-size: 22px;
+    --mdc-icon-size: 22px;
+    --ha-icon-size: 22px;
+    width: 22px;
+    height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: #fff;
+  }
+
+  .custom-bottom-action ha-icon {
+    font-size: 19px;
+    --mdc-icon-size: 19px;
+    --ha-icon-size: 19px;
+    width: 19px;
+    height: 19px;
   }
 
   .volume-icon-btn.favorite-volume-btn {
@@ -1573,7 +1591,6 @@ export const yampCardStyles = css`
   .vol-stepper .button {
     min-width: 36px;
     min-height: 36px;
-    font-size: 1.5em;
     padding: 6px 0;
     border-radius: 50%;
     display: flex;


### PR DESCRIPTION
## Summary of Changes
- Standardized icon sizing across all volume row controls (mute, search, power, favorite, and stepper buttons) to 22px (`--mdc-icon-size`, `--ha-icon-size`, `width`, `height`, `font-size`).
- Added an optical size calibration (19px) for custom configured bottom action icons (`.custom-bottom-action ha-icon`) so dense solid MDI glyphs visually balance with outline icons like search and heart.