### PR TITLE
Fix card height overflow with adaptive details & add marquee auto-scroll

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -982,6 +982,8 @@ export const yampCardStyles = css`
     padding-top: calc(8px * var(--yamp-details-scale, 1));
     padding-bottom: calc(4px * var(--yamp-details-scale, 1));
     margin-bottom: calc(-4px * var(--yamp-details-scale, 1));
+    max-width: 100%;
+    position: relative;
   }
 
   .details .artist {
@@ -989,6 +991,67 @@ export const yampCardStyles = css`
     line-height: var(--yamp-details-line-height, 1.2);
     padding-bottom: calc(4px * var(--yamp-details-scale, 1));
     margin-bottom: calc(-4px * var(--yamp-details-scale, 1));
+    max-width: 100%;
+    position: relative;
+  }
+
+  .marquee-inner {
+    display: inline-block;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+
+  [data-marquee="true"] {
+    overflow: hidden !important;
+    display: block !important;
+    text-overflow: clip !important;
+    -webkit-line-clamp: unset !important;
+    text-align: left !important;
+  }
+
+  [data-marquee="true"] > .marquee-inner {
+    max-width: none !important;
+    will-change: transform, opacity;
+    animation: yamp-marquee var(--yamp-marquee-duration, 8s) ease-in-out infinite;
+  }
+
+  @media (hover: hover) {
+    [data-marquee="true"]:hover > .marquee-inner {
+      animation-play-state: paused;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-marquee="true"] > .marquee-inner {
+      animation: none !important;
+      transform: none !important;
+      opacity: 1 !important;
+    }
+  }
+
+  @keyframes yamp-marquee {
+    0%,
+    22% {
+      transform: translateX(0);
+      opacity: 1;
+    }
+    72%,
+    88% {
+      transform: translateX(var(--yamp-marquee-distance, 0px));
+      opacity: 1;
+    }
+    93% {
+      transform: translateX(var(--yamp-marquee-distance, 0px));
+      opacity: 0;
+    }
+    96% {
+      transform: translateX(0);
+      opacity: 0;
+    }
+    100% {
+      transform: translateX(0);
+      opacity: 1;
+    }
   }
 
   .track-options-row {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -92,6 +92,7 @@ export const yampCardStyles = css`
     --yamp-details-scale: var(--yamp-text-scale-details, 1);
     --yamp-details-line-height: 1.2;
     --yamp-details-max-lines: 3;
+    --yamp-details-white-space: normal;
     --yamp-section-bg: rgba(255, 255, 255, 0.02);
     --yamp-section-border: rgba(255, 255, 255, 0.1);
     --yamp-section-radius: 12px;
@@ -971,14 +972,13 @@ export const yampCardStyles = css`
     font-size: 1.1em;
     font-weight: 600;
     line-height: var(--yamp-details-line-height, 1.2);
-    white-space: normal;
+    white-space: var(--yamp-details-white-space, normal);
     word-break: break-word;
-    overflow: visible;
-    text-overflow: unset;
+    overflow: hidden;
+    text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: var(--yamp-details-max-lines, 3);
-    overflow: hidden;
     padding-top: calc(8px * var(--yamp-details-scale, 1));
     padding-bottom: calc(4px * var(--yamp-details-scale, 1));
     margin-bottom: calc(-4px * var(--yamp-details-scale, 1));

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -4089,8 +4089,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const detailLineHeight = detailActive ? this._calculateDetailsLineHeight(safeDetailsScale) : 1.2;
     this.style.setProperty("--yamp-details-scale", detailScaleString);
     this.style.setProperty("--yamp-details-line-height", detailLineHeight.toFixed(2));
-    const detailMaxLines = detailActive ? (safeDetailsScale >= 2 ? 3 : safeDetailsScale >= 1.3 ? 2 : 1) : 3;
+    const detailMaxLines = detailActive ? 1 : 3;
     this.style.setProperty("--yamp-details-max-lines", detailMaxLines.toString());
+    this.style.setProperty("--yamp-details-white-space", detailActive ? "nowrap" : "normal");
     const lyricsActive = !!targetSet?.has("lyrics");
     this.style.setProperty("--yamp-text-scale-lyrics", lyricsActive ? safeDetailsScale.toFixed(2) : "1");
   }

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -4157,6 +4157,31 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       this._setAdaptiveTextVars(scale, undefined, detailScale);
       this.requestUpdate();
     }
+    this._updateMarquee();
+  }
+
+  _updateMarquee() {
+    if (!this.isConnected || !this.renderRoot) return;
+    const containers = this.renderRoot.querySelectorAll('.details .track-options-title, .details .artist');
+    containers.forEach((container) => {
+      const inner = container.querySelector('.marquee-inner');
+      if (!inner) return;
+      const containerWidth = container.clientWidth;
+      const contentWidth = inner.scrollWidth;
+      const overflow = contentWidth - containerWidth;
+      if (overflow > 4) {
+        const speed = 30; // pixels per second
+        const scrollDuration = overflow / speed;
+        const totalDuration = Math.max(5, Math.round((scrollDuration + 4.3) * 10) / 10);
+        container.style.setProperty('--yamp-marquee-distance', `-${Math.ceil(overflow)}px`);
+        container.style.setProperty('--yamp-marquee-duration', `${totalDuration}s`);
+        container.setAttribute('data-marquee', 'true');
+      } else {
+        container.removeAttribute('data-marquee');
+        container.style.removeProperty('--yamp-marquee-distance');
+        container.style.removeProperty('--yamp-marquee-duration');
+      }
+    });
   }
 
   _calculateDetailsScale(width, height, fallbackScale = 1) {
@@ -6576,6 +6601,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         if (overlayEl) overlayEl.scrollTop = 0;
       }, 0);
     }
+    this.updateComplete.then(() => this._updateMarquee());
   }
 
   _toggleSourceMenu() {
@@ -8500,7 +8526,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                       </div>
                     ` : html`
                       <div class="title track-options-title" @click=${(e) => { if (shouldShowDetails && title) { e.stopPropagation(); this._showMediaTitleOptions = true; } }} style="${shouldShowDetails && title ? 'cursor: pointer;' : ''}" title="${shouldShowDetails && title ? localize('search.show_track_options') : ''}">
-                        ${shouldShowDetails && title ? title : html`&nbsp;`}
+                        <span class="marquee-inner">${shouldShowDetails && title ? title : html`&nbsp;`}</span>
                       </div>
                     `}
                     <div
@@ -8509,7 +8535,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           if (shouldShowDetails && stateObj.attributes.media_artist) this._searchArtistFromNowPlaying();
         }}
                         title=${shouldShowDetails && stateObj.attributes.media_artist ? localize('search.search_artist') : ""}
-                      >${shouldShowDetails && artist ? artist : html`&nbsp;`}</div>
+                      ><span class="marquee-inner">${shouldShowDetails && artist ? artist : html`&nbsp;`}</span></div>
                   </div>
                 ` : nothing}
                 ${(!collapsed && !this._alternateProgressBar)


### PR DESCRIPTION
### Summary of Changes
- **Single-Line Details Constraint**: Fixed an issue where enabling `adaptive_text_targets: [details]` with long track titles caused multiline wrapping and expanded the overall card height beyond its configured baseline. Details title text is now constrained to 1 line (`--yamp-details-max-lines: 1`, `white-space: nowrap`, `text-overflow: ellipsis`) when adaptive scaling is active.
- **Marquee Auto-Scroll**: Implemented smooth marquee scrolling for overflowing track titles and artists in `.details`:
  - Starts with an initial ~2s pause for readability.
  - Smoothly scrolls to reveal the remainder of the title/artist at ~30px/sec.
  - Pauses for ~1.5s at the end.
  - Fades out, resets position to start, and fades back in to loop.
  - Automatically pauses on mouse hover and respects `prefers-reduced-motion`.
  - Zero overhead/animation when text fits within container width.

### User-Facing Impact
- Cards with large/scaled track details will no longer grow vertically or disrupt dashboard layouts.
- Long song and artist names remain fully readable through seamless marquee scrolling.

### Testing & Validation
- Validated with `npm run lint` and `npm run format:check` (0 errors).
- Built production bundle with `rollup -c` and verified in Home Assistant.