### PR TITLE
Feature: Mini Grid Menus & Search Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Below you will find a list of all configuration options.
 | **Behavior**               |              |              |             |                                                                                                 |
 | `collapse_on_idle`         | boolean      | No           | `false`     | Collapse the card when nothing is playing                                                       |
 | `always_collapsed`         | boolean      | No           | `false`     | Keep the card collapsed even when something is playing ([Supports Templates](#template-support))                                          |
+| `disable_mini_menu`        | boolean      | No           | `false`     | Fallback to standard full-width menus instead of the mini grid menu layout when in `always_collapsed` mode |
 | `expand_on_search`         | boolean      | No           | `false`     | Temporarily expand the card when search is open (only available when `always_collapsed` is `true`) |
 | `hide_menu_player`         | boolean      | No           | `false`     | Hide the persistent media controls in the bottom sheet menu to reclaim space (only available when `always_collapsed` is `false`) |
 | `hide_reorder_progress`   | boolean      | No           | `false`     | Hide the floating queue re-ordering progress indicator at the bottom (also hidden if `hide_menu_player` is `true`) |

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -167,6 +167,7 @@ export default {
         "Nicht verfügbar mit alternativem Fortschrittsbalken oder im Modus 'Immer eingeklappt'.",
       not_available_collapsed: "Nicht verfügbar, wenn 'Immer eingeklappt' aktiviert ist.",
       only_available_collapsed: "Nur verfügbar, wenn 'Immer eingeklappt' aktiviert ist.",
+      only_available_mini_menu: "Nur verfügbar, wenn 'Immer eingeklappt' aktiviert und 'Bei Suche erweitern' deaktiviert ist",
       only_available_modern: "Nur verfügbar im modernen Layout.",
       image_url_helper: "Direkte Bild-URL oder lokalen Dateipfad eingeben.",
       selected_entity_helper:

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -134,6 +134,8 @@ export default {
         "Textgruppen wählen, die mit dem Platz skalieren (leer lassen zum Deaktivieren).",
       collapse_expand:
         "Immer eingeklappt aktiviert den Mini-Player-Modus. Bei Suche ausklappen aktiviert ihn temporär.",
+      disable_mini_menu:
+        "Kehrt zu Standardlisten zurück, anstatt die neuen Mini-Grid-Menüs im Modus 'Immer eingeklappt' zu verwenden.",
       idle_screen: "Wählen Sie, welcher Bildschirm im Leerlauf automatisch angezeigt wird.",
       hide_controls:
         "Wählen Sie Steuerelemente aus, die für diese Entität ausgeblendet werden sollen.",
@@ -229,6 +231,7 @@ export default {
       hide_menu_player_toggle: "Menü-Player ausblenden",
       hide_reorder_progress_toggle: "Neusortierungs-Fortschritt ausblenden",
       always_collapsed: "Immer eingeklappt",
+      disable_mini_menu: "Mini-Grid-Menüs deaktivieren",
       expand_on_search: "Bei Suche ausklappen",
       script_var: "Skript-Variable (yamp_entity)",
       use_ma_template: "Template für Music Assistant Entität verwenden",

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -197,6 +197,7 @@ export default {
         "Not available with Alternate Progress Bar or Always Collapsed mode",
       not_available_collapsed: "Not available when Always Collapsed is enabled",
       only_available_collapsed: "Only available when Always Collapsed is enabled",
+      only_available_mini_menu: "Only available when Always Collapsed is true and Expand on Search is false",
       only_available_modern: "Only available with Modern layout",
       image_url_helper: "Enter a direct URL to an image or a local file path",
       selected_entity_helper:

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -161,6 +161,8 @@ export default {
         "Choose which text groups should scale with available space (leave empty to disable adaptive text).",
       collapse_expand:
         "Always Collapsed creates mini player mode. Expand on Search temporarily expands when searching.",
+      disable_mini_menu:
+        "Revert to standard lists instead of using the new mini grid menus in Always Collapsed mode.",
       idle_screen: "Choose which screen to display automatically when the card becomes idle.",
       hide_controls: "Select buttons to hide from the persistent playback controls row.",
       hide_remote_buttons: "Select buttons to hide from the Remote Control overlay.",
@@ -257,6 +259,7 @@ export default {
       hide_menu_player_toggle: "Hide Menu Player",
       hide_reorder_progress_toggle: "Hide Re-ordering Progress",
       always_collapsed: "Always Collapsed",
+      disable_mini_menu: "Disable mini grid menus",
       expand_on_search: "Expand on Search",
       script_var: "Script Variable (yamp_entity)",
       use_ma_template: "Use template for Music Assistant Entity",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -123,6 +123,8 @@ export default {
       adaptive_text: "Elegir qué textos se adaptan al espacio.",
       collapse_expand:
         "Siempre contraído activa el modo mini. Expandir al buscar expande temporalmente.",
+      disable_mini_menu:
+        "Vuelve a las listas estándar en lugar de usar los nuevos menús de cuadrícula mini en el modo 'Siempre contraído'.",
       idle_screen: "Elegir pantalla a mostrar en reposo.",
       hide_controls: "Seleccionar controles a ocultar.",
       hide_remote_buttons:
@@ -216,6 +218,7 @@ export default {
       hide_menu_player_toggle: "Ocultar reproductor del menú",
       hide_reorder_progress_toggle: "Ocultar progreso de reordenación",
       always_collapsed: "Siempre contraído",
+      disable_mini_menu: "Desactivar menús de cuadrícula mini",
       expand_on_search: "Expandir al buscar",
       script_var: "Variable script (yamp_entity)",
       use_ma_template: "Usar plantilla MA",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -154,6 +154,7 @@ export default {
       not_available_alt_collapsed: "No disponible en modo contraído.",
       not_available_collapsed: "No disponible si está contraído.",
       only_available_collapsed: "Solo disponible si está contraído.",
+      only_available_mini_menu: "Solo disponible cuando 'Siempre contraído' es verdadero y 'Expandir en la búsqueda' es falso",
       only_available_modern: "Solo disponible con diseño Moderno.",
       image_url_helper: "Ingrese una URL directa a una imagen o una ruta de archivo local",
       selected_entity_helper:

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -129,6 +129,8 @@ export default {
       adaptive_text: "Choisir quels textes doivent s'adapter à l'espace.",
       collapse_expand:
         "Toujours réduit crée un mini lecteur. Agrandir à la Recherche agrandit temporairement.",
+      disable_mini_menu:
+        "Revenir aux listes standards au lieu d'utiliser les nouveaux mini menus en grille en mode 'Toujours réduit'.",
       idle_screen: "Choisir l'écran à afficher automatiquement en veille.",
       hide_controls: "Sélectionner les commandes à masquer pour cette entité.",
       hide_remote_buttons: "Sélectionnez les boutons à masquer de la télécommande.",
@@ -221,6 +223,7 @@ export default {
       hide_menu_player_toggle: "Masquer le lecteur menu",
       hide_reorder_progress_toggle: "Masquer la progression de réorganisation",
       always_collapsed: "Toujours réduit",
+      disable_mini_menu: "Désactiver les mini menus en grille",
       expand_on_search: "Agrandir en recherche",
       script_var: "Variable script (yamp_entity)",
       use_ma_template: "Utiliser modèle MA",

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -159,6 +159,7 @@ export default {
       not_available_alt_collapsed: "Non disponible en mode 'Toujours réduit'.",
       not_available_collapsed: "Non disponible si 'Toujours réduit' est activé.",
       only_available_collapsed: "Uniquement disponible si 'Toujours réduit' est activé.",
+      only_available_mini_menu: "Uniquement disponible lorsque 'Toujours réduit' est vrai et 'Développer lors de la recherche' est faux",
       only_available_modern: "Uniquement disponible avec la mise en page Moderne.",
       image_url_helper: "Entrez une URL directe vers une image ou un chemin de fichier local",
       selected_entity_helper:

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -122,6 +122,8 @@ export default {
       adaptive_text: "Scegli quali testi si adattano allo spazio.",
       collapse_expand:
         "Sempre contratto attiva il modo mini. Espandi alla ricerca espande temporaneamente.",
+      disable_mini_menu:
+        "Torna agli elenchi standard invece di usare i nuovi mini menu a griglia in modalità 'Sempre compresso'.",
       idle_screen: "Scegli schermata da mostrare in riposo.",
       hide_controls: "Seleziona controlli da nascondere.",
       hide_remote_buttons: "Seleziona i pulsanti da nascondere dal telecomando.",
@@ -214,6 +216,7 @@ export default {
       hide_menu_player_toggle: "Nascondi lettore menu",
       hide_reorder_progress_toggle: "Nascondi avanzamento riordinamento",
       always_collapsed: "Sempre contratto",
+      disable_mini_menu: "Disabilita i mini menu a griglia",
       expand_on_search: "Espandi alla ricerca",
       script_var: "Variabile script (yamp_entity)",
       use_ma_template: "Usa modello MA",

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -152,6 +152,7 @@ export default {
       not_available_alt_collapsed: "Non disponibile in modo contratto.",
       not_available_collapsed: "Non disponibile se contratto.",
       only_available_collapsed: "Solo disponibile se contratto.",
+      only_available_mini_menu: "Disponibile solo quando 'Sempre compresso' è vero ed 'Espandi in ricerca' è falso",
       only_available_modern: "Solo disponibile con layout Moderno.",
       image_url_helper: "Inserisci un URL diretto a un'immagine o un percorso file locale",
       selected_entity_helper:

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -178,6 +178,7 @@ export default {
         "Niet beschikbaar met Alternatieve Voortgangsbalk of Altijd Ingeklapte modus",
       not_available_collapsed: "Niet beschikbaar wanneer Altijd Ingeklapt is ingeschakeld",
       only_available_collapsed: "Alleen beschikbaar wanneer Altijd Ingeklapt is ingeschakeld",
+      only_available_mini_menu: "Alleen beschikbaar wanneer 'Altijd ingeklapt' waar is en 'Uitvouwen bij zoeken' onwaar is",
       only_available_modern: "Alleen beschikbaar met de Moderne lay-out",
       image_url_helper: "Voer een directe URL naar een afbeelding of een lokaal bestandspad in",
       selected_entity_helper:

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -138,6 +138,8 @@ export default {
         "Kies welke tekstgroepen moeten schalen met de beschikbare ruimte (laat leeg om adaptieve tekst uit te schakelen).",
       collapse_expand:
         "Altijd Ingeklapt creëert de mini-spelermodus. Uitklappen bij Zoeken klapt tijdelijk uit tijdens het zoeken.",
+      disable_mini_menu:
+        "Keer terug naar standaardlijsten in plaats van de nieuwe mini rastermenu's te gebruiken in de modus 'Altijd ingeklapt'.",
       idle_screen:
         "Kies welk scherm automatisch wordt weergegeven wanneer de kaart inactief wordt.",
       hide_controls:
@@ -240,6 +242,7 @@ export default {
       hide_menu_player_toggle: "Menu-speler Verbergen",
       hide_reorder_progress_toggle: "Wachtrijsortering Verbergen",
       always_collapsed: "Altijd Ingeklapt",
+      disable_mini_menu: "Mini rastermenu's uitschakelen",
       expand_on_search: "Uitklappen bij Zoeken",
       script_var: "Script Variabele (yamp_entity)",
       use_ma_template: "Sjabloon gebruiken voor Music Assistant Entiteit",

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -152,6 +152,7 @@ export default {
       not_available_alt_collapsed: "Não disponível em modo contraído.",
       not_available_collapsed: "Não disponível se contraído.",
       only_available_collapsed: "Apenas disponível se contraído.",
+      only_available_mini_menu: "Disponível apenas quando 'Sempre recolhido' é verdadeiro e 'Expandir na pesquisa' é falso",
       only_available_modern: "Apenas disponível com layout Moderno.",
       image_url_helper: "Insira um URL direto para uma imagem ou um caminho de arquivo local",
       selected_entity_helper:

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -122,6 +122,8 @@ export default {
       adaptive_text: "Escolher que textos se adaptam ao espaço.",
       collapse_expand:
         "Sempre contraído ativa modo mini. Expandir ao procurar expande temporariamente.",
+      disable_mini_menu:
+        "Reverter para listas padrão em vez de usar os novos mini menus em grade no modo 'Sempre recolhido'.",
       idle_screen: "Escolher ecrã a mostrar em repouso.",
       hide_controls: "Selecionar controlos a ocultar.",
       hide_remote_buttons: "Selecione botões para ocultar do controle remoto.",
@@ -215,6 +217,7 @@ export default {
       hide_menu_player_toggle: "Ocultar leitor do menu",
       hide_reorder_progress_toggle: "Ocultar progresso de reordenação",
       always_collapsed: "Sempre contraído",
+      disable_mini_menu: "Desativar mini menus em grade",
       expand_on_search: "Expandir ao procurar",
       script_var: "Variável script (yamp_entity)",
       use_ma_template: "Usar modelo MA",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -133,6 +133,8 @@ export default {
         "Vyberte skupiny textu, ktoré sa majú škálovať podľa priestoru (nechajte prázdne pre vypnutie).",
       collapse_expand:
         '"Vždy zbalené" vytvorí režim mini prehrávača. "Rozbaliť pri hľadaní" kartu dočasne rozbalí pri vyhľadávaní.',
+      disable_mini_menu:
+        "Návrat k štandardným zoznamom namiesto použitia nových mini mriežkových ponúk v režime 'Vždy zbalené'.",
       idle_screen: "Vyberte obrazovku, ktorá sa má automaticky zobraziť v režime nečinnosti.",
       hide_controls:
         "Vyberte ovládacie prvky, ktoré chcete pre túto entitu skryť (štandardne sú zobrazené všetky).",
@@ -231,6 +233,7 @@ export default {
       hide_menu_player_toggle: "Skryť prehrávač v menu",
       hide_reorder_progress_toggle: "Skryť priebeh preusporiadania",
       always_collapsed: "Vždy zbalené",
+      disable_mini_menu: "Vypnúť mini mriežkové ponuky",
       expand_on_search: "Rozbaliť pri hľadaní",
       script_var: "Premenná skriptu (yamp_entity)",
       use_ma_template: "Použiť šablónu pre Music Assistant",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -170,6 +170,7 @@ export default {
         "Nedostupné s alternatívnym indikátorom priebehu alebo v režime Vždy zbalené.",
       not_available_collapsed: "Nedostupné, keď je zapnuté Vždy zbalené.",
       only_available_collapsed: "Dostupné len pri zapnutom režime Vždy zbalené.",
+      only_available_mini_menu: "K dispozícii iba vtedy, keď je 'Vždy zbalené' zapnuté a 'Rozbaliť pri vyhľadávaní' vypnuté",
       only_available_modern: "Dostupné len s moderným rozložením.",
       image_url_helper: "Zadajte priamu URL na obrázok alebo lokálnu cestu k súboru",
       selected_entity_helper:

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -154,6 +154,7 @@ export default {
       not_available_alt_collapsed: "Ni na voljo z alternativno vrstico napredka.",
       not_available_collapsed: "Ni na voljo v vedno skrčenem načinu.",
       only_available_collapsed: "Na voljo le v vedno skrčenem načinu.",
+      only_available_mini_menu: "Na voljo samo, ko je 'Vedno strnjeno' omogočeno in 'Razširi ob iskanju' onemogočeno",
       only_available_modern: "Na voljo le v moderni postavitvi.",
       image_url_helper: "Vnesite neposredni URL do slike ali lokalno pot do datoteke",
       selected_entity_helper:

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -125,6 +125,8 @@ export default {
         "Skrij lebdeči indikator napredka prerazvrščanja čakalne vrste na dnu.",
       adaptive_text: "Izberi skupine besedila za prilagajanje velikosti.",
       collapse_expand: "Vedno skrčeno ustvari mini predvajalnik.",
+      disable_mini_menu:
+        "Vrnite se na standardne sezname namesto uporabe novih mini mrežnih menijev v načinu 'Vedno strnjeno'.",
       idle_screen: "Izberi zaslon, prikazan v mirovanju.",
       hide_controls: "Izberi kontrolnike za skrivanje.",
       hide_remote_buttons: "Izberite gumbe za skrivanje na daljinskem upravljalniku.",
@@ -213,6 +215,7 @@ export default {
       hide_menu_player_toggle: "Skrij predvajalnik v meniju",
       hide_reorder_progress_toggle: "Skrij napredek prerazvrščanja",
       always_collapsed: "Vedno skrčeno",
+      disable_mini_menu: "Onemogoči mini mrežne menije",
       expand_on_search: "Razširi ob iskanju",
       script_var: "Skriptna spremenljivka",
       use_ma_template: "Uporabi predlogo za entiteto Music Assistant",

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -524,6 +524,7 @@ export function renderSearchResultItem({
   item,
   isCard,
   isMinimal,
+  isGridMode,
   activeSearchRowMenuId,
   loadingSearchRowMenuId,
   errorSearchRowMenuId,
@@ -562,6 +563,40 @@ export function renderSearchResultItem({
     item.media_content_id != null &&
     activeSearchRowMenuId === item.media_content_id;
   const hideActions = isSelectionFlow;
+
+  if (isGridMode) {
+    return html`
+      <button
+        class="entity-options-item menu-action-item search-result-grid-mode nodrag no-drag ignore-drag ${item._justMoved ? "just-moved" : ""} ${isActive ? "menu-active" : ""}"
+        @click=${(e) => {
+          if (!isSelectionFlow) {
+            onPlay?.(item, e);
+          } else {
+            onResultClick?.(item, e);
+          }
+        }}
+        title=${getClickTitle(item) || item.title}
+      >
+        ${
+          item.thumbnail && isValidArtwork(item.thumbnail)
+            ? html`
+                <img
+                  class="yamp-search-result-thumb"
+                  src=${applyHostnameToUrl(item.thumbnail, artworkHostname)}
+                  alt=${item.title}
+                  onerror="this.style.display='none'"
+                />
+              `
+            : html`
+                <div class="yamp-search-result-thumb-placeholder">
+                  <ha-icon icon="mdi:music"></ha-icon>
+                </div>
+              `
+        }
+        <span class="menu-action-label">${item.title}</span>
+      </button>
+    `;
+  }
 
   return html`
     <div

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -567,7 +567,11 @@ export function renderSearchResultItem({
   if (isGridMode) {
     return html`
       <button
-        class="entity-options-item menu-action-item search-result-grid-mode nodrag no-drag ignore-drag ${item._justMoved ? "just-moved" : ""} ${isActive ? "menu-active" : ""}"
+        class="entity-options-item menu-action-item search-result-grid-mode ${
+          upcomingFilterActive && massQueueAvailable && queueControlsStyle === "drag_handle"
+            ? "queue-drag-handle"
+            : "nodrag no-drag ignore-drag"
+        } ${item._justMoved ? "just-moved" : ""} ${isActive ? "menu-active" : ""}"
         @click=${(e) => {
           if (!isSelectionFlow) {
             onPlay?.(item, e);

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2475,8 +2475,8 @@ export const yampCardStyles = css`
   .grid-menu .entity-options-item {
     margin: 0;
     border-radius: 0;
-    border-bottom: 1px solid var(--yamp-overlay-divider);
-    border-right: 1px solid var(--yamp-overlay-divider);
+    border-bottom: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
+    border-right: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -2489,7 +2489,7 @@ export const yampCardStyles = css`
 
   /* Remove right border on every 5th item */
   .grid-menu .entity-options-item:nth-child(5n) {
-    border-right: none;
+    border-right: none !important;
   }
   
   /* Give the icon a specific size in grid mode */
@@ -2518,8 +2518,8 @@ export const yampCardStyles = css`
     justify-content: center;
     margin: 0;
     border-radius: 0;
-    border-bottom: 1px solid var(--yamp-overlay-divider);
-    border-right: 1px solid var(--yamp-overlay-divider);
+    border-bottom: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
+    border-right: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
     padding: 12px 4px;
     gap: 6px;
     font-size: 0.7em;
@@ -2534,7 +2534,7 @@ export const yampCardStyles = css`
      Virtualizer absolutely positions things, but if the wrapper is 100% width, we can use the left position.
      However, standard nth-child(5n) will work if the virtualizer doesn't omit elements. */
   .search-result-grid-mode:nth-child(5n) {
-    border-right: none;
+    border-right: none !important;
   }
 
   .search-result-grid-mode .yamp-search-result-thumb,
@@ -3700,7 +3700,7 @@ export const yampCardStyles = css`
   }
 
   .queue-sortable-container.is-card-layout.grid-mode > .queue-drag-wrapper:nth-child(5n) .search-result-grid-mode {
-    border-right: none;
+    border-right: none !important;
   }
 
   .queue-sortable-container.is-card-layout .queue-drag-wrapper {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2504,11 +2504,72 @@ export const yampCardStyles = css`
   }
 
   .grid-menu .menu-action-label,
-  .grid-menu .entity-options-item > span {
+  .grid-menu .entity-options-item > span,
+  .search-result-grid-mode .menu-action-label {
     line-height: 1.1;
     text-align: center;
     color: inherit;
   }
+
+  .search-result-grid-mode {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    border-radius: 0;
+    border-bottom: 1px solid var(--yamp-overlay-divider);
+    border-right: 1px solid var(--yamp-overlay-divider);
+    padding: 12px 4px;
+    gap: 6px;
+    font-size: 0.7em;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    cursor: pointer;
+    box-sizing: border-box;
+  }
+
+  /* Target every 5th item by using column positioning via nth-of-type or nth-child.
+     Virtualizer absolutely positions things, but if the wrapper is 100% width, we can use the left position.
+     However, standard nth-child(5n) will work if the virtualizer doesn't omit elements. */
+  .search-result-grid-mode:nth-child(5n) {
+    border-right: none;
+  }
+
+  .search-result-grid-mode .yamp-search-result-thumb,
+  .search-result-grid-mode .yamp-search-result-thumb-placeholder {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    object-fit: cover;
+    flex-shrink: 0;
+    margin: 0;
+  }
+
+  .search-result-grid-mode .yamp-search-result-thumb-placeholder {
+    background-color: var(--yamp-surface-variant);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .search-result-grid-mode .yamp-search-result-thumb-placeholder ha-icon {
+    --mdc-icon-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  .search-result-grid-mode .menu-action-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    width: 100%;
+    word-break: break-word;
+  }
+
 
   .entity-options-item.menu-action-item {
     display: flex;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -337,7 +337,8 @@ export const yampCardStyles = css`
     z-index: ${Z_LAYERS.FLOATING_CONTROLS};
   }
 
-  .dim-idle .more-info-menu {
+  .dim-idle .more-info-menu,
+  .more-info-menu.volume-collapsed {
     position: absolute;
     bottom: 14px;
     right: 12px;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2464,6 +2464,52 @@ export const yampCardStyles = css`
     text-align: center;
   }
 
+  .grid-menu {
+    display: grid !important;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 0;
+    padding: 0;
+    margin: 8px 0;
+  }
+
+  .grid-menu .entity-options-item {
+    margin: 0;
+    border-radius: 0;
+    border-bottom: 1px solid var(--yamp-overlay-divider);
+    border-right: 1px solid var(--yamp-overlay-divider);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 4px;
+    min-height: 64px;
+    gap: 6px;
+    font-size: 0.7em;
+  }
+
+  /* Remove right border on every 5th item */
+  .grid-menu .entity-options-item:nth-child(5n) {
+    border-right: none;
+  }
+  
+  /* Give the icon a specific size in grid mode */
+  .grid-menu .menu-action-icon,
+  .grid-menu .entity-options-item > ha-icon {
+    --mdc-icon-size: 24px;
+    width: 24px;
+    height: 24px;
+    color: inherit;
+    --mdc-icon-color: currentColor;
+    --icon-color: currentColor;
+  }
+
+  .grid-menu .menu-action-label,
+  .grid-menu .entity-options-item > span {
+    line-height: 1.1;
+    text-align: center;
+    color: inherit;
+  }
+
   .entity-options-item.menu-action-item {
     display: flex;
     align-items: center;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2493,7 +2493,7 @@ export const yampCardStyles = css`
   .grid-menu .entity-options-item:nth-child(5n) {
     border-right: none !important;
   }
-  
+
   /* Give the icon a specific size in grid mode */
   .grid-menu .menu-action-icon,
   .grid-menu .entity-options-item > ha-icon {
@@ -2571,7 +2571,6 @@ export const yampCardStyles = css`
     width: 100%;
     word-break: break-word;
   }
-
 
   .entity-options-item.menu-action-item {
     display: flex;
@@ -3701,7 +3700,9 @@ export const yampCardStyles = css`
     padding: 0;
   }
 
-  .queue-sortable-container.is-card-layout.grid-mode > .queue-drag-wrapper:nth-child(5n) .search-result-grid-mode {
+  .queue-sortable-container.is-card-layout.grid-mode
+    > .queue-drag-wrapper:nth-child(5n)
+    .search-result-grid-mode {
     border-right: none !important;
   }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3397,7 +3397,7 @@ export const yampCardStyles = css`
     font-size: 1em;
     outline: none;
   }
-  .entity-options-resolved-entities .entity-options-item {
+  .entity-options-resolved-entities-list:not(.grid-menu) .entity-options-item {
     background: none;
     color: var(--yamp-overlay-text);
     border: none;
@@ -3416,14 +3416,14 @@ export const yampCardStyles = css`
   }
 
   @media (hover: hover) {
-    .entity-options-resolved-entities .entity-options-item:hover,
-    .entity-options-resolved-entities .entity-options-item:focus {
+    .entity-options-resolved-entities-list:not(.grid-menu) .entity-options-item:hover,
+    .entity-options-resolved-entities-list:not(.grid-menu) .entity-options-item:focus {
       color: var(--custom-accent);
       background: none;
     }
   }
 
-  .entity-options-resolved-entities .entity-options-item:last-child {
+  .entity-options-resolved-entities-list:not(.grid-menu) .entity-options-item:last-child {
     border-bottom: none;
   }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3694,6 +3694,15 @@ export const yampCardStyles = css`
     padding: 12px 12px 24px 12px;
   }
 
+  .queue-sortable-container.is-card-layout.grid-mode {
+    gap: 0;
+    padding: 0;
+  }
+
+  .queue-sortable-container.is-card-layout.grid-mode > .queue-drag-wrapper:nth-child(5n) .search-result-grid-mode {
+    border-right: none;
+  }
+
   .queue-sortable-container.is-card-layout .queue-drag-wrapper {
     height: 100%;
     display: flex;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -316,6 +316,7 @@ export const yampCardStyles = css`
   .dim-idle .details,
   .dim-idle .controls-row,
   .dim-idle .volume-row,
+  .dim-idle .more-info-menu.volume-collapsed,
   .dim-idle:not(.no-chip-dim) .chip-row,
   .dim-idle:not(.no-chip-dim) .action-chip-row {
     opacity: 0.28;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -2466,9 +2466,23 @@ export const yampCardStyles = css`
     text-align: center;
   }
 
+  .entity-options-item[disabled] {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .transfer-queue-item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 12px;
+  }
+
+  /* Override entity-options-scroll display:flex (line ~3355) — !important needed because
+     .grid-menu appears earlier in source order than .entity-options-scroll */
   .grid-menu {
     display: grid !important;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(5, 1fr); /* MINI_GRID_COLUMNS */
     gap: 0;
     padding: 0;
     margin: 8px 0;
@@ -2477,8 +2491,8 @@ export const yampCardStyles = css`
   .grid-menu .entity-options-item {
     margin: 0;
     border-radius: 0;
-    border-bottom: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
-    border-right: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
+    border-bottom: 1px solid var(--divider-color, var(--yamp-overlay-divider));
+    border-right: 1px solid var(--divider-color, var(--yamp-overlay-divider));
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -2489,9 +2503,31 @@ export const yampCardStyles = css`
     font-size: 0.7em;
   }
 
-  /* Remove right border on every 5th item */
+  /* Remove right border on last column */
   .grid-menu .entity-options-item:nth-child(5n) {
-    border-right: none !important;
+    /* MINI_GRID_COLUMNS */
+    border-right: none;
+  }
+
+  .grid-menu .entity-options-item[disabled] {
+    cursor: default;
+    opacity: 0.5;
+  }
+
+  .grid-menu .entity-options-item.grid-active {
+    color: var(--custom-accent);
+  }
+
+  /* Wrapper for grid-menu children — display:contents lets items participate in the grid directly */
+  .grid-menu-items {
+    display: contents;
+  }
+
+  /* Non-grid transfer queue layout */
+  .transfer-queue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
   }
 
   /* Give the icon a specific size in grid mode */
@@ -2520,8 +2556,8 @@ export const yampCardStyles = css`
     justify-content: center;
     margin: 0;
     border-radius: 0;
-    border-bottom: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
-    border-right: 1px solid var(--divider-color, var(--yamp-overlay-divider)) !important;
+    border-bottom: 1px solid var(--divider-color, var(--yamp-overlay-divider));
+    border-right: 1px solid var(--divider-color, var(--yamp-overlay-divider));
     padding: 12px 4px;
     gap: 6px;
     font-size: 0.7em;
@@ -2532,11 +2568,10 @@ export const yampCardStyles = css`
     box-sizing: border-box;
   }
 
-  /* Target every 5th item by using column positioning via nth-of-type or nth-child.
-     Virtualizer absolutely positions things, but if the wrapper is 100% width, we can use the left position.
-     However, standard nth-child(5n) will work if the virtualizer doesn't omit elements. */
+  /* Remove right border on last column */
   .search-result-grid-mode:nth-child(5n) {
-    border-right: none !important;
+    /* MINI_GRID_COLUMNS */
+    border-right: none;
   }
 
   .search-result-grid-mode .yamp-search-result-thumb,
@@ -3701,9 +3736,9 @@ export const yampCardStyles = css`
   }
 
   .queue-sortable-container.is-card-layout.grid-mode
-    > .queue-drag-wrapper:nth-child(5n)
+    > .queue-drag-wrapper:nth-child(5n) /* MINI_GRID_COLUMNS */
     .search-result-grid-mode {
-    border-right: none !important;
+    border-right: none;
   }
 
   .queue-sortable-container.is-card-layout .queue-drag-wrapper {

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -3070,6 +3070,29 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         <div class="form-row">
           <div class="config-subtitle">${localize("editor.subtitles.collapse_expand")}</div>
         </div>
+        <div
+          data-search-keys="disable_mini_menu"
+          class="form-row"
+          style="${this._config.always_collapsed === true && !this._config.expand_on_search ? "" : "opacity: 0.5;"}"
+          title="${
+            this._config.always_collapsed === true && !this._config.expand_on_search
+              ? ""
+              : "Only available when Always Collapsed is true and Expand on Search is false"
+          }"
+        >
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <ha-switch
+              id="disable-mini-menu-toggle"
+              .checked=${this._config.disable_mini_menu === true}
+              @change=${(e) => this._updateConfig("disable_mini_menu", e.target.checked)}
+              .disabled=${!(this._config.always_collapsed === true && !this._config.expand_on_search)}
+            ></ha-switch>
+            <span>${localize("editor.labels.disable_mini_menu")}</span>
+          </div>
+        </div>
+        <div class="form-row">
+          <div class="config-subtitle">${localize("editor.subtitles.disable_mini_menu")}</div>
+        </div>
         <div class="form-row">
           <ha-selector
             .hass=${this.hass}

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -3077,7 +3077,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           title="${
             this._config.always_collapsed === true && !this._config.expand_on_search
               ? ""
-              : "Only available when Always Collapsed is true and Expand on Search is false"
+              : localize("editor.subtitles.only_available_mini_menu")
           }"
         >
           <div style="display: flex; align-items: center; gap: 8px;">

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -240,7 +240,7 @@ export const QueueDragMixin = (superClass) =>
 
           // Cache original static positions to prevent flickering on layout shifts
           const itemElements = container.querySelectorAll(
-            ".queue-drag-wrapper > .yamp-search-result"
+            ".queue-drag-wrapper > *:first-child"
           );
           cachedPositions = [];
           for (const el of itemElements) {
@@ -299,7 +299,7 @@ export const QueueDragMixin = (superClass) =>
         this._applyQueueDragVisuals(dragIdx, dragItemHeight, null);
 
         // Create a floating clone that follows the pointer
-        const itemEl = wrapper.querySelector(".yamp-search-result");
+        const itemEl = wrapper.firstElementChild;
         if (itemEl) {
           const rect = itemEl.getBoundingClientRect();
           cloneOffsetY = startY - rect.top;

--- a/src/yamp-queue-drag.js
+++ b/src/yamp-queue-drag.js
@@ -239,9 +239,7 @@ export const QueueDragMixin = (superClass) =>
           }
 
           // Cache original static positions to prevent flickering on layout shifts
-          const itemElements = container.querySelectorAll(
-            ".queue-drag-wrapper > *:first-child"
-          );
+          const itemElements = container.querySelectorAll(".queue-drag-wrapper > *:first-child");
           cachedPositions = [];
           for (const el of itemElements) {
             const wrapperEl = el.parentElement;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5272,6 +5272,21 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderMainMenu(sourceList, menuOnlyActions, showChipsInMenu) {
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+    const renderMenuItem = (label, icon, onClick) => {
+      if (isGridMode) {
+        return html`
+          <button class="entity-options-item menu-action-item" @click=${onClick}>
+            <ha-icon class="menu-action-icon" icon=${icon}></ha-icon>
+            <span class="menu-action-label">${label}</span>
+          </button>
+        `;
+      }
+      return html`
+        <button class="entity-options-item" @click=${onClick}>${label}</button>
+      `;
+    };
+
     return html`
       <div class="entity-options-header">
         <button class="entity-options-item close-item" @click=${() => this._closeEntityOptions()}>
@@ -5279,37 +5294,28 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         </button>
         <div class="entity-options-divider"></div>
       </div>
-      <div class="entity-options-menu ${showChipsInMenu ? 'chips-in-menu' : ''} entity-options-scroll" style="display:flex; flex-direction:column;">
-        <button class="entity-options-item" @click=${() => {
-        const resolvedEntities = this._getResolvedEntitiesForCurrentChip();
-        if (resolvedEntities.length === 1) {
-          this._openMoreInfoForEntity(resolvedEntities[0]);
-          this._showEntityOptions = false;
-        } else {
-          this._showResolvedEntities = true;
-        }
-        this.requestUpdate();
-      }}>${localize('card.menu.more_info')}</button>
-        <button class="entity-options-item" @click=${() => { this._showSearchSheetInOptions(); }}>${localize('common.search')}</button>
+      <div class="entity-options-menu ${showChipsInMenu ? 'chips-in-menu' : ''} ${isGridMode ? 'grid-menu' : 'entity-options-scroll'}" style="${!isGridMode ? 'display:flex; flex-direction:column;' : ''}">
+        ${renderMenuItem(localize('card.menu.more_info'), 'mdi:information-outline', () => {
+          const resolvedEntities = this._getResolvedEntitiesForCurrentChip();
+          if (resolvedEntities.length === 1) {
+            this._openMoreInfoForEntity(resolvedEntities[0]);
+            this._showEntityOptions = false;
+          } else {
+            this._showResolvedEntities = true;
+          }
+          this.requestUpdate();
+        })}
+        ${renderMenuItem(localize('common.search'), 'mdi:magnify', () => { this._showSearchSheetInOptions(); })}
 
-        ${Array.isArray(sourceList) && sourceList.length > 0 ? html`
-          <button class="entity-options-item" @click=${() => this._openSourceList()}>${localize('card.menu.source')}</button>
-        ` : nothing}
+        ${Array.isArray(sourceList) && sourceList.length > 0 ? renderMenuItem(localize('card.menu.source'), 'mdi:import', () => this._openSourceList()) : nothing}
         
-        ${this._canShowTransferQueueOption() ? html`
-          <button class="entity-options-item" @click=${() => this._openTransferQueue()}>${localize('card.menu.transfer_queue')}</button>
-        ` : nothing}
+        ${this._canShowTransferQueueOption() ? renderMenuItem(localize('card.menu.transfer_queue'), 'mdi:swap-horizontal', () => this._openTransferQueue()) : nothing}
         
-        ${this._renderGroupingMenuOption()}
+        ${this._renderGroupingMenuOption(isGridMode)}
         
-        ${this._hasRemoteControlSupport() ? html`
-          <button class="entity-options-item" @click=${() => this._openRemoteControl()}>
-            ${localize('card.menu.remote_controls')}
-          </button>
-        ` : nothing}
+        ${this._hasRemoteControlSupport() ? renderMenuItem(localize('card.menu.remote_controls'), 'mdi:remote', () => this._openRemoteControl()) : nothing}
         
-        ${!this._alwaysCollapsed ? html`
-          <button class="entity-options-item" @click=${() => {
+        ${!this._alwaysCollapsed ? renderMenuItem(localize(this._lyricsActive ? 'card.menu.hide_lyrics' : 'card.menu.show_lyrics'), 'mdi:script-text-outline', () => {
           this._lyricsActive = !this._lyricsActive;
           if (!this._lyricsActive) {
             this._lastLyricsTrackId = null;
@@ -5319,28 +5325,26 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           }
           this._showEntityOptions = false;
           this.requestUpdate();
-        }}>${localize(this._lyricsActive ? 'card.menu.hide_lyrics' : 'card.menu.show_lyrics')}</button>
-        ` : nothing}
-        
+        }) : nothing}
         
         ${menuOnlyActions.length ? html`
           ${menuOnlyActions.map(({ action, idx }) => {
-          const label = this._getActionLabel(action);
-          return html`
-              <button
-                class="entity-options-item menu-action-item"
-                @click=${() => this._onMenuActionClick(idx)}
-              >
-                ${action.icon ? html`
-                  <ha-icon
-                    class="menu-action-icon"
-                    .icon=${action.icon}
-                  ></ha-icon>
-                ` : nothing}
-                ${label ? html`<span class="menu-action-label">${label}</span>` : nothing}
-              </button>
-            `;
-        })}
+            const label = this._getActionLabel(action);
+            return html`
+                <button
+                  class="entity-options-item menu-action-item"
+                  @click=${() => this._onMenuActionClick(idx)}
+                >
+                  ${action.icon ? html`
+                    <ha-icon
+                      class="menu-action-icon"
+                      .icon=${action.icon}
+                    ></ha-icon>
+                  ` : nothing}
+                  ${label ? html`<span class="menu-action-label">${label}</span>` : nothing}
+                </button>
+              `;
+          })}
         ` : nothing}
       </div>
     `;
@@ -5469,7 +5473,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     `;
   }
 
-  _renderGroupingMenuOption() {
+  _renderGroupingMenuOption(isGridMode = false) {
     const totalEntities = this.entityIds.length;
     if (totalEntities <= 1) return nothing;
 
@@ -5488,6 +5492,14 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const isFollower = groupKey !== currentId;
 
     if (groupableCount > 1 && this._isGroupCapable(currGroupState) && !isFollower) {
+      if (isGridMode) {
+        return html`
+          <button class="entity-options-item menu-action-item" @click=${() => this._openGrouping()}>
+            <ha-icon class="menu-action-icon" icon="mdi:speaker-multiple"></ha-icon>
+            <span class="menu-action-label">${localize('card.menu.group_players')}</span>
+          </button>
+        `;
+      }
       return html`
         <button class="entity-options-item" @click=${() => this._openGrouping()}>${localize('card.menu.group_players')}</button>
       `;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9212,9 +9212,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
           if (isQueueDragAndDrop) {
             return html`
-              <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} queue-results-wrapper"
-                   style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? `--search-card-columns: ${this.config.search_card_columns || 4};` : ''}">
-                <div class="queue-sortable-container ${isCard ? 'is-card-layout' : ''}"
+              <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} queue-results-wrapper ${isGridMode ? 'grid-mode' : ''}"
+                   style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal' || isGridMode) ? `--search-card-columns: ${isGridMode ? 5 : (this.config.search_card_columns || 4)};` : ''}">
+                <div class="queue-sortable-container ${(isCard || isGridMode) ? 'is-card-layout' : ''} ${isGridMode ? 'grid-mode' : ''}"
                   @pointerdown=${(e) => this._onQueueDragStart(e)}
                 >
                   ${currentResults.map((item, idx) => html`

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5271,8 +5271,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     return !!this._addToPlaylistTarget || !!this._searchHierarchy.some(h => h.type === 'select_track_for_playlist');
   }
 
+  /** Whether the mini grid menu layout is active (always_collapsed + no expand_on_search + mini menus enabled). */
+  get _isGridMode() {
+    return this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+  }
+
   _renderMainMenu(sourceList, menuOnlyActions, showChipsInMenu) {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+    const isGridMode = this._isGridMode;
     const renderMenuItem = (label, icon, onClick) => {
       if (isGridMode) {
         return html`
@@ -5564,7 +5569,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderGroupingSheet() {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+    const isGridMode = this._isGridMode;
     const masterId = this._getGroupingMasterId();
     const masterIdx = masterId ? this.entityIds.indexOf(masterId) : -1;
     const masterGroupId = masterIdx >= 0 ? this._getGroupingEntityId(masterIdx) : masterId;
@@ -5655,7 +5660,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             ${localize('card.grouping.no_players')}
           </div>
         ` : html`
-          <div style="${isGridMode ? 'display:contents;' : ''}">
+          <div class="${isGridMode ? 'grid-menu-items' : ''}">
             ${sortedGroupIds.map(item => {
               const id = item.id;
               const actualGroupId = item.groupId;
@@ -5692,11 +5697,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                   : localize('card.grouping.join_with').replace('{master}', masterName);
                 
                 return html`
-                  <button class="entity-options-item menu-action-item group-toggle-btn" 
+                  <button class="entity-options-item menu-action-item group-toggle-btn ${(!showToggleButton || grouped) ? 'grid-active' : ''}" 
                     ?disabled=${isDisabled}
                     @click=${() => !isDisabled && this._toggleGroup(id)}
-                    title=${isBusy ? localize('card.grouping.unavailable') : (!showToggleButton ? stateLabel : toggleTooltip)}
-                    style="${isDisabled ? "cursor: default; opacity: 0.5;" : ""} ${(!showToggleButton || grouped) ? "color: var(--custom-accent);" : ""}">
+                    title=${isBusy ? localize('card.grouping.unavailable') : (!showToggleButton ? stateLabel : toggleTooltip)}>
                     <ha-icon class="menu-action-icon" icon=${isPrimaryRow ? "mdi:star" : (grouped ? "mdi:speaker-multiple" : "mdi:speaker")}></ha-icon>
                     <span class="menu-action-label">${name}</span>
                   </button>
@@ -5775,7 +5779,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderTransferQueueSheet() {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+    const isGridMode = this._isGridMode;
     const targets = this._getTransferQueueTargets();
     return html`
       <div class="entity-options-header">
@@ -5789,14 +5793,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         ${!targets.length ? html`
           <div style="padding: 12px; opacity: 0.75;">${localize('card.menu.no_players')}</div>
         ` : html`
-          <div style="${isGridMode ? 'display:contents;' : 'display:flex;flex-direction:column;gap:8px;'}">
+          <div class="${isGridMode ? 'grid-menu-items' : 'transfer-queue-list'}">
             ${targets.map(target => {
               if (isGridMode) {
                 return html`
                   <button class="entity-options-item menu-action-item" 
                     ?disabled=${this._transferQueuePendingTarget === target.maEntityId}
-                    @click=${() => this._transferQueueTo(target)}
-                    style="${this._transferQueuePendingTarget === target.maEntityId ? 'opacity:0.6;' : ''}">
+                    @click=${() => this._transferQueueTo(target)}>
                     <ha-icon class="menu-action-icon" .icon=${target.icon}></ha-icon>
                     <span class="menu-action-label">${target.name}</span>
                   </button>
@@ -5804,10 +5807,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               }
               return html`
                 <button
-                  class="entity-options-item"
+                  class="entity-options-item transfer-queue-item"
                   ?disabled=${this._transferQueuePendingTarget === target.maEntityId}
-                  @click=${() => this._transferQueueTo(target)}
-                  style="display:flex;align-items:center;justify-content:flex-start;gap:12px;${this._transferQueuePendingTarget === target.maEntityId ? 'opacity:0.6;' : ''}">
+                  @click=${() => this._transferQueueTo(target)}>
                   <ha-icon .icon=${target.icon} style="margin-right:4px;"></ha-icon>
                   <div style="display:flex;flex-direction:column;align-items:flex-start;">
                     <div>${target.name}</div>
@@ -5837,7 +5839,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderResolvedEntitiesSheet() {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+    const isGridMode = this._isGridMode;
 
     return html`
       <div class="entity-options-header">
@@ -9175,7 +9177,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           const currentResults = this._getDisplaySearchResults();
           const isCard = this.config.search_view === 'card' || this.config.search_view === 'card_minimal';
           const isMinimal = this.config.search_view === 'card_minimal';
-          const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+          const isGridMode = this._isGridMode;
           
           const renderItemFn = (item) => renderSearchResultItem({
             item,
@@ -9220,7 +9222,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           if (isQueueDragAndDrop) {
             return html`
               <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} queue-results-wrapper ${isGridMode ? 'grid-mode' : ''}"
-                   style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal' || isGridMode) ? `--search-card-columns: ${isGridMode ? 5 : (this.config.search_card_columns || 4)};` : ''}">
+                   style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal' || isGridMode) ? `--search-card-columns: ${isGridMode ? 5 /* MINI_GRID_COLUMNS */ : (this.config.search_card_columns || 4)};` : ''}">
                 <div class="queue-sortable-container ${(isCard || isGridMode) ? 'is-card-layout' : ''} ${isGridMode ? 'grid-mode' : ''}"
                   @pointerdown=${(e) => this._onQueueDragStart(e)}
                 >
@@ -9234,8 +9236,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             `;
           }
 
-          if (!this._cachedSearchGridLayout || this._cachedSearchGridLayoutColumns !== (isGridMode ? 5 : (this.config.search_card_columns || 4)) || this._cachedSearchGridLayoutIsMinimal !== isMinimal || this._cachedSearchGridLayoutIsGridMode !== isGridMode) {
-            const columns = isGridMode ? 5 : (this.config.search_card_columns || 4);
+          if (!this._cachedSearchGridLayout || this._cachedSearchGridLayoutColumns !== (isGridMode ? 5 /* MINI_GRID_COLUMNS */ : (this.config.search_card_columns || 4)) || this._cachedSearchGridLayoutIsMinimal !== isMinimal || this._cachedSearchGridLayoutIsGridMode !== isGridMode) {
+            const columns = isGridMode ? 5 /* MINI_GRID_COLUMNS */ : (this.config.search_card_columns || 4);
             this._cachedSearchGridLayoutColumns = columns;
             this._cachedSearchGridLayoutIsMinimal = isMinimal;
             this._cachedSearchGridLayoutIsGridMode = isGridMode;
@@ -9253,7 +9255,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
           return html`
             <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} virtualized-results-wrapper ${isGridMode ? 'grid-mode' : ''}"
-                 style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal' || isGridMode) ? `--search-card-columns: ${isGridMode ? 5 : (this.config.search_card_columns || 4)};` : ''}">
+                 style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal' || isGridMode) ? `--search-card-columns: ${isGridMode ? 5 /* MINI_GRID_COLUMNS */ : (this.config.search_card_columns || 4)};` : ''}">
               ${(isCard || isGridMode)
                 ? virtualize({
                   items: currentResults,
@@ -9271,7 +9273,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderSourceListSheet(sourceList, sourceLetters, availableSourceFirstLetters) {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
+    const isGridMode = this._isGridMode;
 
     return html`
       <div class="entity-options-header">

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5799,6 +5799,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderResolvedEntitiesSheet() {
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+
     return html`
       <div class="entity-options-header">
         <button class="entity-options-item close-item" @click=${() => {
@@ -5809,8 +5811,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         </button>
         <div class="entity-options-divider"></div>
         <div class="entity-options-resolved-entities" style="margin-top:12px;">
-          <div class="entity-options-title">${localize('card.menu.select_entity')}</div>
-          <div class="entity-options-resolved-entities-list">
+          ${!isGridMode ? html`<div class="entity-options-title">${localize('card.menu.select_entity')}</div>` : nothing}
+          <div class="entity-options-resolved-entities-list ${isGridMode ? 'grid-menu' : ''}">
             ${this._getResolvedEntitiesForCurrentChip().map(entityId => {
         const state = this.hass?.states?.[entityId];
         const name = state?.attributes?.friendly_name || entityId;
@@ -5832,6 +5834,20 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           } else if (entityId === volEntity && volEntity !== obj.entity_id && volEntity !== maEntity) {
             role = "Volume Entity";
           }
+        }
+
+        if (isGridMode) {
+          return html`
+            <button class="entity-options-item menu-action-item" @click=${() => {
+              this._openMoreInfoForEntity(entityId);
+              this._showEntityOptions = false;
+              this._showResolvedEntities = false;
+              this.requestUpdate();
+            }}>
+              <ha-icon class="menu-action-icon" .icon=${icon}></ha-icon>
+              <span class="menu-action-label">${isActive ? `${name} (Active)` : name}</span>
+            </button>
+          `;
         }
 
         return html`

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5564,6 +5564,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderGroupingSheet() {
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
     const masterId = this._getGroupingMasterId();
     const masterIdx = masterId ? this.entityIds.indexOf(masterId) : -1;
     const masterGroupId = masterIdx >= 0 ? this._getGroupingEntityId(masterIdx) : masterId;
@@ -5648,109 +5649,126 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           ${groupedAny ? localize('card.grouping.ungroup_all') : localize('card.grouping.group_all')}
         </button>
       </div>
-      <div class="group-list-scroll">
+      <div class="group-list-scroll ${isGridMode ? 'grid-menu' : ''}">
         ${sortedGroupIds.length === 0 ? html`
           <div class="entity-options-item" style="padding:12px; opacity:0.75; text-align:center;">
             ${localize('card.grouping.no_players')}
           </div>
-        ` : sortedGroupIds.map(item => {
-      const id = item.id;
-      const actualGroupId = item.groupId;
-      const filteredMembers = Array.isArray(masterState?.attributes?.group_members) ? masterState.attributes.group_members : [];
-      const grouped = filteredMembers.includes(actualGroupId);
-      const name = this.getChipName(id);
-      const isBusy = item.isBusy;
-      const busyLabel = item.busyLabel;
+        ` : html`
+          <div style="${isGridMode ? 'display:contents;' : ''}">
+            ${sortedGroupIds.map(item => {
+              const id = item.id;
+              const actualGroupId = item.groupId;
+              const filteredMembers = Array.isArray(masterState?.attributes?.group_members) ? masterState.attributes.group_members : [];
+              const grouped = filteredMembers.includes(actualGroupId);
+              const name = this.getChipName(id);
+              const isBusy = item.isBusy;
+              const busyLabel = item.busyLabel;
 
-      const entityIdx = this.entityIds.indexOf(id);
-      const volumeEntity = this._getVolumeEntity(entityIdx);
-      const displayEntity = volumeEntity || actualGroupId;
-      const displayVolumeState = this.hass.states[displayEntity];
+              const entityIdx = this.entityIds.indexOf(id);
+              const volumeEntity = this._getVolumeEntity(entityIdx);
+              const displayEntity = volumeEntity || actualGroupId;
+              const displayVolumeState = this.hass.states[displayEntity];
 
-      const isRemoteVol = displayEntity?.startsWith && displayEntity.startsWith("remote.");
-      const volVal = Number(displayVolumeState?.attributes?.volume_level || 0);
-      const isPrimaryRow = id === masterId;
-      const showToggleButton = !isPrimaryRow;
-      const isCurrent = id === activeId;
+              const isRemoteVol = displayEntity?.startsWith && displayEntity.startsWith("remote.");
+              const volVal = Number(displayVolumeState?.attributes?.volume_level || 0);
+              const isPrimaryRow = id === masterId;
+              const showToggleButton = !isPrimaryRow;
+              const isCurrent = id === activeId;
 
-      let stateLabel = groupedAny
-        ? (isPrimaryRow ? localize('card.grouping.master') : (grouped ? localize('card.grouping.joined') : localize('card.grouping.available')))
-        : (isCurrent ? localize('card.grouping.current') : localize('card.grouping.available'));
+              let stateLabel = groupedAny
+                ? (isPrimaryRow ? localize('card.grouping.master') : (grouped ? localize('card.grouping.joined') : localize('card.grouping.available')))
+                : (isCurrent ? localize('card.grouping.current') : localize('card.grouping.available'));
 
-      if (isBusy) {
-        stateLabel = busyLabel || "Unavailable";
-      }
+              if (isBusy) {
+                stateLabel = busyLabel || "Unavailable";
+              }
+              
+              if (isGridMode) {
+                return html`
+                  <button class="entity-options-item menu-action-item group-toggle-btn" 
+                    @click=${() => !isBusy && showToggleButton && this._toggleGroup(id)}
+                    title=${isBusy ? "Player is unavailable" : (grouped ? "Unjoin" : "Join")}
+                    style="${isBusy ? "cursor: not-allowed; opacity: 0.5;" : ""} ${grouped ? "color: var(--custom-accent);" : ""}">
+                    <ha-icon class="menu-action-icon" icon=${isPrimaryRow ? "mdi:star" : (grouped ? "mdi:speaker-multiple" : "mdi:speaker")}></ha-icon>
+                    <span class="menu-action-label">${name}</span>
+                  </button>
+                `;
+              }
 
-      return html`
-            <div class="entity-options-item group-player-row" style="
-              display:flex;
-              align-items:center;
-              gap:6px;
-              padding: 12px 8px 4px 8px;
-              margin-bottom: 1px;
-              ${isBusy ? "opacity: 0.5;" : ""}
-            ">
-              <div style="flex:1; min-width:120px;">
-                <div style="text-align:left;">${name}</div>
-                <div style="font-size:0.8em; opacity:0.7; text-align:left;">${stateLabel}</div>
-              </div>
-              <div style="flex:1.8;display:flex;align-items:center;gap:4px;margin:0 6px; min-width:160px;">
-                ${isRemoteVol
-          ? html`
-                    <div class="vol-stepper" style="display:flex;align-items:center;gap:4px;">
-                      <button @click=${() => this._onGroupVolumeStep(displayEntity, -1)} title="${localize('common.vol_down')}" style="background:none;border:none;padding:0;width:28px;height:28px;display:flex;align-items:center;justify-content:center;color:inherit;">
-                        <ha-icon icon="mdi:minus"></ha-icon>
-                      </button>
-                      <button @click=${() => this._onGroupVolumeStep(displayEntity, 1)} title="${localize('common.vol_up')}" style="background:none;border:none;padding:0;width:28px;height:28px;display:flex;align-items:center;justify-content:center;color:inherit;">
-                        <ha-icon icon="mdi:plus"></ha-icon>
-                      </button>
-                    </div>
-                  `
-          : html`
-                    <div class="volume-slider-container grouping-vol-slider-container" style="flex:1; padding: 0 4px; position: relative; display: flex; align-items: center;">
-                      <div class="volume-percentage-indicator ${this._volumeDraggingEntity === id ? 'visible' : ''}" style="left: calc(13px + ${this._dragVolume} * (100% - 26px))">
-                        ${Math.round(this._dragVolume * 100)}%
+              return html`
+                    <div class="entity-options-item group-player-row" style="
+                      display:flex;
+                      align-items:center;
+                      gap:6px;
+                      padding: 12px 8px 4px 8px;
+                      margin-bottom: 1px;
+                      ${isBusy ? "opacity: 0.5;" : ""}
+                    ">
+                      <div style="flex:1; min-width:120px;">
+                        <div style="text-align:left;">${name}</div>
+                        <div style="font-size:0.8em; opacity:0.7; text-align:left;">${stateLabel}</div>
                       </div>
-                      <input
-                        class="vol-slider"
-                        type="range"
-                        min="0"
-                        max="1"
-                        step="0.01"
-                        .value=${volVal}
-                        @mousedown=${(e) => this._onVolumeDragStart(e, id)}
-                        @touchstart=${(e) => this._onVolumeDragStart(e, id)}
-                        @input=${(e) => this._onVolumeInput(e)}
-                        @mouseup=${(e) => this._onVolumeDragEnd(e)}
-                        @touchend=${(e) => this._onVolumeDragEnd(e)}
-                        @change=${e => this._onGroupVolumeChange(id, displayEntity, e)}
-                        title="${localize('common.volume')}"
-                        style="width:100%;max-width:260px;"
-                      />
+                      <div style="flex:1.8;display:flex;align-items:center;gap:4px;margin:0 6px; min-width:160px;">
+                        ${isRemoteVol
+                  ? html`
+                            <div class="vol-stepper" style="display:flex;align-items:center;gap:4px;">
+                              <button @click=${() => this._onGroupVolumeStep(displayEntity, -1)} title="${localize('common.vol_down')}" style="background:none;border:none;padding:0;width:28px;height:28px;display:flex;align-items:center;justify-content:center;color:inherit;">
+                                <ha-icon icon="mdi:minus"></ha-icon>
+                              </button>
+                              <button @click=${() => this._onGroupVolumeStep(displayEntity, 1)} title="${localize('common.vol_up')}" style="background:none;border:none;padding:0;width:28px;height:28px;display:flex;align-items:center;justify-content:center;color:inherit;">
+                                <ha-icon icon="mdi:plus"></ha-icon>
+                              </button>
+                            </div>
+                          `
+                  : html`
+                            <div class="volume-slider-container grouping-vol-slider-container" style="flex:1; padding: 0 4px; position: relative; display: flex; align-items: center;">
+                              <div class="volume-percentage-indicator ${this._volumeDraggingEntity === id ? 'visible' : ''}" style="left: calc(13px + ${this._dragVolume} * (100% - 26px))">
+                                ${Math.round(this._dragVolume * 100)}%
+                              </div>
+                              <input
+                                class="vol-slider"
+                                type="range"
+                                min="0"
+                                max="1"
+                                step="0.01"
+                                .value=${volVal}
+                                @mousedown=${(e) => this._onVolumeDragStart(e, id)}
+                                @touchstart=${(e) => this._onVolumeDragStart(e, id)}
+                                @input=${(e) => this._onVolumeInput(e)}
+                                @mouseup=${(e) => this._onVolumeDragEnd(e)}
+                                @touchend=${(e) => this._onVolumeDragEnd(e)}
+                                @change=${e => this._onGroupVolumeChange(id, displayEntity, e)}
+                                title="${localize('common.volume')}"
+                                style="width:100%;max-width:260px;"
+                              />
+                            </div>
+                          `
+                }
+                        <span style="min-width:36px;display:inline-block;text-align:right;">${typeof volVal === "number" ? Math.round(volVal * 100) + "%" : "--"}</span>
+                      </div>
+                      ${showToggleButton
+                  ? html`
+                            <button class="group-toggle-btn"
+                                    @click=${() => !isBusy && this._toggleGroup(id)}
+                                    title=${isBusy ? "Player is unavailable" : (grouped ? "Unjoin" : "Join")}
+                                    style="margin-left:4px; ${isBusy ? "cursor: not-allowed; opacity: 0.5;" : ""}">
+                              <ha-icon icon=${grouped ? "mdi:minus-circle-outline" : "mdi:plus-circle-outline"}></ha-icon>
+                            </button>
+                          `
+                  : html`<span style="margin-left:4px;margin-right:10px;width:32px;display:inline-block;"></span>`
+                }
                     </div>
-                  `
-        }
-                <span style="min-width:36px;display:inline-block;text-align:right;">${typeof volVal === "number" ? Math.round(volVal * 100) + "%" : "--"}</span>
-              </div>
-              ${showToggleButton
-          ? html`
-                    <button class="group-toggle-btn"
-                            @click=${() => !isBusy && this._toggleGroup(id)}
-                            title=${isBusy ? "Player is unavailable" : (grouped ? "Unjoin" : "Join")}
-                            style="margin-left:4px; ${isBusy ? "cursor: not-allowed; opacity: 0.5;" : ""}">
-                      <ha-icon icon=${grouped ? "mdi:minus-circle-outline" : "mdi:plus-circle-outline"}></ha-icon>
-                    </button>
-                  `
-          : html`<span style="margin-left:4px;margin-right:10px;width:32px;display:inline-block;"></span>`
-        }
-            </div>
-          `;
-    })}
+                  `;
+            })}
+          </div>
+        `}
       </div>
     `;
   }
 
   _renderTransferQueueSheet() {
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
     const targets = this._getTransferQueueTargets();
     return html`
       <div class="entity-options-header">
@@ -5758,27 +5776,40 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           ${localize('common.back')}
         </button>
         <div class="entity-options-divider"></div>
-        <div class="entity-options-title" style="margin-bottom:12px;">${localize('card.menu.transfer_to')}</div>
+        ${!isGridMode ? html`<div class="entity-options-title" style="margin-bottom:12px;">${localize('card.menu.transfer_to')}</div>` : nothing}
       </div>
-      <div class="entity-options-scroll">
+      <div class="entity-options-scroll ${isGridMode ? 'grid-menu' : ''}">
         ${!targets.length ? html`
           <div style="padding: 12px; opacity: 0.75;">${localize('card.menu.no_players')}</div>
         ` : html`
-          <div style="display:flex;flex-direction:column;gap:8px;">
-            ${targets.map(target => html`
-              <button
-                class="entity-options-item"
-                ?disabled=${this._transferQueuePendingTarget === target.maEntityId}
-                @click=${() => this._transferQueueTo(target)}
-                style="display:flex;align-items:center;justify-content:flex-start;gap:12px;${this._transferQueuePendingTarget === target.maEntityId ? 'opacity:0.6;' : ''}">
-                <ha-icon .icon=${target.icon} style="margin-right:4px;"></ha-icon>
-                <div style="display:flex;flex-direction:column;align-items:flex-start;">
-                  <div>${target.name}</div>
-                  <div style="font-size:0.82em;opacity:0.7;">${target.subtitle}</div>
-                </div>
-                ${target.state ? html`<div style="margin-left:auto;font-size:0.82em;opacity:0.7;text-transform:capitalize;">${target.state}</div>` : nothing}
-              </button>
-            `)}
+          <div style="${isGridMode ? 'display:contents;' : 'display:flex;flex-direction:column;gap:8px;'}">
+            ${targets.map(target => {
+              if (isGridMode) {
+                return html`
+                  <button class="entity-options-item menu-action-item" 
+                    ?disabled=${this._transferQueuePendingTarget === target.maEntityId}
+                    @click=${() => this._transferQueueTo(target)}
+                    style="${this._transferQueuePendingTarget === target.maEntityId ? 'opacity:0.6;' : ''}">
+                    <ha-icon class="menu-action-icon" .icon=${target.icon}></ha-icon>
+                    <span class="menu-action-label">${target.name}</span>
+                  </button>
+                `;
+              }
+              return html`
+                <button
+                  class="entity-options-item"
+                  ?disabled=${this._transferQueuePendingTarget === target.maEntityId}
+                  @click=${() => this._transferQueueTo(target)}
+                  style="display:flex;align-items:center;justify-content:flex-start;gap:12px;${this._transferQueuePendingTarget === target.maEntityId ? 'opacity:0.6;' : ''}">
+                  <ha-icon .icon=${target.icon} style="margin-right:4px;"></ha-icon>
+                  <div style="display:flex;flex-direction:column;align-items:flex-start;">
+                    <div>${target.name}</div>
+                    <div style="font-size:0.82em;opacity:0.7;">${target.subtitle}</div>
+                  </div>
+                  ${target.state ? html`<div style="margin-left:auto;font-size:0.82em;opacity:0.7;text-transform:capitalize;">${target.state}</div>` : nothing}
+                </button>
+              `;
+            })}
           </div>
         `}
         ${this._transferQueueStatus ? html`
@@ -9219,6 +9250,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderSourceListSheet(sourceList, sourceLetters, availableSourceFirstLetters) {
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+
     return html`
       <div class="entity-options-header">
         <button class="entity-options-item close-item" @click=${() => { if (this._quickMenuInvoke) { this._dismissWithAnimation(); } else { this._closeSourceList(); } }}>
@@ -9228,38 +9261,50 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       </div>
       <div class="entity-options-scroll source-list-centering-wrapper">
         <div class="source-list-sheet">
-          <div class="source-list-scroll">
-            ${sourceList.map(src => html`
-              <div class="entity-options-item" data-source-name="${src}" @click=${() => this._selectSource(src)}>${src}</div>
-            `)}
+          <div class="source-list-scroll ${isGridMode ? 'grid-menu' : ''}">
+            ${sourceList.map(src => {
+              if (isGridMode) {
+                return html`
+                  <button class="entity-options-item menu-action-item" @click=${() => this._selectSource(src)}>
+                    <ha-icon class="menu-action-icon" icon="mdi:login"></ha-icon>
+                    <span class="menu-action-label">${src}</span>
+                  </button>
+                `;
+              }
+              return html`
+                <div class="entity-options-item" data-source-name="${src}" @click=${() => this._selectSource(src)}>${src}</div>
+              `;
+            })}
           </div>
         </div>
       </div>
-      <div class="floating-source-index">
-        ${sourceLetters.map((letter, i) => {
-      const isAvailable = availableSourceFirstLetters.has(letter);
-      const hovered = this._hoveredSourceLetterIndex;
-      let scale = "";
-      if (isAvailable && hovered !== null && hovered !== undefined) {
-        const dist = Math.abs(hovered - i);
-        if (dist === 0) scale = "max";
-        else if (dist === 1) scale = "large";
-        else if (dist === 2) scale = "med";
-      }
-      return html`
-            <button
-              class="source-index-letter"
-              ?disabled=${!isAvailable}
-              data-scale=${scale}
-              @mouseenter=${isAvailable ? () => { this._hoveredSourceLetterIndex = i; this.requestUpdate(); } : nothing}
-              @mouseleave=${() => { this._hoveredSourceLetterIndex = null; this.requestUpdate(); }}
-              @click=${isAvailable ? () => this._scrollToSourceLetter(letter) : nothing}
-            >
-              ${letter}
-            </button>
-          `;
-    })}
-      </div>
+      ${!isGridMode ? html`
+        <div class="floating-source-index">
+          ${sourceLetters.map((letter, i) => {
+        const isAvailable = availableSourceFirstLetters.has(letter);
+        const hovered = this._hoveredSourceLetterIndex;
+        let scale = "";
+        if (isAvailable && hovered !== null && hovered !== undefined) {
+          const dist = Math.abs(hovered - i);
+          if (dist === 0) scale = "max";
+          else if (dist === 1) scale = "large";
+          else if (dist === 2) scale = "med";
+        }
+        return html`
+              <button
+                class="source-index-letter"
+                ?disabled=${!isAvailable}
+                data-scale=${scale}
+                @mouseenter=${isAvailable ? () => { this._hoveredSourceLetterIndex = i; this.requestUpdate(); } : nothing}
+                @mouseleave=${() => { this._hoveredSourceLetterIndex = null; this.requestUpdate(); }}
+                @click=${isAvailable ? () => this._scrollToSourceLetter(letter) : nothing}
+              >
+                ${letter}
+              </button>
+            `;
+      })}
+        </div>
+      ` : nothing}
     `;
   }
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -9168,10 +9168,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           const currentResults = this._getDisplaySearchResults();
           const isCard = this.config.search_view === 'card' || this.config.search_view === 'card_minimal';
           const isMinimal = this.config.search_view === 'card_minimal';
+          const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+          
           const renderItemFn = (item) => renderSearchResultItem({
             item,
             isCard,
             isMinimal,
+            isGridMode,
             activeSearchRowMenuId: this._activeSearchRowMenuId,
             loadingSearchRowMenuId: this._loadingSearchRowMenuId,
             errorSearchRowMenuId: this._errorSearchRowMenuId,
@@ -9224,23 +9227,27 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             `;
           }
 
-          if (!this._cachedSearchGridLayout || this._cachedSearchGridLayoutColumns !== (this.config.search_card_columns || 4) || this._cachedSearchGridLayoutIsMinimal !== isMinimal) {
-            this._cachedSearchGridLayoutColumns = this.config.search_card_columns || 4;
+          if (!this._cachedSearchGridLayout || this._cachedSearchGridLayoutColumns !== (isGridMode ? 5 : (this.config.search_card_columns || 4)) || this._cachedSearchGridLayoutIsMinimal !== isMinimal || this._cachedSearchGridLayoutIsGridMode !== isGridMode) {
+            const columns = isGridMode ? 5 : (this.config.search_card_columns || 4);
+            this._cachedSearchGridLayoutColumns = columns;
             this._cachedSearchGridLayoutIsMinimal = isMinimal;
+            this._cachedSearchGridLayoutIsGridMode = isGridMode;
             this._cachedSearchGridLayout = yampGrid({
-              columns: this._cachedSearchGridLayoutColumns,
-              gap: '12px',
-              padding: '12px',
-              itemSize: isMinimal
-                ? { width: 150, height: 150 }
-                : { width: 150, height: 244 }
+              columns: columns,
+              gap: isGridMode ? '0px' : '12px',
+              padding: isGridMode ? '0px' : '12px',
+              itemSize: isGridMode 
+                ? { width: 70, height: 85 } 
+                : (isMinimal
+                  ? { width: 150, height: 150 }
+                  : { width: 150, height: 244 })
             });
           }
 
           return html`
-            <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} virtualized-results-wrapper"
-                 style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal') ? `--search-card-columns: ${this.config.search_card_columns || 4};` : ''}">
-              ${isCard
+            <div class="${this._showSearchInSheet ? 'search-sheet-results' : 'entity-options-search-results'} virtualized-results-wrapper ${isGridMode ? 'grid-mode' : ''}"
+                 style="${(this.config.search_view === 'card' || this.config.search_view === 'card_minimal' || isGridMode) ? `--search-card-columns: ${isGridMode ? 5 : (this.config.search_card_columns || 4)};` : ''}">
+              ${(isCard || isGridMode)
                 ? virtualize({
                   items: currentResults,
                   renderItem: renderItemFn,

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5675,6 +5675,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               const isPrimaryRow = id === masterId;
               const showToggleButton = !isPrimaryRow;
               const isCurrent = id === activeId;
+              const masterName = masterId ? this.getChipName(masterId) : localize('card.grouping.master');
 
               let stateLabel = groupedAny
                 ? (isPrimaryRow ? localize('card.grouping.master') : (grouped ? localize('card.grouping.joined') : localize('card.grouping.available')))
@@ -5685,11 +5686,17 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               }
               
               if (isGridMode) {
+                const isDisabled = isBusy || !showToggleButton;
+                const toggleTooltip = grouped 
+                  ? localize('card.grouping.unjoin_from').replace('{master}', masterName)
+                  : localize('card.grouping.join_with').replace('{master}', masterName);
+                
                 return html`
                   <button class="entity-options-item menu-action-item group-toggle-btn" 
-                    @click=${() => !isBusy && showToggleButton && this._toggleGroup(id)}
-                    title=${isBusy ? "Player is unavailable" : (grouped ? "Unjoin" : "Join")}
-                    style="${isBusy ? "cursor: not-allowed; opacity: 0.5;" : ""} ${grouped ? "color: var(--custom-accent);" : ""}">
+                    ?disabled=${isDisabled}
+                    @click=${() => !isDisabled && this._toggleGroup(id)}
+                    title=${isBusy ? localize('card.grouping.unavailable') : (!showToggleButton ? stateLabel : toggleTooltip)}
+                    style="${isDisabled ? "cursor: default; opacity: 0.5;" : ""} ${(!showToggleButton || grouped) ? "color: var(--custom-accent);" : ""}">
                     <ha-icon class="menu-action-icon" icon=${isPrimaryRow ? "mdi:star" : (grouped ? "mdi:speaker-multiple" : "mdi:speaker")}></ha-icon>
                     <span class="menu-action-label">${name}</span>
                   </button>
@@ -5751,7 +5758,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                   ? html`
                             <button class="group-toggle-btn"
                                     @click=${() => !isBusy && this._toggleGroup(id)}
-                                    title=${isBusy ? "Player is unavailable" : (grouped ? "Unjoin" : "Join")}
+                                    title=${isBusy ? localize('card.grouping.unavailable') : (grouped ? localize('card.grouping.unjoin_from').replace('{master}', masterName) : localize('card.grouping.join_with').replace('{master}', masterName))}
                                     style="margin-left:4px; ${isBusy ? "cursor: not-allowed; opacity: 0.5;" : ""}">
                               <ha-icon icon=${grouped ? "mdi:minus-circle-outline" : "mdi:plus-circle-outline"}></ha-icon>
                             </button>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8590,7 +8590,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         muteSlotTemplate: shouldHideVolumeControls ? (muteSlotTemplate !== nothing ? html`<div style="visibility:hidden; opacity:0; pointer-events:none;">${muteSlotTemplate}</div>` : nothing) : muteSlotTemplate,
         hideVolume: isVolumeHidden,
         collapseRow: volumeRowWillCollapse,
-        moreInfoMenu: (!this._showEntityOptions && !isCompactVolume) ? html`
+        moreInfoMenu: (!this._showEntityOptions && !isCompactVolume && !volumeRowWillCollapse) ? html`
           <div class="more-info-menu">
             <button class="more-info-btn" @click=${async () => await this._openEntityOptions()}>
               <span class="more-info-icon">&#9776;</span>
@@ -8598,6 +8598,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           </div>
         ` : nothing,
       })}
+            ${(volumeRowWillCollapse && !this._showEntityOptions && !isCompactVolume) ? html`
+              <div class="more-info-menu volume-collapsed">
+                <button class="more-info-btn" @click=${async () => await this._openEntityOptions()}>
+                  <span class="more-info-icon">&#9776;</span>
+                </button>
+              </div>
+            ` : nothing}
             ${showChipsInMenu && !this._hideActiveEntityLabel && !(this._hideActiveEntityLabelOnIdle && this._isIdle) ? html`
               <div class="in-menu-active-label" style="${this._showEntityOptions ? 'visibility:hidden; opacity:0; pointer-events:none;' : ''}">${activeChipName}</div>
             ` : nothing}

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -5272,7 +5272,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderMainMenu(sourceList, menuOnlyActions, showChipsInMenu) {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
     const renderMenuItem = (label, icon, onClick) => {
       if (isGridMode) {
         return html`
@@ -5564,7 +5564,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderGroupingSheet() {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
     const masterId = this._getGroupingMasterId();
     const masterIdx = masterId ? this.entityIds.indexOf(masterId) : -1;
     const masterGroupId = masterIdx >= 0 ? this._getGroupingEntityId(masterIdx) : masterId;
@@ -5775,7 +5775,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderTransferQueueSheet() {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
     const targets = this._getTransferQueueTargets();
     return html`
       <div class="entity-options-header">
@@ -5837,7 +5837,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderResolvedEntitiesSheet() {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
 
     return html`
       <div class="entity-options-header">
@@ -9168,7 +9168,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           const currentResults = this._getDisplaySearchResults();
           const isCard = this.config.search_view === 'card' || this.config.search_view === 'card_minimal';
           const isMinimal = this.config.search_view === 'card_minimal';
-          const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+          const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
           
           const renderItemFn = (item) => renderSearchResultItem({
             item,
@@ -9264,7 +9264,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _renderSourceListSheet(sourceList, sourceLetters, availableSourceFirstLetters) {
-    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet);
+    const isGridMode = this._alwaysCollapsed && (!this._expandOnSearch || !this._showSearchInSheet) && !this.config.disable_mini_menu;
 
     return html`
       <div class="entity-options-header">


### PR DESCRIPTION
## Description

This PR introduces a mini grid menu layout for the `always_collapsed` mode across all menu surfaces, including the main menu, grouping, transfer queue, resolved entities, source list, and search results.

### User-facing Changes:
* **Grid Menus**: Replaces standard vertical lists with a 5-column grid layout for various menus when in `always_collapsed` mode (and no search sheet expansion is set).
* **Configuration Toggle**: Adds the `disable_mini_menu` option to disable this new grid mode, falling back to full-width menus. This is documented in the README and available in the visual editor.
* **Drag-and-Drop Enhancements**: The queue list now supports robust drag-and-drop interactions while in grid layout, utilizing ghost clone behavior and proper boundary detection.
* **Localization Parity**: The new configuration options (`disable_mini_menu` / `disable_mini_menu_desc`) have been translated and added to all supported languages.
* **Bug Fixes**: Fixes an issue where the hamburger menu button (more-info) would disappear in idle state when the volume row collapsed.