### PR TITLE
fix: improve queue sync and mass_queue fetch limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ You can configure the maximum number of search results to display using the `sea
 - **Default**: 20 results
 - **Range**: 0-1000 results
 - **Music Assistant default**: Set to `0` to defer to Music Assistant’s built-in limits (not unlimited)
-- **Note**: Higher limits may increase load time and memory usage when rendering large result sets.
+- **Note**: Higher limits may increase load time and memory usage when rendering large result sets. Additionally, streaming providers may enforce rate limits on concurrent API requests if this is set too high.
 - **Scope**: Global setting that applies to all entities and search types
 
 #### Example Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yet-another-media-player",
-  "version": "2026.9.0-beta.3",
+  "version": "2026.9.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yet-another-media-player",
-      "version": "2026.9.0-beta.3",
+      "version": "2026.9.0-beta.4",
       "license": "ISC",
       "dependencies": {
         "@lit-labs/virtualizer": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yet-another-media-player",
-  "version": "2026.9.0-beta.3",
+  "version": "2026.9.0-beta.4",
   "description": "Home Assistant media card for controlling multiple entities with customizable actions.",
   "main": "rollup.config.js",
   "type": "module",

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -2958,11 +2958,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         },
         return_response: true,
       };
-      const configLimit = this._getSearchResultsLimit();
-      const normalizedLimit = Number.isFinite(limit) ? limit : configLimit;
-      const limitAfter = Math.max(normalizedLimit || 0, configLimit || 0);
+      const limitAfter = Number.isFinite(limit) ? Math.max(0, limit) : this._getSearchResultsLimit();
       if (limitAfter > 0) {
-        message.service_data.limit_after = limitAfter;  // Use config search_results_limit
+        message.service_data.limit_after = limitAfter;  // Keep for backwards compatibility
+        message.service_data.limit = limitAfter + 1;    // Account for 1 active item + limitAfter upcoming items
       }
 
       const response = await hass.connection.sendMessagePromise(message);
@@ -2990,8 +2989,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       const upcomingItems = currentTrackIndex >= 0 ? queueItems.slice(currentTrackIndex + 1) : queueItems;
 
       // Process the upcoming items like the companion card does
-      const itemsToRender = normalizedLimit > 0
-        ? upcomingItems.slice(0, normalizedLimit)
+      const itemsToRender = limitAfter > 0
+        ? upcomingItems.slice(0, limitAfter)
         : upcomingItems;
       const results = itemsToRender.map((item, index) => ({
         media_content_id: item.media_content_id || `queue_${index}`,


### PR DESCRIPTION
### Description
This PR addresses rate-limiting issues when syncing the queue with Music Assistant via the `mass_queue` service. 

### Changes
* **Search Results Limit Fix**: Modified `_getUpcomingQueueWithMassQueue` to correctly honor explicitly passed `search_results_limit` config instead of forcibly overriding them with the larger global mass_queue defaults. 
* **Buffer Queue Items**: Account for the active playing item by adding `+1` to the limit explicitly in the service data call.
* **Documentation**: Updated the `README.md` to note that even with large explicit bounds in `search_results_limit`, the user's backend streaming providers may still rate limit large parallel API requests.
* **Version Bump**: Updated project to beta 4.

 Addresses issue #434 