### PR TITLE
Fix: Layout inconsistencies and artwork overlap in lyrics mode

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -5,16 +5,16 @@ export const Z_LAYERS = Object.freeze({
   MEDIA_BACKGROUND: 0,
   MEDIA_OVERLAY: 0,
   LYRICS_OVERLAY: 1,
-  FLOATING_ELEMENT: 1,
-  STICKY_CHIPS: 1,
-  ACCENT_FOREGROUND: 1,
-  FLOATING_CONTROLS: 1,
-  OVERLAY_BASE: 2,
-  MODAL_BACKDROP: 2,
-  MODAL_TOAST: 2,
-  SEARCH_SLIDE_OUT: 1,
-  SEARCH_SUCCESS: 1,
-  VOLUME_OVERLAY: 3,
+  FLOATING_ELEMENT: 3,
+  STICKY_CHIPS: 3,
+  ACCENT_FOREGROUND: 3,
+  FLOATING_CONTROLS: 3,
+  OVERLAY_BASE: 4,
+  MODAL_BACKDROP: 4,
+  MODAL_TOAST: 4,
+  SEARCH_SLIDE_OUT: 3,
+  SEARCH_SUCCESS: 3,
+  VOLUME_OVERLAY: 5,
 });
 
 const LYRICS_MASK_GRADIENT = css`linear-gradient(to bottom, transparent 0px, black 30px, black calc(100% - 30px), transparent 100%)`;
@@ -302,16 +302,17 @@ export const yampCardStyles = css`
   }
 
   .yamp-card-inner[data-lyrics-active="true"] .full-bleed-artwork-fade {
+    z-index: ${Z_LAYERS.LYRICS_OVERLAY + 1};
     background: linear-gradient(
       to bottom,
       transparent 0%,
       color-mix(
           in srgb,
-          var(--ha-card-background, var(--card-background-color, #000)) 40%,
+          var(--ha-card-background, var(--card-background-color, var(--card-bg, #000))) 40%,
           transparent
         )
         55%,
-      var(--ha-card-background, var(--card-background-color, #000)) 100%
+      var(--ha-card-background, var(--card-background-color, var(--card-bg, #000))) 100%
     );
   }
 
@@ -963,7 +964,7 @@ export const yampCardStyles = css`
     font-size: calc(1em * var(--yamp-details-scale, 1));
     flex-shrink: 0;
     position: relative;
-    z-index: ${Z_LAYERS.LYRICS_OVERLAY + 1};
+    z-index: ${Z_LAYERS.FLOATING_ELEMENT};
   }
 
   .details .title {
@@ -1175,7 +1176,7 @@ export const yampCardStyles = css`
     gap: 12px;
     padding: 4px 16px;
     position: relative;
-    z-index: ${Z_LAYERS.LYRICS_OVERLAY + 1};
+    z-index: ${Z_LAYERS.FLOATING_CONTROLS};
   }
 
   .controls-row.adaptive {
@@ -1356,7 +1357,7 @@ export const yampCardStyles = css`
     padding-right: 24px;
     box-sizing: border-box;
     position: relative;
-    z-index: ${Z_LAYERS.LYRICS_OVERLAY + 1};
+    z-index: ${Z_LAYERS.FLOATING_ELEMENT};
   }
 
   .progress-bar {
@@ -1392,7 +1393,7 @@ export const yampCardStyles = css`
     align-items: center;
     padding: 10px 16px 14px 16px;
     position: relative;
-    z-index: ${Z_LAYERS.LYRICS_OVERLAY + 1};
+    z-index: ${Z_LAYERS.FLOATING_CONTROLS};
   }
 
   /* Remove flex:1 since we are using grid columns */
@@ -1784,16 +1785,20 @@ export const yampCardStyles = css`
   }
 
   .yamp-card-inner[data-lyrics-active="true"] .card-lower-fade {
+    z-index: ${Z_LAYERS.LYRICS_OVERLAY + 1};
     background: linear-gradient(
       to bottom,
       transparent 0%,
+      transparent calc(100% - var(--yamp-lyrics-bottom-offset, 180px)),
       color-mix(
           in srgb,
-          var(--ha-card-background, var(--card-background-color, #000)) 40%,
+          var(--ha-card-background, var(--card-background-color, var(--card-bg, #000))) 85%,
           transparent
         )
-        55%,
-      var(--ha-card-background, var(--card-background-color, #000)) 100%
+        calc(100% - var(--yamp-lyrics-bottom-offset, 180px) + 30px),
+      var(--ha-card-background, var(--card-background-color, var(--card-bg, #000)))
+        calc(100% - var(--yamp-lyrics-bottom-offset, 180px) + 70px),
+      var(--ha-card-background, var(--card-background-color, var(--card-bg, #000))) 100%
     );
   }
 
@@ -4493,10 +4498,7 @@ export const lyricsStyles = css`
   :host {
     display: block;
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: -600px;
+    inset: 0;
     z-index: ${Z_LAYERS.LYRICS_OVERLAY};
     overflow: hidden;
     pointer-events: auto;
@@ -4508,10 +4510,10 @@ export const lyricsStyles = css`
 
   .lyrics-scroll-container {
     position: absolute;
-    top: 0;
+    top: var(--yamp-lyrics-top-offset, 0px);
     left: 0;
     right: 0;
-    bottom: 600px;
+    bottom: var(--yamp-lyrics-bottom-offset, 180px);
     box-sizing: border-box;
     overflow-y: auto;
     overflow-x: hidden;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -416,10 +416,6 @@ export const yampCardStyles = css`
     min-height: 48px;
   }
 
-  .yamp-card-inner[data-lyrics-active="true"] .card-artwork-spacer {
-    min-height: 80px;
-  }
-
   /* Media background */
   .media-bg-full {
     position: absolute;

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -680,6 +680,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._hideActiveEntityLabelOnIdle = false;
     this._currentDetailsScale = null;
     this._lastTitleLength = 0;
+    this._lastNonLyricsLowerContentHeight = null;
+    this._lowerControlsHeight = null;
 
     // Lyrics state
     this._massLyrics = []; // Array of parsed lyric objects { time, text }
@@ -4087,7 +4089,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       const isActive = !!targetSet?.has(target);
       this.style.setProperty(varName, isActive ? scaleString : "1");
     }
-    const detailActive = !!targetSet?.has("details");
+    const detailActive = !!targetSet?.has("details") && !this._lyricsActive;
     const safeDetailsScale = Number.isFinite(detailsScale) ? detailsScale : safeScale;
     const detailScaleString = detailActive ? safeDetailsScale.toFixed(2) : "1";
     const detailLineHeight = detailActive ? this._calculateDetailsLineHeight(safeDetailsScale) : 1.2;
@@ -4157,6 +4159,12 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const detailScale = this._calculateDetailsScale(width, height, scale, this._lastTitleLength || 0);
     const textScaleChanged = this._currentTextScale === null || Math.abs(this._currentTextScale - scale) > 0.01;
     const detailScaleChanged = this._currentDetailsScale === null || Math.abs(this._currentDetailsScale - detailScale) > 0.02;
+    if (!this._lyricsActive) {
+      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
+      if (lowerContentEl && lowerContentEl.offsetHeight > 50) {
+        this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
+      }
+    }
     if (textScaleChanged || detailScaleChanged) {
       this._currentTextScale = scale;
       this._currentDetailsScale = detailScale;
@@ -6529,6 +6537,30 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     // Volume overlay detection (Issue #252)
     this._handleVolumeOverlayDetection(changedProps);
 
+    if (changedProps.has("_lyricsActive")) {
+      if (this._adaptiveText) {
+        this._setAdaptiveTextVars(this._currentTextScale, undefined, this._currentDetailsScale);
+        this._updateMarquee();
+      }
+    }
+
+    if (!this._lyricsActive) {
+      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
+      if (lowerContentEl && lowerContentEl.offsetHeight > 50) {
+        this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
+      }
+    } else {
+      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
+      const detailsEl = this.shadowRoot?.querySelector('.details');
+      if (lowerContentEl && detailsEl) {
+        const controlsH = Math.round(lowerContentEl.getBoundingClientRect().bottom - detailsEl.getBoundingClientRect().top);
+        if (controlsH > 30 && this._lowerControlsHeight !== controlsH) {
+          this._lowerControlsHeight = controlsH;
+          this.requestUpdate();
+        }
+      }
+    }
+
     // Lyrics fetch trigger
     if (this._lyricsActive) {
       const activeState = this.metadataStateObj || this.currentActivePlaybackStateObj || this.currentPlaybackStateObj || this.currentStateObj;
@@ -8327,7 +8359,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const collapsedDetailsMinHeight = effectiveExtraSpace > 0
       ? Math.round(baseDetailsMinHeight + detailGrowth)
       : (effectiveExtraSpace < -20 ? 36 : baseDetailsMinHeight);
-    const detailsScale = (this._adaptiveTextTargets?.has("details")) ? (this._currentDetailsScale || 1) : 1;
+    const detailsScale = (this._adaptiveTextTargets?.has("details") && !this._lyricsActive) ? (this._currentDetailsScale || 1) : 1;
     const detailsMinHeight = Math.round((collapsed ? collapsedDetailsMinHeight : baseDetailsMinHeight) * detailsScale);
     let showCollapsedPlaceholder;
     const expandedHeightBaseline = 350;
@@ -8453,15 +8485,21 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     const volumeRowWillCollapse = isVolumeHiddenByConfig && !isCompactVolume && !hasLeadingControl && !hasRightPlaceholder;
 
-    const detailsHasAdaptiveText = this._adaptiveTextTargets?.has("details");
+    const detailsHasAdaptiveText = this._adaptiveTextTargets?.has("details") && !this._lyricsActive;
     this._lastSpacerRendered = !!(showCollapsedPlaceholder || (!collapsed && (!detailsHasAdaptiveText || hasSpacerContent)));
     this._lastVolumeRendered = !volumeRowWillCollapse;
 
-    const effectiveDetailsHeight = this.config.details_alignment === 'none' ? 0 : (detailsMinHeight || 48);
-    const lyricsBottomOffset = effectiveDetailsHeight +
+    const lowerControlsH = this._lowerControlsHeight || (
+      72 + // average unscaled details height
       (!this._alternateProgressBar ? 24 : 0) +
       (hideControlsNow ? 0 : 56) +
-      (volumeRowWillCollapse ? 0 : 56);
+      (volumeRowWillCollapse ? 0 : 56)
+    );
+    const spacerMarginBottom = 8; // details margin-top is 8px at scale 1.0
+    const lyricsSpacerHeight = this._lastNonLyricsLowerContentHeight != null
+      ? Math.max(48, Math.round(this._lastNonLyricsLowerContentHeight - lowerControlsH - spacerMarginBottom))
+      : 180;
+    const lyricsBottomOffset = lowerControlsH;
 
     return html`
         <ha-card class="yamp-card" 
@@ -8587,7 +8625,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                     @pointermove=${this._onTapAreaPointerMove}
                     @pointerup=${this._onTapAreaPointerUp}
                     @pointercancel=${this._onTapAreaPointerCancel}
-                    style="${this._getGestureStyles()}"
+                    style="${[
+                      this._lyricsActive ? `height: ${lyricsSpacerHeight}px; min-height: ${lyricsSpacerHeight}px; max-height: ${lyricsSpacerHeight}px; flex: none;` : '',
+                      this._getGestureStyles()
+                    ].filter(Boolean).join('; ')}"
                   >
                     ${useInsetArtwork && artworkUrl ? html`
                       <div style="position: absolute; ${needsArtworkTopPadding ? 'top: 20px; right: 0; bottom: 0; left: 0;' : 'inset: 0;'} display: flex; align-items: center; justify-content: center; pointer-events: none; box-sizing: border-box; padding: 0 5px;">
@@ -8615,7 +8656,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           detailStyleParts.push(`min-height:${detailsMinHeight}px`);
           if (!shouldShowDetails) detailStyleParts.push('opacity:0');
           if (!this._lastSpacerRendered) {
-            detailStyleParts.push('flex: 1');
+            if (!this._lyricsActive) {
+              detailStyleParts.push('flex: 1');
+            } else {
+              detailStyleParts.push('margin-top: auto');
+            }
             detailStyleParts.push('justify-content: flex-end');
           }
           const gestureStyles = this._getGestureStyles(this._isIdle);

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -6550,10 +6550,16 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
       }
     } else {
-      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
       const detailsEl = this.shadowRoot?.querySelector('.details');
-      if (lowerContentEl && detailsEl) {
-        const controlsH = Math.round(lowerContentEl.getBoundingClientRect().bottom - detailsEl.getBoundingClientRect().top);
+      if (detailsEl) {
+        let controlsH = detailsEl.offsetHeight;
+        const progressEl = this.shadowRoot?.querySelector('.progress-bar-container:not(.alternate)');
+        if (progressEl) controlsH += progressEl.offsetHeight;
+        const controlsRowEl = this.shadowRoot?.querySelector('.controls-row');
+        if (controlsRowEl) controlsH += controlsRowEl.offsetHeight;
+        const volumeRowEl = this.shadowRoot?.querySelector('.volume-row');
+        if (volumeRowEl) controlsH += volumeRowEl.offsetHeight;
+        
         if (controlsH > 30 && this._lowerControlsHeight !== controlsH) {
           this._lowerControlsHeight = controlsH;
           this.requestUpdate();

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8129,7 +8129,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     // We'll set useInsetArtwork again later with full collapsed context for rendering.
     const preCalcInsetArtwork = this._artworkObjectFit === "scaled-contain" || this._artworkObjectFit === "scaled-contain-alternate";
     // Extend artwork when configured, when chips are hidden inline (in_menu_on_idle + idle), or when using scaled-contain
-    const artworkFullBleed = this.config.extend_artwork === true || chipsHiddenInline || preCalcInsetArtwork;
+    const artworkFullBleed = this.config.extend_artwork === true || chipsHiddenInline || preCalcInsetArtwork || this._lyricsActive;
 
     // Calculate shuffle/repeat state from the active playback entity when available
     const mainStateForPlayback = this.currentStateObj;
@@ -8434,7 +8434,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     const activeArtworkFit = artworkObjectFit || this._artworkObjectFit;
     const isAlternateFit = activeArtworkFit === "scaled-contain-alternate";
-    const useInsetArtwork = (activeArtworkFit === "scaled-contain" || isAlternateFit) && !collapsed && !this._alwaysCollapsed;
+    const useInsetArtwork = (activeArtworkFit === "scaled-contain" || isAlternateFit) && !collapsed && !this._alwaysCollapsed && !this._lyricsActive;
     const hasSpacerContent =
       (useInsetArtwork && artworkUrl) ||
       (!useInsetArtwork && !artworkUrl && !idleImageUrl);
@@ -8450,13 +8450,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     const backgroundImageValue = (activeArtworkFit === "no_artwork")
       ? "none"
-      : (idleImageUrl || isAlternateFit)
+      : (idleImageUrl || (isAlternateFit && !this._lyricsActive))
         ? (idleImageUrl ? `url('${idleImageUrl}')` : "none")
         : artworkUrl
           ? `url('${artworkUrl}')`
           : "none";
     const hasBackgroundImage = backgroundImageValue !== "none";
-    const backgroundFilter = (artworkUrl && (this.config.blurred_artwork === true || (this.config.blurred_artwork !== false && (collapsed || (useInsetArtwork && activeArtworkFit === "scaled-contain")))))
+    const backgroundFilter = (artworkUrl && (this._lyricsActive || this.config.blurred_artwork === true || (this.config.blurred_artwork !== false && (collapsed || (useInsetArtwork && activeArtworkFit === "scaled-contain")))))
       ? "blur(18px) brightness(0.7) saturate(1.15)"
       : "none";
     let artworkPos = (typeof artworkObjectPosition !== 'undefined' ? artworkObjectPosition : null) || this.config.artwork_position || "top center";

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8399,8 +8399,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const useInsetArtwork = (activeArtworkFit === "scaled-contain" || isAlternateFit) && !collapsed && !this._alwaysCollapsed;
     const hasSpacerContent =
       (useInsetArtwork && artworkUrl) ||
-      (!useInsetArtwork && !artworkUrl && !idleImageUrl) ||
-      (this._lyricsActive && !this._isIdle);
+      (!useInsetArtwork && !artworkUrl && !idleImageUrl);
     // Add top padding to artwork spacer when scaled-contain and chips are not shown inline
     const needsArtworkTopPadding = (activeArtworkFit === "scaled-contain" || isAlternateFit) &&
       (showChipRow === "in_menu" || (hasSingleEntity && showChipRow !== "always"));
@@ -8458,6 +8457,12 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._lastSpacerRendered = !!(showCollapsedPlaceholder || (!collapsed && (!detailsHasAdaptiveText || hasSpacerContent)));
     this._lastVolumeRendered = !volumeRowWillCollapse;
 
+    const effectiveDetailsHeight = this.config.details_alignment === 'none' ? 0 : (detailsMinHeight || 48);
+    const lyricsBottomOffset = effectiveDetailsHeight +
+      (!this._alternateProgressBar ? 24 : 0) +
+      (hideControlsNow ? 0 : 56) +
+      (volumeRowWillCollapse ? 0 : 56);
+
     return html`
         <ha-card class="yamp-card" 
           style=${(hasCustomCardHeight && (!collapsed || this._alwaysCollapsed)) ? `height:${customCardHeight}px;` : nothing}>
@@ -8496,6 +8501,29 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 </svg>
               </div>
             ` : nothing}
+            ${(this._lyricsActive && !this._isIdle) ? html`
+              <yamp-lyrics-view
+                data-match-theme="${String(this.config.match_theme === true)}"
+                data-artwork-fit="${activeArtworkFit}"
+                .hass=${this.hass}
+                .lyrics=${this._massLyrics}
+                .position=${pos}
+                .loading=${this._fetchingLyrics}
+                .error=${this._lyricsError}
+                .activeThemeColor=${this.config.match_theme === true ? "var(--custom-accent, var(--state-media_player-active-color, var(--primary-color, #ffffff)))" : "var(--custom-accent, #ffffff)"}
+                .mode=${this._isCurrentlyPlayingRadio() ? 'text' : (this.config.lyrics_mode || 'default')}
+                .preRoll=${this.config.lyrics_pre_roll ?? 0}
+                @pointerdown=${this._onTapAreaPointerDown}
+                @pointermove=${this._onTapAreaPointerMove}
+                @pointerup=${this._onTapAreaPointerUp}
+                @pointercancel=${this._onTapAreaPointerCancel}
+                style="${[
+                  `--yamp-lyrics-top-offset: ${showChipsInline ? 48 : 0}px`,
+                  `--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px`,
+                  this._getGestureStyles()
+                ].filter(Boolean).join('; ')}"
+              ></yamp-lyrics-view>
+            ` : nothing}
             ${chipsHiddenInline
         ? html`${this._renderInlineActionRow(rowActions)}${this._renderInlineChipRow(showChipsInline, chipsHiddenInline)}`
         : html`${this._renderInlineChipRow(showChipsInline, chipsHiddenInline)}${this._renderInlineActionRow(rowActions)}`}
@@ -8521,7 +8549,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         return styles.join('; ');
       })()}"
               ></div>
-              ${!(dimIdleFrame || this._isIdle) && (!useInsetArtwork || this._lyricsActive) ? html`<div class="card-lower-fade"></div>` : nothing}
+              ${!(dimIdleFrame || this._isIdle) && (!useInsetArtwork || this._lyricsActive) ? html`<div class="card-lower-fade" style="--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px;"></div>` : nothing}
               <div class="card-lower-content${collapsed ? ' collapsed transitioning' : ' transitioning'}${collapsed && artworkUrl && collapsedArtworkSize > 0 ? ' has-artwork' : ''}" style="${(() => {
         if (!hideControlsNow) return '';
         return collapsed
@@ -8569,22 +8597,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                           style="max-width: 100%; max-height: 100%; object-fit: contain; pointer-events: none;" 
                         />
                       </div>
-                    ` : nothing}
-
-
-                    ${(this._lyricsActive && !this._isIdle) ? html`
-                      <yamp-lyrics-view
-                        data-match-theme="${String(this.config.match_theme === true)}"
-                        data-artwork-fit="${activeArtworkFit}"
-                        .hass=${this.hass}
-                        .lyrics=${this._massLyrics}
-                        .position=${pos}
-                        .loading=${this._fetchingLyrics}
-                        .error=${this._lyricsError}
-                        .activeThemeColor=${this.config.match_theme === true ? "var(--custom-accent, var(--state-media_player-active-color, var(--primary-color, #ffffff)))" : "var(--custom-accent, #ffffff)"}
-                        .mode=${this._isCurrentlyPlayingRadio() ? 'text' : (this.config.lyrics_mode || 'default')}
-                        .preRoll=${this.config.lyrics_pre_roll ?? 0}
-                      ></yamp-lyrics-view>
                     ` : nothing}
                   </div>
                 ` : nothing}


### PR DESCRIPTION
This Pull Request resolves several visual layout bugs that occurred when activating Lyrics mode across various configurations, particularly those enforcing strict `card_height`, using `adaptive_text`, or configuring inset artwork properties (`scaled-contain-alternate`).

### Changes Made

- **Migrated Lyrics View to Absolute Overlay**: Moved `<yamp-lyrics-view>` up the DOM tree and adjusted `Z_LAYERS` to allow it to overlay the artwork spacer directly, utilizing `backdrop-filter` for the frosted-glass aesthetic.
- **Dynamic Controls Height Calculation**: Replaced the flawed container bounding-box measurement (which caused a feedback loop and collapsed the card due to empty flex space) with a precise summation of the physical `offsetHeight` values of the individual lower controls (`.details`, `.progress-bar-container`, `.controls-row`, `.volume-row`).
- **Fixed Inset Artwork Overlap**: Updated the rendering logic for `artworkFullBleed`, `useInsetArtwork`, and `backgroundImageValue` to prioritize lyrics mode. When lyrics are active, the background is forced to full-bleed blur and the inset artwork widget is hidden, regardless of the `extend_artwork: false` or `scaled-contain-alternate` configuration.

### User Facing Impact
- The overall card height now strictly remains invariant when toggling lyrics ON/OFF, even if the user has defined a fixed `card_height`.
- Active lyrics remain properly centered and legible over a frosted background.
- Floating inset album covers no longer awkwardly overlay the scrolling lyrics text.