### PR TITLE
fix: resolve 'Up Next' queue scrolling issue when invoked via action button

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3551,6 +3551,11 @@ export const yampCardStyles = css`
     ${HIDE_SCROLLBAR}
   }
 
+  .entity-options-sheet:not([data-pin-search-headers="true"]) .search-sheet-results,
+  .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search-results {
+    overflow-y: visible;
+  }
+
   .queue-sortable-container {
     padding-bottom: 24px;
   }

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3161,10 +3161,6 @@ export const yampCardStyles = css`
   }
 
   .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search {
-    display: flex;
-    flex-direction: column;
-    height: auto;
-    min-height: 100%;
   }
 
   .entity-options-sheet .entity-options-search-row,
@@ -3246,6 +3242,8 @@ export const yampCardStyles = css`
   /* The scrollable area for all menus */
   .entity-options-scroll {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     overflow-y: auto;
     min-height: 0;
     ${HIDE_SCROLLBAR}
@@ -3274,7 +3272,6 @@ export const yampCardStyles = css`
     padding-bottom: 12px;
   }
 
-  /* Clean up legacy margin override rules since we now use padding on parent */
   :host([data-hide-persistent-controls="true"])
     .entity-options-sheet[data-pin-search-headers="true"]
     .entity-options-scroll,

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2315,6 +2315,7 @@ export const yampCardStyles = css`
     border-radius: var(--border-radius);
     box-shadow: none;
     width: 100%;
+    height: 100%;
     padding: 18px 8px 0px 8px;
     padding-top: clamp(12px, 6vh, 18px);
     display: flex;
@@ -3159,10 +3160,11 @@ export const yampCardStyles = css`
     flex-shrink: 0;
   }
 
-  .entity-options-sheet .entity-options-search {
+  .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    height: auto;
+    min-height: 100%;
   }
 
   .entity-options-sheet .entity-options-search-row,
@@ -3529,16 +3531,15 @@ export const yampCardStyles = css`
     ${HIDE_SCROLLBAR}
   }
 
-  .entity-options-sheet:not([data-pin-search-headers="true"]) .search-sheet-results,
-  .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search-results {
-    overflow-y: visible;
+  .queue-sortable-container {
+    padding-bottom: 24px;
   }
 
   .queue-sortable-container.is-card-layout {
     display: grid;
     grid-template-columns: repeat(var(--search-card-columns, 4), 1fr);
     gap: 12px;
-    padding: 12px;
+    padding: 12px 12px 24px 12px;
   }
 
   .queue-sortable-container.is-card-layout .queue-drag-wrapper {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3164,6 +3164,7 @@ export const yampCardStyles = css`
   .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search {
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
   }
 
   .entity-options-sheet .entity-options-search-row,
@@ -3571,6 +3572,8 @@ export const yampCardStyles = css`
   .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search-results {
     overflow-y: visible;
     padding-bottom: 80px;
+    flex: none;
+    min-height: auto;
   }
 
   .queue-sortable-container {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2322,6 +2322,7 @@ export const yampCardStyles = css`
     flex-direction: column;
     align-items: stretch;
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
     overscroll-behavior: contain;
@@ -2687,7 +2688,7 @@ export const yampCardStyles = css`
 
   /* Search functionality */
   .entity-options-search {
-    padding: 0px 10px 80px 10px;
+    padding: 0px 10px 0px 10px;
   }
 
   .entity-options-search-row {
@@ -3161,6 +3162,8 @@ export const yampCardStyles = css`
   }
 
   .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search {
+    display: flex;
+    flex-direction: column;
   }
 
   .entity-options-sheet .entity-options-search-row,
@@ -3303,6 +3306,22 @@ export const yampCardStyles = css`
     .entity-options-sheet[data-pin-search-headers="true"]
     .entity-options-search-results {
     margin-bottom: 0px;
+    padding-bottom: 0px;
+  }
+
+  /* Remove bottom clearance for unpinned mode when persistent controls are hidden */
+  :host([data-hide-persistent-controls="true"])
+    .entity-options-sheet:not([data-pin-search-headers="true"])
+    .search-sheet-results,
+  :host([data-hide-persistent-controls="true"])
+    .entity-options-sheet:not([data-pin-search-headers="true"])
+    .entity-options-search-results,
+  :host([data-hide-menu-player="true"])
+    .entity-options-sheet:not([data-pin-search-headers="true"])
+    .search-sheet-results,
+  :host([data-hide-menu-player="true"])
+    .entity-options-sheet:not([data-pin-search-headers="true"])
+    .entity-options-search-results {
     padding-bottom: 0px;
   }
   /* Hide scrollbars for Webkit browsers (Chrome, Safari, etc.) */
@@ -3551,6 +3570,7 @@ export const yampCardStyles = css`
   .entity-options-sheet:not([data-pin-search-headers="true"]) .search-sheet-results,
   .entity-options-sheet:not([data-pin-search-headers="true"]) .entity-options-search-results {
     overflow-y: visible;
+    padding-bottom: 80px;
   }
 
   .queue-sortable-container {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1433,14 +1433,6 @@ export const yampCardStyles = css`
     color: #fff;
   }
 
-  .custom-bottom-action ha-icon {
-    font-size: 19px;
-    --mdc-icon-size: 19px;
-    --ha-icon-size: 19px;
-    width: 19px;
-    height: 19px;
-  }
-
   .volume-icon-btn.favorite-volume-btn {
     width: 36px;
     height: 36px;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3253,9 +3253,16 @@ export const yampCardStyles = css`
 
   /* Reserved space for persistent media controls when pinning is active */
   .entity-options-sheet[data-pin-search-headers="true"] .entity-options-scroll,
-  .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search,
-  .entity-options-sheet[data-pin-search-headers="true"] .group-list-scroll {
-    margin-bottom: 80px;
+  .entity-options-sheet[data-pin-search-headers="true"] .group-list-scroll,
+  .entity-options-sheet[data-pin-search-headers="true"] .search-sheet-results,
+  .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search-results {
+    margin-bottom: 0px;
+    padding-bottom: 80px;
+    background: none;
+  }
+
+  .entity-options-sheet[data-pin-search-headers="true"] .entity-options-search {
+    margin-bottom: 0px;
     padding-bottom: 0px;
     background: none;
   }
@@ -3277,6 +3284,12 @@ export const yampCardStyles = css`
   :host([data-hide-persistent-controls="true"])
     .entity-options-sheet[data-pin-search-headers="true"]
     .group-list-scroll,
+  :host([data-hide-persistent-controls="true"])
+    .entity-options-sheet[data-pin-search-headers="true"]
+    .search-sheet-results,
+  :host([data-hide-persistent-controls="true"])
+    .entity-options-sheet[data-pin-search-headers="true"]
+    .entity-options-search-results,
   :host([data-hide-menu-player="true"])
     .entity-options-sheet[data-pin-search-headers="true"]
     .entity-options-scroll,
@@ -3285,8 +3298,15 @@ export const yampCardStyles = css`
     .entity-options-search,
   :host([data-hide-menu-player="true"])
     .entity-options-sheet[data-pin-search-headers="true"]
-    .group-list-scroll {
+    .group-list-scroll,
+  :host([data-hide-menu-player="true"])
+    .entity-options-sheet[data-pin-search-headers="true"]
+    .search-sheet-results,
+  :host([data-hide-menu-player="true"])
+    .entity-options-sheet[data-pin-search-headers="true"]
+    .entity-options-search-results {
     margin-bottom: 0px;
+    padding-bottom: 0px;
   }
   /* Hide scrollbars for Webkit browsers (Chrome, Safari, etc.) */
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -2027,6 +2027,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
     this._searchLoading = false;
     this.requestUpdate();
+    setTimeout(() => this._notifyResize(), 0);
   }
 
   async _playCurrentCollection() {
@@ -8537,7 +8538,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
       ${this._showEntityOptions ? html`
       <div class="entity-options-overlay entity-options-overlay-opening" @click=${(e) => this._closeEntityOptions(e)}>
-        <div class="entity-options-container entity-options-container-opening">
+        <div class="entity-options-container entity-options-container-opening" style="${this._showSearchInSheet ? 'height:100%;' : ''}">
           <div class="entity-options-sheet${(showChipsInMenu || reserveChipSpaceInMenu) ? ' chips-mode' : ''} entity-options-sheet-opening" 
                @click=${e => e.stopPropagation()}
                data-pin-search-headers="${effectivePinHeaders}">

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -2943,21 +2943,24 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   // Get queue using mass_queue integration
   async _getUpcomingQueueWithMassQueue(hass, entityId, limit = 250) {
     try {
+      // Get the currently playing track's media_content_id
+      const playerState = hass.states[entityId];
+      const currentTrackId = playerState?.attributes?.media_content_id;
+
       // Use limit_before and limit_after like the companion card does
-      // limit_before: 0 means get items starting at the current track
       const message = {
         type: "call_service",
         domain: "mass_queue",
         service: "get_queue_items",
         service_data: {
           entity: entityId,
-          limit_before: 0  // Start list at the currently active item
+          limit_before: 5  // Request some history to avoid falsy zero bugs in backend
         },
         return_response: true,
       };
       const limitAfter = Number.isFinite(limit) && limit > 0 ? limit : 250;
       message.service_data.limit_after = limitAfter;  // Keep for backwards compatibility
-      message.service_data.limit = limitAfter + 1;    // Account for 1 active item + limitAfter upcoming items
+      message.service_data.limit = limitAfter + 6;    // Account for 5 history + 1 active + limitAfter upcoming items
 
       const response = await hass.connection.sendMessagePromise(message);
       const queueItems = response?.response?.[entityId];
@@ -2966,9 +2969,15 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         throw new Error('Invalid response from mass_queue');
       }
 
-      // With limit_before: 0, Music Assistant returns queue items starting at the currently active track (index 0).
-      // Find active item index, defaulting to index 0. Avoid matching duplicate media_content_id entries further down.
+      // Find active item index
       let currentTrackIndex = queueItems.findIndex(item => item.active === true || item.state === 'playing');
+      
+      // Fallback to Home Assistant's media_content_id (slower sync but reliable)
+      if (currentTrackIndex === -1 && currentTrackId) {
+        currentTrackIndex = queueItems.findIndex(item => item.media_content_id === currentTrackId || item.queue_item_id === currentTrackId);
+      }
+
+      // Default to 0 if all else fails
       if (currentTrackIndex === -1 && queueItems.length > 0) {
         currentTrackIndex = 0;
       }
@@ -2977,7 +2986,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       const upcomingItems = currentTrackIndex >= 0 ? queueItems.slice(currentTrackIndex + 1) : queueItems;
 
       // Process the upcoming items like the companion card does
-      const itemsToRender = upcomingItems;
+      const itemsToRender = limitAfter > 0 ? upcomingItems.slice(0, limitAfter) : upcomingItems;
       const results = itemsToRender.map((item, index) => ({
         media_content_id: item.media_content_id || item.queue_item_id || `queue_${index}`,
         media_content_type: 'track',

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9099,11 +9099,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         const currentResults = this._getDisplaySearchResults();
         const isCard = this.config.search_view === 'card' || this.config.search_view === 'card_minimal';
         const isMinimal = this.config.search_view === 'card_minimal';
-        const totalRows = Math.max(15, this._searchTotalRows || currentResults.length);
-        const paddedResults = [
-          ...currentResults,
-          ...Array.from({ length: Math.max(0, totalRows - currentResults.length) }, () => null)
-        ];
         const renderItemFn = (item) => renderSearchResultItem({
           item,
           isCard,
@@ -9170,12 +9165,12 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
         return isCard
           ? virtualize({
-            items: paddedResults,
+            items: currentResults,
             renderItem: renderItemFn,
             layout: this._cachedSearchGridLayout,
             scroller: pinSearchHeaders
           })
-          : virtualize({ items: paddedResults, renderItem: renderItemFn, scroller: pinSearchHeaders });
+          : virtualize({ items: currentResults, renderItem: renderItemFn, scroller: pinSearchHeaders });
       })()}
         </div>
       </div>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1914,7 +1914,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       } else if (isUpcoming) {
         // Load upcoming queue items
         this._initialFavoritesLoaded = false;
-        searchResponse = await this._getUpcomingQueue(this.hass, searchEntityId, this._getSearchResultsLimit());
+        const upcomingLimit = Math.min(250, this._getSearchResultsLimit());
+        searchResponse = await this._getUpcomingQueue(this.hass, searchEntityId, upcomingLimit);
         this._lastSearchUsedServerFavorites = false;
       } else if (isRecommendations) {
         this._initialFavoritesLoaded = false;
@@ -2738,7 +2739,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   // Get next track from Music Assistant (limited by Music Assistant API)
-  async _getUpcomingQueue(hass, entityId, limit = 20) {
+  async _getUpcomingQueue(hass, entityId, limit = 250) {
     try {
       // Always check for mass_queue integration (don't cache this)
       const hasMassQueue = await this._isMassQueueIntegrationAvailable(hass);
@@ -2940,15 +2941,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   // Get queue using mass_queue integration
-  async _getUpcomingQueueWithMassQueue(hass, entityId, limit = 20) {
+  async _getUpcomingQueueWithMassQueue(hass, entityId, limit = 250) {
     try {
-      // Get the currently playing track's media_content_id
-      const playerState = hass.states[entityId];
-      const currentTrackId = playerState?.attributes?.media_content_id;
-
       // Use limit_before and limit_after like the companion card does
-      // limit_before: 5 means get 5 items before the current track (to include current track)
-      // limit_after: limit means get up to 'limit' upcoming items
+      // limit_before: 0 means get items starting at the current track
       const message = {
         type: "call_service",
         domain: "mass_queue",
@@ -2959,11 +2955,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         },
         return_response: true,
       };
-      const limitAfter = Number.isFinite(limit) ? Math.max(0, limit) : this._getSearchResultsLimit();
-      if (limitAfter > 0) {
-        message.service_data.limit_after = limitAfter;  // Keep for backwards compatibility
-        message.service_data.limit = limitAfter + 1;    // Account for 1 active item + limitAfter upcoming items
-      }
+      const limitAfter = Number.isFinite(limit) && limit > 0 ? limit : 250;
+      message.service_data.limit_after = limitAfter;  // Keep for backwards compatibility
+      message.service_data.limit = limitAfter + 1;    // Account for 1 active item + limitAfter upcoming items
 
       const response = await hass.connection.sendMessagePromise(message);
       const queueItems = response?.response?.[entityId];
@@ -2972,16 +2966,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         throw new Error('Invalid response from mass_queue');
       }
 
-      // Find the currently playing track's index in the queue
-      // 1. Prioritize Music Assistant's native "active" or playback state (near-instant)
+      // With limit_before: 0, Music Assistant returns queue items starting at the currently active track (index 0).
+      // Find active item index, defaulting to index 0. Avoid matching duplicate media_content_id entries further down.
       let currentTrackIndex = queueItems.findIndex(item => item.active === true || item.state === 'playing');
-
-      // 2. Fallback to Home Assistant's media_content_id (slower sync)
-      if (currentTrackIndex === -1 && currentTrackId) {
-        currentTrackIndex = queueItems.findIndex(item => item.media_content_id === currentTrackId);
-      }
-
-      // 3. Last resort: since we requested limit_before: 0, the first item SHOULD be the one
       if (currentTrackIndex === -1 && queueItems.length > 0) {
         currentTrackIndex = 0;
       }
@@ -2990,22 +2977,19 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       const upcomingItems = currentTrackIndex >= 0 ? queueItems.slice(currentTrackIndex + 1) : queueItems;
 
       // Process the upcoming items like the companion card does
-      const itemsToRender = limitAfter > 0
-        ? upcomingItems.slice(0, limitAfter)
-        : upcomingItems;
+      const itemsToRender = upcomingItems;
       const results = itemsToRender.map((item, index) => ({
-        media_content_id: item.media_content_id || `queue_${index}`,
+        media_content_id: item.media_content_id || item.queue_item_id || `queue_${index}`,
         media_content_type: 'track',
         media_class: 'track',
-        title: item.media_title || 'Unknown Track',
-        artist: item.media_artist || 'Unknown Artist',
-        album: item.media_album_name || 'Unknown Album',
-        thumbnail: item.media_image || null,
-        duration: null,
+        title: item.media_title || item.name || 'Unknown Track',
+        artist: item.media_artist || item.artist || 'Unknown Artist',
+        album: item.media_album_name || item.album || 'Unknown Album',
+        thumbnail: item.media_image || item.image || null,
+        duration: item.duration || null,
         position: index + 1,
         queue_item_id: item.queue_item_id || null
       }));
-
 
       return {
         results,

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -3632,6 +3632,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       this._queueRefreshTimer = setTimeout(() => {
         this._queueRefreshTimer = null;
 
+        if (!this._upcomingFilterActive) return;
+
         // Capture a new token to protect against stale results from entry/heartbeat fetches
         const searchToken = Date.now();
         this._latestSearchToken = searchToken;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -2641,10 +2641,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
   // Toggle upcoming queue filter
   async _toggleUpcomingFilter(forceState = null) {
-    const targetState = typeof forceState === "boolean"
-      ? forceState
-      : !this._upcomingFilterActive;
-    this._upcomingFilterActive = targetState;
+    if (!this.hass) return;
+
+    if (forceState !== null) {
+      this._upcomingFilterActive = forceState;
+    } else {
+      this._upcomingFilterActive = !this._upcomingFilterActive;
+    }
 
     // Make mutually exclusive with other filters
     if (this._upcomingFilterActive) {
@@ -9094,85 +9097,94 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         
         ${this._renderSearchSubFilters(showSearchHeaders)}
  
-        <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'}" 
-             style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? `--search-card-columns: ${this.config.search_card_columns || 4};` : ''}">
-          ${(() => {
-        const currentResults = this._getDisplaySearchResults();
-        const isCard = this.config.search_view === 'card' || this.config.search_view === 'card_minimal';
-        const isMinimal = this.config.search_view === 'card_minimal';
-        const renderItemFn = (item) => renderSearchResultItem({
-          item,
-          isCard,
-          isMinimal,
-          activeSearchRowMenuId: this._activeSearchRowMenuId,
-          loadingSearchRowMenuId: this._loadingSearchRowMenuId,
-          errorSearchRowMenuId: this._errorSearchRowMenuId,
-          successSearchRowMenuId: this._successSearchRowMenuId,
-          successSearchRowType: this._successSearchRowType,
-          isSelectionFlow: this._isSelectionFlow,
-          massQueueAvailable: this._massQueueAvailable,
-          upcomingFilterActive: !!this._upcomingFilterActive,
-          recentlyPlayedFilterActive: !!this._recentlyPlayedFilterActive,
-          recommendationsFilterActive: !!this._recommendationsFilterActive,
-          searchMediaClassFilter: this._searchMediaClassFilter,
-          queueControlsStyle: this.config.queue_controls_style || "drag_handle",
-          onPlay: (it, e) => this._playMediaFromSearch(it, e),
-          onResultClick: (it, e) => this._handleSearchResultClick(it, e),
-          onResultTouch: (it, e) => this._handleSearchResultTouch(it, e),
-          onOptionsToggle: (it) => { this._activeSearchRowMenuId = it?.media_content_id || null; this.requestUpdate(); },
-          onPlayOption: (it, mode) => this._performSearchOptionAction(it, mode),
-          onMoveUp: (it) => this._moveQueueItemUp(it.queue_item_id),
-          onMoveDown: (it) => this._moveQueueItemDown(it.queue_item_id),
-          onMoveNext: (it) => this._moveQueueItemNext(it.queue_item_id),
-          onRemove: (it) => this._removeQueueItem(it.queue_item_id),
-          isMusicAssistant: this._isMusicAssistantEntity(),
-          isValidArtwork: (url) => isValidArtworkUrl(url),
-          getClickTitle: (it) => this._getSearchResultClickTitle(it),
-          artworkHostname: this.config?.artwork_hostname || ""
-        });
+        ${(() => {
+          const isQueueDragAndDrop = this._upcomingFilterActive && this._massQueueAvailable;
+          const currentResults = this._getDisplaySearchResults();
+          const isCard = this.config.search_view === 'card' || this.config.search_view === 'card_minimal';
+          const isMinimal = this.config.search_view === 'card_minimal';
+          const renderItemFn = (item) => renderSearchResultItem({
+            item,
+            isCard,
+            isMinimal,
+            activeSearchRowMenuId: this._activeSearchRowMenuId,
+            loadingSearchRowMenuId: this._loadingSearchRowMenuId,
+            errorSearchRowMenuId: this._errorSearchRowMenuId,
+            successSearchRowMenuId: this._successSearchRowMenuId,
+            successSearchRowType: this._successSearchRowType,
+            isSelectionFlow: this._isSelectionFlow,
+            massQueueAvailable: this._massQueueAvailable,
+            upcomingFilterActive: !!this._upcomingFilterActive,
+            recentlyPlayedFilterActive: !!this._recentlyPlayedFilterActive,
+            recommendationsFilterActive: !!this._recommendationsFilterActive,
+            searchMediaClassFilter: this._searchMediaClassFilter,
+            queueControlsStyle: this.config.queue_controls_style || "drag_handle",
+            onPlay: (it, e) => this._playMediaFromSearch(it, e),
+            onResultClick: (it, e) => this._handleSearchResultClick(it, e),
+            onResultTouch: (it, e) => this._handleSearchResultTouch(it, e),
+            onOptionsToggle: (it) => { this._activeSearchRowMenuId = it?.media_content_id || null; this.requestUpdate(); },
+            onPlayOption: (it, mode) => this._performSearchOptionAction(it, mode),
+            onMoveUp: (it) => this._moveQueueItemUp(it.queue_item_id),
+            onMoveDown: (it) => this._moveQueueItemDown(it.queue_item_id),
+            onMoveNext: (it) => this._moveQueueItemNext(it.queue_item_id),
+            onRemove: (it) => this._removeQueueItem(it.queue_item_id),
+            isMusicAssistant: this._isMusicAssistantEntity(),
+            isValidArtwork: (url) => isValidArtworkUrl(url),
+            getClickTitle: (it) => this._getSearchResultClickTitle(it),
+            artworkHostname: this.config?.artwork_hostname || ""
+          });
 
-        if (this._searchAttempted && currentResults.length === 0 && !this._searchLoading) {
-          return html`<div class="entity-options-search-empty">${localize('common.no_results')}</div>`;
-        }
+          if (this._searchAttempted && currentResults.length === 0 && !this._searchLoading) {
+            return html`
+              <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'}">
+                <div class="entity-options-search-empty">${localize('common.no_results')}</div>
+              </div>
+            `;
+          }
 
-        const isQueueDragAndDrop = this._upcomingFilterActive && this._massQueueAvailable;
-
-        if (isQueueDragAndDrop) {
-          return html`
-            <div class="queue-sortable-container ${isCard ? 'is-card-layout' : ''}"
-              @pointerdown=${(e) => this._onQueueDragStart(e)}
-            >
-              ${currentResults.map((item, idx) => html`
-                <div class="queue-drag-wrapper" data-queue-idx="${idx}">
-                  ${renderItemFn(item)}
+          if (isQueueDragAndDrop) {
+            return html`
+              <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} queue-results-wrapper"
+                   style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? `--search-card-columns: ${this.config.search_card_columns || 4};` : ''}">
+                <div class="queue-sortable-container ${isCard ? 'is-card-layout' : ''}"
+                  @pointerdown=${(e) => this._onQueueDragStart(e)}
+                >
+                  ${currentResults.map((item, idx) => html`
+                    <div class="queue-drag-wrapper" data-queue-idx="${idx}">
+                      ${renderItemFn(item)}
+                    </div>
+                  `)}
                 </div>
-              `)}
+              </div>
+            `;
+          }
+
+          if (!this._cachedSearchGridLayout || this._cachedSearchGridLayoutColumns !== (this.config.search_card_columns || 4) || this._cachedSearchGridLayoutIsMinimal !== isMinimal) {
+            this._cachedSearchGridLayoutColumns = this.config.search_card_columns || 4;
+            this._cachedSearchGridLayoutIsMinimal = isMinimal;
+            this._cachedSearchGridLayout = yampGrid({
+              columns: this._cachedSearchGridLayoutColumns,
+              gap: '12px',
+              padding: '12px',
+              itemSize: isMinimal
+                ? { width: 150, height: 150 }
+                : { width: 150, height: 244 }
+            });
+          }
+
+          return html`
+            <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} virtualized-results-wrapper"
+                 style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? `--search-card-columns: ${this.config.search_card_columns || 4};` : ''}">
+              ${isCard
+                ? virtualize({
+                  items: currentResults,
+                  renderItem: renderItemFn,
+                  layout: this._cachedSearchGridLayout,
+                  scroller: pinSearchHeaders
+                })
+                : virtualize({ items: currentResults, renderItem: renderItemFn, scroller: pinSearchHeaders })}
             </div>
           `;
-        }
-
-        if (!this._cachedSearchGridLayout || this._cachedSearchGridLayoutColumns !== (this.config.search_card_columns || 4) || this._cachedSearchGridLayoutIsMinimal !== isMinimal) {
-          this._cachedSearchGridLayoutColumns = this.config.search_card_columns || 4;
-          this._cachedSearchGridLayoutIsMinimal = isMinimal;
-          this._cachedSearchGridLayout = yampGrid({
-            columns: this._cachedSearchGridLayoutColumns,
-            gap: '12px',
-            padding: '12px',
-            itemSize: isMinimal
-              ? { width: 150, height: 150 }
-              : { width: 150, height: 244 }
-          });
-        }
-
-        return isCard
-          ? virtualize({
-            items: currentResults,
-            renderItem: renderItemFn,
-            layout: this._cachedSearchGridLayout,
-            scroller: pinSearchHeaders
-          })
-          : virtualize({ items: currentResults, renderItem: renderItemFn, scroller: pinSearchHeaders });
-      })()}
+        })()}
         </div>
       </div>
     `;


### PR DESCRIPTION
## Summary
Fixes an issue where navigating directly to the "Up Next" queue view using an action button caused the list container to collapse to a minimal intrinsic height, preventing the user from scrolling through the queue items.

## Changes Made
- **DOM Node Isolation**: Separated the rendering paths for `@lit-labs/virtualizer` search results and drag-and-drop queue lists into distinct outer HTML elements (`queue-results-wrapper` vs `virtualized-results-wrapper`). This forces Lit to destroy and recreate the DOM node when switching modes, eliminating persistent inline layout containment (`contain: strict`) injected by the virtualizer on empty initial renders.
- **Flexbox Layout Adjustments**: Added `flex: none`, `min-height: auto`, and `flex-shrink: 0` constraints to unpinned search containers in `src/yamp-card-styles.js` to ensure natural content height calculation within scrollable sheets.
- **Queue Reliability & Spacing**: Refined queue item limit parameters, active track detection fallbacks, and control spacing.

## User-Facing Impact
- Invoking "Up Next" directly via configured card action buttons now properly expands the container and allows full vertical scrolling through all queue items without clipping.