### PR TITLE
feat: move lyrics loading indicator from lyrics-view to bottom progress badge

### DIFF
--- a/src/lyrics-view.js
+++ b/src/lyrics-view.js
@@ -133,12 +133,7 @@ export class YampLyricsView extends LitElement {
     }
 
     if (this.loading) {
-      return html`
-        <div class="lyrics-loading">
-          <ha-circular-progress active></ha-circular-progress>
-          <div>${localize("lyrics.finding")}</div>
-        </div>
-      `;
+      return html``;
     }
 
     if (!this.lyrics || this.lyrics.length === 0) {

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8667,6 +8667,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                       Re-ordering ${this._queueOpsCompleted} / ${this._queueOpsTotal}
                     </div>
                   ` : nothing}
+                  ${this._lyricsActive && !this._isIdle && this._fetchingLyrics ? html`
+                    <div class="queue-ops-progress" style="position: absolute !important; bottom: -20px !important; left: 50% !important; transform: translate(-50%, 0) !important; z-index: 1000 !important; width: max-content !important; pointer-events: none !important; color: var(--search-text-secondary) !important;">
+                      ${localize("lyrics.finding")}
+                    </div>
+                  ` : nothing}
                 </div>
                 ${(() => {
             const idx = this._selectedIndex;
@@ -8706,6 +8711,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           ${!shouldShowPersistentControls && !this.config.hide_reorder_progress && !this.config.hide_menu_player && this._queueOpsTotal > 0 ? html`
             <div class="queue-ops-progress" style="position: absolute !important; bottom: 12px !important; left: 50% !important; transform: translate(-50%, 0) !important; z-index: 1000 !important; width: max-content !important; pointer-events: none !important; color: var(--search-text-secondary) !important;">
               Re-ordering ${this._queueOpsCompleted} / ${this._queueOpsTotal}
+            </div>
+          ` : ""}
+          ${(!this._showEntityOptions || !shouldShowPersistentControls) && this._lyricsActive && !this._isIdle && this._fetchingLyrics ? html`
+            <div class="queue-ops-progress" style="position: absolute !important; bottom: 2px !important; left: 50% !important; transform: translate(-50%, 0) !important; z-index: 1000 !important; width: max-content !important; pointer-events: none !important; color: var(--search-text-secondary) !important;">
+              ${localize("lyrics.finding")}
             </div>
           ` : ""}
           </div>


### PR DESCRIPTION
### Summary of Changes
- **Lyrics View Loading State**: Removed the circular loading spinner from the center of `lyrics-view` (`YampLyricsView`), keeping the view clean while lyrics are being fetched.
- **Unified Progress Badge**: Rendered a "Finding Lyrics..." progress indicator styled identically to the queue re-ordering indicator (`.queue-ops-progress`).
- **Non-Intersecting Positioning**: Positioned the finding lyrics indicator at the bottom edge of the card (`bottom: 2px` on the main card view, and `bottom: -20px` inside persistent media controls) to ensure it sits cleanly without intersecting with volume or playback controls.