### PR TITLE
fix: resolve sub-pixel anti-aliasing blur for custom bottom action icons

### DIFF
--- a/src/volume-row.js
+++ b/src/volume-row.js
@@ -62,7 +62,7 @@ export function renderVolumeRow({
             hideVolume || isRemoteVolumeEntity
               ? "visibility:hidden; opacity:0; pointer-events:none;"
               : ""
-          }"
+          } display: flex; align-items: center; justify-content: center;"
         >
           ${
             muteSlotTemplate !== nothing


### PR DESCRIPTION
## Intent
This PR fixes a visual inconsistency where custom bottom action icons (such as those replacing the mute button) would appear slightly thicker or blurrier than adjacent stock icons (like the search button) in WebKit/Blink browsers.

## User Facing Changes
- Custom bottom actions now visually match the exact optical sizing and stroke weight of stock action icons perfectly.

## Details
This was caused by a sub-pixel rendering artifact. The `muteSlotTemplate` was wrapped in a standard `div` instead of a flex container. Because the inner `ha-icon` button was `inline-flex`, it rested on the text baseline, causing a fractional pixel shift (e.g. 0.5px). When an SVG is offset by a fractional pixel in Chrome/Safari, the anti-aliasing engine blurs the edges across two pixels, which artificially makes the SVG stroke look noticeably thicker. Adding `display: flex; align-items: center; justify-content: center;` to the wrapper div ensures perfect alignment to the pixel grid.