### PR TITLE
Fix false ellipsis on short track titles with adaptive details

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -92,6 +92,8 @@ export const yampCardStyles = css`
     --yamp-details-scale: var(--yamp-text-scale-details, 1);
     --yamp-details-line-height: 1.2;
     --yamp-details-max-lines: 3;
+    --yamp-details-line-clamp: 3;
+    --yamp-details-display: -webkit-box;
     --yamp-details-white-space: normal;
     --yamp-section-bg: rgba(255, 255, 255, 0.02);
     --yamp-section-border: rgba(255, 255, 255, 0.1);
@@ -976,9 +978,9 @@ export const yampCardStyles = css`
     word-break: break-word;
     overflow: hidden;
     text-overflow: ellipsis;
-    display: -webkit-box;
+    display: var(--yamp-details-display, -webkit-box);
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: var(--yamp-details-max-lines, 3);
+    -webkit-line-clamp: var(--yamp-details-line-clamp, var(--yamp-details-max-lines, 3));
     padding-top: calc(8px * var(--yamp-details-scale, 1));
     padding-bottom: calc(4px * var(--yamp-details-scale, 1));
     margin-bottom: calc(-4px * var(--yamp-details-scale, 1));
@@ -997,7 +999,7 @@ export const yampCardStyles = css`
 
   .marquee-inner {
     display: inline-block;
-    white-space: nowrap;
+    white-space: inherit;
     max-width: 100%;
   }
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -4091,6 +4091,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this.style.setProperty("--yamp-details-line-height", detailLineHeight.toFixed(2));
     const detailMaxLines = detailActive ? 1 : 3;
     this.style.setProperty("--yamp-details-max-lines", detailMaxLines.toString());
+    this.style.setProperty("--yamp-details-line-clamp", detailActive ? "unset" : "3");
+    this.style.setProperty("--yamp-details-display", detailActive ? "block" : "-webkit-box");
     this.style.setProperty("--yamp-details-white-space", detailActive ? "nowrap" : "normal");
     const lyricsActive = !!targetSet?.has("lyrics");
     this.style.setProperty("--yamp-text-scale-lyrics", lyricsActive ? safeDetailsScale.toFixed(2) : "1");


### PR DESCRIPTION
### Summary
Fixes an issue where short, single-row track titles were prematurely truncated with an ellipsis (`...`) when `adaptive_text_targets` includes `details`.

### Problem & Cause
When `adaptive_text_targets` was configured with `details`, `--yamp-details-max-lines: 1` applied CSS `-webkit-line-clamp: 1` on `.details .title`. In WebKit/Chromium engines, `-webkit-line-clamp: 1` evaluates vertical box height against a single line-height threshold. Because `.details .title` includes vertical padding (scaled by `--yamp-details-scale`) and an `inline-block` inner span, the browser falsely detected a vertical height overflow and appended trailing ellipses (`...`), even when the track title had plenty of horizontal room to render.

### Solution
* **Block Truncation for Single-Line Mode**: Updated `_setAdaptiveTextVars` to set `--yamp-details-display: block` and `--yamp-details-line-clamp: unset` when adaptive details is active, disabling the vertical line-clamp calculation while preserving horizontal `text-overflow: ellipsis`.
* **Preserved Marquee & Multi-Line Modes**:
  * Longer titles that exceed card width (`overflow > 4px`) continue to trigger horizontal marquee auto-scrolling (`data-marquee="true"`).
  * Multi-line mode (when `details` is not in `adaptive_text_targets`) retains `display: -webkit-box` and `-webkit-line-clamp: 3` with `white-space: normal`.
  * `.marquee-inner` now uses `white-space: inherit` to support both single-line and multi-line modes cleanly.

### User-Facing Changes
* Short track titles and single-word titles render completely without false trailing `...` when adaptive details scaling is enabled.