### PR TITLE
feat: display clickable album details with quick-search and generalize favorite button detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Below you will find a list of all configuration options.
 | `adaptive_controls`        | boolean      | No           | `false`     | Control buttons expand to fill extra horizontal space, giving you larger tap targets when there’s room |
 | `control_layout`           | choice       | No           | `classic`   | `classic` keeps the legacy evenly sized controls, while `modern` adopts Home Assistant’s more-info layout (shuffle/prev/play/next/repeat) and moves the favorite and power buttons along the bottom of the card ([Supports Templates](#template-support)) |
 | `swap_pause_for_stop`      | boolean      | No           | `false`     | Only for `control_layout: modern`; when `true`, the center pause button is replaced with a stop button |
+| `show_album`               | boolean      | No           | `true`      | Display the album name next to the artist in player details (clickable to quick-browse album tracks) |
 | `adaptive_text`            | boolean/array| No           | `false`     | Set to `true` to scale all text, or supply a list of targets (`details`, `menu`, `action_chips`) to choose exactly which sections adapt |
 | `hide_active_entity_label` | boolean      | No           | `false`     | Hide the small entity name label shown at the bottom center when chips are placed in the menu |
 | `details_alignment`        | choice       | No           | `left`      | Align the track title and artist (`left`, `center`, `right`). Set to `none` to completely hide the details section. |

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -159,6 +159,7 @@ export const CARD_CONFIG_DEFAULTS = Object.freeze({
   hide_active_entity_label: false,
   hide_active_entity_label_on_idle: false,
   swap_pause_for_stop: false,
+  show_album: true,
 });
 
 /**

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -126,6 +126,7 @@ export default {
       hide_search_headers_on_idle: "Sucheingabe und Filter im Leerlauf ausblenden.",
       disable_mass: "Optionale Mass Queue Integration deaktivieren, auch wenn sie installiert ist.",
       swap_pause_stop: "Pause-Taste durch Stop-Taste im modernen Layout ersetzen.",
+      show_album: "Den Albumnamen neben dem Interpreten in den Player-Details anzeigen.",
       adaptive_controls: "Wiedergabetasten an verfügbaren Platz anpassen.",
       hide_menu_player: "Entitäts-Label unten ausblenden, wenn Chips im Menü sind.",
       hide_reorder_progress:
@@ -226,6 +227,7 @@ export default {
       progress_bar_height: "Fortschrittsbalkenhöhe",
       display_timestamps: "Zeitstempel anzeigen",
       swap_pause_stop: "Pause durch Stop ersetzen",
+      show_album: "Albumname anzeigen",
       adaptive_controls: "Adaptive Tastengröße",
       hide_active_entity: "Aktives Entitäts-Label ausblenden",
       hide_active_entity_on_idle: "Aktive Entitätsbeschriftung im Leerlauf ausblenden",
@@ -487,6 +489,7 @@ export default {
       audiobook: "Hörbuch",
     },
     search_artist: "Nach diesem Künstler suchen",
+    search_album: "Titel von diesem Album durchsuchen",
     browse_album: "Albentitel von {album} durchsuchen",
     play_collection: "Diese Sammlung abspielen",
     play_collection_error: "Diese Sammlung kann nicht direkt abgespielt werden",

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -152,6 +152,7 @@ export default {
       hide_search_headers_on_idle: "Hide search input and filters when the player is idle.",
       disable_mass: "Disable the optional Mass Queue integration even if it is installed.",
       swap_pause_stop: "Replace the pause button with stop while using the modern layout.",
+      show_album: "Display the album name next to the artist in the player details.",
       adaptive_controls: "Let the playback buttons grow or shrink to fit the available space.",
       hide_menu_player:
         "When chips live in the menu, hide the entity label at the bottom of the card.",
@@ -254,6 +255,7 @@ export default {
       progress_bar_height: "Progress Bar Height",
       display_timestamps: "Display Timestamps",
       swap_pause_stop: "Swap Pause with Stop",
+      show_album: "Show Album Name",
       adaptive_controls: "Adaptive Control Size",
       hide_active_entity: "Hide Active Entity Label",
       hide_active_entity_on_idle: "Hide Active Entity Label on Idle",
@@ -512,6 +514,7 @@ export default {
       audiobook: "Audiobook",
     },
     search_artist: "Search for this artist",
+    search_album: "Browse tracks from this album",
     browse_album: "Browse tracks from {album}",
     play_collection: "Play this collection",
     play_collection_error: "Unable to play this collection directly",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -116,6 +116,7 @@ export default {
       hide_search_headers_on_idle: "Ocultar encabezados de búsqueda en inactividad.",
       disable_mass: "Desactivar integración con Mass Queue.",
       swap_pause_stop: "Cambiar pausa por stop en diseño moderno.",
+      show_album: "Mostrar el nombre del álbum junto al artista en los detalles del reproductor.",
       adaptive_controls: "Permitir que los botones se adapten al espacio.",
       hide_menu_player: "Ocultar nombre de entidad cuando está en el menú.",
       hide_reorder_progress:
@@ -213,6 +214,7 @@ export default {
       progress_bar_height: "Altura de la barra de progreso",
       display_timestamps: "Mostrar sellos de tiempo",
       swap_pause_stop: "Cambiar Pausa por Stop",
+      show_album: "Mostrar nombre del álbum",
       adaptive_controls: "Tamaño adaptativo",
       hide_active_entity: "Ocultar nombre de entidad activa",
       hide_active_entity_on_idle: "Ocultar etiqueta de entidad activa al estar inactivo",
@@ -474,6 +476,7 @@ export default {
       audiobook: "Audiolibro",
     },
     search_artist: "Buscar este artista",
+    search_album: "Explorar pistas de este álbum",
     browse_album: "Explorar pistas de {album}",
     play_collection: "Reproducir esta colección",
     play_collection_error: "No se puede reproducir esta colección directamente",

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -121,6 +121,7 @@ export default {
       hide_search_headers_on_idle: "Masquer la recherche et les filtres en mode veille.",
       disable_mass: "Désactiver l'intégration Mass Queue.",
       swap_pause_stop: "Remplacer le bouton pause par stop en mode moderne.",
+      show_album: "Afficher le nom de l'album à côté de l'artiste dans les détails du lecteur.",
       adaptive_controls: "Laisser les boutons s'adapter à l'espace disponible.",
       hide_menu_player:
         "Masquer l'étiquette de l'entité en bas quand les jetons sont dans le menu.",
@@ -218,6 +219,7 @@ export default {
       progress_bar_height: "Hauteur de la barre de progression",
       display_timestamps: "Afficher les horodatages",
       swap_pause_stop: "Remplacer Pause par Stop",
+      show_album: "Afficher le nom de l'album",
       adaptive_controls: "Taille adaptative",
       hide_active_entity: "Masquer l'étiquette active",
       hide_active_entity_on_idle: "Masquer l'étiquette de l'entité active en mode veille",
@@ -479,6 +481,7 @@ export default {
       audiobook: "Livre audio",
     },
     search_artist: "Chercher cet artiste",
+    search_album: "Parcourir les pistes de cet album",
     browse_album: "Parcourir les titres de {album}",
     play_collection: "Lire cette collection",
     play_collection_error: "Impossible de lire cette collection directement",

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -115,6 +115,7 @@ export default {
       hide_search_headers_on_idle: "Nascondi la ricerca e i filtri quando inattivo.",
       disable_mass: "Disabilita integrazione Mass Queue.",
       swap_pause_stop: "Sostituisci pausa con stop nel design moderno.",
+      show_album: "Visualizza il nome dell'album accanto all'artista nei dettagli del lettore.",
       adaptive_controls: "Permetti ai pulsanti di adattarsi allo spazio.",
       hide_menu_player: "Nascondi nome entità quando è nel menu.",
       hide_reorder_progress:
@@ -211,6 +212,7 @@ export default {
       progress_bar_height: "Altezza barra di avanzamento",
       display_timestamps: "Mostra timestamp",
       swap_pause_stop: "Sostituisci Pausa con Stop",
+      show_album: "Mostra nome album",
       adaptive_controls: "Dimensione adattativa",
       hide_active_entity: "Nascondi nome entità attiva",
       hide_active_entity_on_idle: "Nascondi etichetta entità attiva quando inattivo",
@@ -472,6 +474,7 @@ export default {
       audiobook: "Audiolibro",
     },
     search_artist: "Cerca questo artista",
+    search_album: "Sfoglia i brani di questo album",
     browse_album: "Sfoglia i brani di {album}",
     play_collection: "Riproduci questa collezione",
     play_collection_error: "Impossibile riprodurre direttamente questa collezione",

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -128,6 +128,7 @@ export default {
       disable_mass:
         "Schakel de optionele Mass Queue integratie uit, zelfs als deze is geïnstalleerd.",
       swap_pause_stop: "Vervang de pauzeknop door stop bij gebruik van de moderne lay-out.",
+      show_album: "Toon de albumnaam naast de artiest in de spelerdetails.",
       adaptive_controls:
         "Laat de afspeelknoppen groeien of krimpen om in de beschikbare ruimte te passen.",
       hide_menu_player:
@@ -237,6 +238,7 @@ export default {
       progress_bar_height: "Hoogte voortgangsbalk",
       display_timestamps: "Tijdstempels Weergeven",
       swap_pause_stop: "Pauze vervangen door Stop",
+      show_album: "Toon albumnaam",
       adaptive_controls: "Adaptieve Knoppen Grootte",
       hide_active_entity: "Label van Actieve Entiteit verbergen",
       hide_active_entity_on_idle: "Actieve entiteitslabel verbergen bij inactiviteit",
@@ -498,6 +500,7 @@ export default {
       audiobook: "Luisterboek",
     },
     search_artist: "Zoek naar deze artiest",
+    search_album: "Blader door nummers van dit album",
     browse_album: "Tracks van {album} doorzoeken",
     play_collection: "Speel deze collectie af",
     play_collection_error: "Kan deze collectie niet direct afspelen",

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -115,6 +115,7 @@ export default {
       hide_search_headers_on_idle: "Ocultar pesquisa e filtros quando inativo.",
       disable_mass: "Desativar integração Mass Queue.",
       swap_pause_stop: "Substituir pausa por stop no design moderno.",
+      show_album: "Exibir o nome do álbum ao lado do artista nos detalhes do reprodutor.",
       adaptive_controls: "Permitir que os botões se adaptem ao espaço.",
       hide_menu_player: "Ocultar nome da entidade quando no menu.",
       hide_reorder_progress:
@@ -212,6 +213,7 @@ export default {
       progress_bar_height: "Altura da barra de progresso",
       display_timestamps: "Mostrar carimbos de tempo",
       swap_pause_stop: "Substituir Pausa por Stop",
+      show_album: "Mostrar nome do álbum",
       adaptive_controls: "Tamanho adaptativo",
       hide_active_entity: "Ocultar nome da entidade ativa",
       hide_active_entity_on_idle: "Ocultar etiqueta de entidade ativa quando inativo",
@@ -473,6 +475,7 @@ export default {
       audiobook: "Audiolivro",
     },
     search_artist: "Procurar este artista",
+    search_album: "Navegar pelas faixas deste álbum",
     browse_album: "Explorar faixas de {album}",
     play_collection: "Reproduzir esta coleção",
     play_collection_error: "Não é possível reproduzir esta coleção diretamente",

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -125,6 +125,7 @@ export default {
       disable_mass: "Deaktivovať voliteľnú integráciu Mass Queue, aj keď je nainštalovaná.",
       swap_pause_stop:
         "Nahradiť tlačidlo pauzy tlačidlom zastavenia pri použití moderného rozloženia.",
+      show_album: "Zobraziť názov albumu vedľa interpreta v podrobnostiach prehrávača.",
       adaptive_controls: "Umožniť tlačidlám prehrávania meniť veľkosť podľa dostupného priestoru.",
       hide_menu_player: "Keď sú čipy v menu, skryť názov entity v spodnej časti karty.",
       hide_reorder_progress:
@@ -228,6 +229,7 @@ export default {
       progress_bar_height: "Výška indikátora priebehu",
       display_timestamps: "Zobraziť časové údaje",
       swap_pause_stop: "Vymeniť pauzu za stop",
+      show_album: "Zobraziť názov albumu",
       adaptive_controls: "Adaptívna veľkosť ovládania",
       hide_active_entity: "Skryť štítok aktívnej entity",
       hide_active_entity_on_idle: "Skryť štítok aktívnej entity pri nečinnosti",
@@ -489,6 +491,7 @@ export default {
       audiobook: "Audiokniha",
     },
     search_artist: "Hľadať tohto interpreta",
+    search_album: "Prehľadávať skladby z tohto albumu",
     browse_album: "Prehľadávať skladby z {album}",
     play_collection: "Prehrať túto kolekciu",
     play_collection_error: "Túto kolekciu nie je možné prehrať priamo",

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -119,6 +119,7 @@ export default {
       hide_search_headers_on_idle: "Skrij iskalno polje in filtre med mirovanjem.",
       disable_mass: "Onemogoči integracijo Mass Queue.",
       swap_pause_stop: "Zamenjaj gumb pavze z gumbom zaustavitve med uporabo moderne postavitve.",
+      show_album: "Prikaži ime albuma zraven izvajalca v podrobnostih predvajalnika.",
       adaptive_controls: "Prilagodi velikost gumbov glede na prostor.",
       hide_menu_player: "Skrij oznako entitete v meniju.",
       hide_reorder_progress:
@@ -210,6 +211,7 @@ export default {
       progress_bar_height: "Višina vrstice napredka",
       display_timestamps: "Prikaži časovne oznake",
       swap_pause_stop: "Zamenjaj pavzo z zaustavitvijo",
+      show_album: "Prikaži ime albuma",
       adaptive_controls: "Prilagodljiva velikost gumbov",
       hide_active_entity: "Skrij oznako aktivne entitete",
       hide_active_entity_on_idle: "Skrij oznako aktivne entitete ob mirovanju",
@@ -471,6 +473,7 @@ export default {
       audiobook: "Zvočna knjiga",
     },
     search_artist: "Išči tega izvajalca",
+    search_album: "Prebrskaj skladbe iz tega albuma",
     browse_album: "Prebrskaj skladbe iz {album}",
     play_collection: "Predvajaj to zbirko",
     play_collection_error: "Te zbirke ni mogoče predvajati neposredno",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -222,6 +222,7 @@ export interface YampCardConfig {
   hide_active_entity_label?: boolean;
   hide_active_entity_label_on_idle?: boolean;
   swap_pause_for_stop?: boolean;
+  show_album?: boolean;
   [key: string]: any;
 }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -3608,13 +3608,15 @@ export const yampCardStyles = css`
     border-bottom: none;
   }
 
-  /* Clickable artist */
-  .clickable-artist {
+  /* Clickable artist and album */
+  .clickable-artist,
+  .clickable-album {
     cursor: pointer;
   }
 
   @media (hover: hover) {
-    .clickable-artist:hover {
+    .clickable-artist:hover,
+    .clickable-album:hover {
       text-decoration: underline;
     }
   }

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -2863,6 +2863,17 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         <div class="form-row">
           <div>
             <ha-switch
+              id="show-album-toggle"
+              .checked=${this._config.show_album ?? true}
+              @change=${(e) => this._updateConfig("show_album", e.target.checked)}
+            ></ha-switch>
+            <span>${localize("editor.labels.show_album")}</span>
+          </div>
+          <div class="config-subtitle">${localize("editor.subtitles.show_album")}</div>
+        </div>
+        <div class="form-row">
+          <div>
+            <ha-switch
               id="hide-active-entity-label-toggle"
               .checked=${this._config.hide_active_entity_label ?? false}
               @change=${(e) => this._updateConfig("hide_active_entity_label", e.target.checked)}

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -255,6 +255,15 @@ export function findAssociatedButtonEntities(hass, maEntityId) {
           reason: "name_similarity",
         });
       }
+      // Check for entity ID match (e.g., button.amzn_echo_show_5_favorite for media_player.amzn_echo_show_5)
+      else if (entityId.toLowerCase().includes(maEntityId.split(".")[1].toLowerCase())) {
+        buttonEntities.push({
+          entity_id: entityId,
+          friendly_name: buttonFriendlyName,
+          device_class: state.attributes.device_class,
+          reason: "entity_id_match",
+        });
+      }
     }
   }
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1484,6 +1484,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const artist = activeObj?.attributes?.media_artist || "";
     if (!album) return;
 
+    this._openedSearchFromNowPlaying = true;
+
     // Open overlay + search sheet
     this._showEntityOptions = true;
     this._showSearchInSheet = true;
@@ -1634,6 +1636,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   _hideSearchSheetInOptions() {
     // In dedicated search mode, never close the search
     if (this._cardType === "search" || this._cardType === "up_next") return;
+    this._openedSearchFromNowPlaying = false;
     this._showSearchInSheet = false;
     this._searchError = "";
     this._searchResults = [];
@@ -2481,6 +2484,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._searchMediaClassFilter = previousLevel.filter || 'all';
 
     if (this._searchHierarchy.length === 0) {
+      if (this._openedSearchFromNowPlaying) {
+        this._openedSearchFromNowPlaying = false;
+        this._closeEntityOptions();
+        return;
+      }
       this._searchBreadcrumb = "";
       this._doSearch(this._searchMediaClassFilter === 'all' ? null : this._searchMediaClassFilter);
     } else {
@@ -10453,6 +10461,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         if (this._cardType !== "remote_control") {
           this._showRemoteControl = false;
         }
+        this._openedSearchFromNowPlaying = false;
         this._searchInputAutoFocused = false;
         this._searchHierarchy = [];
         this._searchBreadcrumb = "";

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -270,13 +270,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const activeEntityId = this._getActivePlaybackEntityId(this._selectedIndex);
     if (!activeEntityId) return null;
 
-    // Check if the active entity is a Music Assistant entity
+    // Check if the active entity exists
     const activeState = this.hass?.states?.[activeEntityId];
-    if (!activeState || !isMusicAssistantEntity(activeState)) {
+    if (!activeState) {
       return null;
     }
 
-    // Active entity is Music Assistant, find its favorite button
+    // Find a favorite button associated with this entity
     const buttonEntities = this._findAssociatedButtonEntities(activeEntityId);
     const favoriteButton = buttonEntities.find(btn =>
       btn.friendly_name.toLowerCase().includes('favorite') ||

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1473,6 +1473,44 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       console.error('yamp: artist quick-search failed:', error);
     });
   }
+
+  /**
+   * Open the search sheet and navigate directly to the current album's tracks
+   * in hierarchical search view (only when media_album_name is present).
+   */
+  _searchAlbumFromNowPlaying() {
+    const activeObj = this.currentActivePlaybackStateObj || this.currentPlaybackStateObj || this.currentStateObj;
+    const album = activeObj?.attributes?.media_album_name || "";
+    const artist = activeObj?.attributes?.media_artist || "";
+    if (!album) return;
+
+    // Open overlay + search sheet
+    this._showEntityOptions = true;
+    this._showSearchInSheet = true;
+    this._searchInputAutoFocused = false;
+
+    // Reset search state
+    this._searchError = "";
+    this._searchResults = [];
+    this._searchQuery = "";
+    this._searchAttempted = false;
+    this._searchResultsByType = {};
+    this._currentSearchQuery = "";
+    this._searchHierarchy = [];
+    this._searchBreadcrumb = "";
+    this._usingMusicAssistant = false;
+    this._favoritesFilterActive = false;
+    this._recentlyPlayedFilterActive = false;
+    this._upcomingFilterActive = false;
+    this._recommendationsFilterActive = false;
+    this._initialFavoritesLoaded = false;
+
+    this.requestUpdate();
+
+    this._searchAlbumTracks(album, artist, null).catch((error) => {
+      console.error("yamp: album quick-search failed:", error);
+    });
+  }
   // Show search sheet inside entity options
   _showSearchSheetInOptions(mode = "default") {
     this._showSearchInSheet = true;
@@ -8268,6 +8306,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         ""
       )
       : "";
+    const showAlbum = this.config.show_album !== false;
+    const album = shouldShowDetails && showAlbum
+      ? (displaySource?.attributes?.media_album_name || "")
+      : "";
     this._lastTitleLength = title ? title.length : 0;
     if (this._adaptiveText) {
       this._updateAdaptiveTextScale(true);
@@ -8716,13 +8758,49 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                         <span class="marquee-inner">${shouldShowDetails && title ? title : html`&nbsp;`}</span>
                       </div>
                     `}
-                    <div
-                        class="artist ${shouldShowDetails && stateObj.attributes.media_artist ? 'clickable-artist' : ''}"
-                        @click=${() => {
-          if (shouldShowDetails && stateObj.attributes.media_artist) this._searchArtistFromNowPlaying();
-        }}
-                        title=${shouldShowDetails && stateObj.attributes.media_artist ? localize('search.search_artist') : ""}
-                      ><span class="marquee-inner">${shouldShowDetails && artist ? artist : html`&nbsp;`}</span></div>
+                    <div class="artist">
+                      <span class="marquee-inner">${shouldShowDetails ? (
+                        artist && album ? html`
+                          <span
+                            class="artist-name ${displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist ? "clickable-artist" : ""}"
+                            @click=${(e) => {
+                              if (displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) {
+                                e.stopPropagation();
+                                this._searchArtistFromNowPlaying();
+                              }
+                            }}
+                            title=${(displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) ? localize("search.search_artist") : ""}
+                          >${artist}</span><span class="artist-album-separator"> - </span><span
+                            class="album-name clickable-album"
+                            @click=${(e) => {
+                              e.stopPropagation();
+                              this._searchAlbumFromNowPlaying();
+                            }}
+                            title=${localize("search.search_album") || localize("search.browse_album", { "{album}": album })}
+                          >${album}</span>
+                        ` : artist ? html`
+                          <span
+                            class="artist-name ${displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist ? "clickable-artist" : ""}"
+                            @click=${(e) => {
+                              if (displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) {
+                                e.stopPropagation();
+                                this._searchArtistFromNowPlaying();
+                              }
+                            }}
+                            title=${(displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) ? localize("search.search_artist") : ""}
+                          >${artist}</span>
+                        ` : album ? html`
+                          <span
+                            class="album-name clickable-album"
+                            @click=${(e) => {
+                              e.stopPropagation();
+                              this._searchAlbumFromNowPlaying();
+                            }}
+                            title=${localize("search.search_album") || localize("search.browse_album", { "{album}": album })}
+                          >${album}</span>
+                        ` : html`&nbsp;`
+                      ) : html`&nbsp;`}</span>
+                    </div>
                   </div>
                 ` : nothing}
                 ${(!collapsed && !this._alternateProgressBar)

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8321,6 +8321,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const album = shouldShowDetails && showAlbum
       ? (displaySource?.attributes?.media_album_name || "")
       : "";
+    const hasSearchableArtist = !!(displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist);
+    const searchAlbumTitle = localize("search.search_album") || localize("search.browse_album", { "{album}": album });
+    const searchArtistTitle = hasSearchableArtist ? localize("search.search_artist") : "";
     this._lastTitleLength = title ? title.length : 0;
     if (this._adaptiveText) {
       this._updateAdaptiveTextScale(true);
@@ -8773,32 +8776,32 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                       <span class="marquee-inner">${shouldShowDetails ? (
                         artist && album ? html`
                           <span
-                            class="artist-name ${displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist ? "clickable-artist" : ""}"
+                            class="artist-name ${hasSearchableArtist ? "clickable-artist" : ""}"
                             @click=${(e) => {
-                              if (displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) {
+                              if (hasSearchableArtist) {
                                 e.stopPropagation();
                                 this._searchArtistFromNowPlaying();
                               }
                             }}
-                            title=${(displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) ? localize("search.search_artist") : ""}
+                            title=${searchArtistTitle}
                           >${artist}</span><span class="artist-album-separator"> - </span><span
                             class="album-name clickable-album"
                             @click=${(e) => {
                               e.stopPropagation();
                               this._searchAlbumFromNowPlaying();
                             }}
-                            title=${localize("search.search_album") || localize("search.browse_album", { "{album}": album })}
+                            title=${searchAlbumTitle}
                           >${album}</span>
                         ` : artist ? html`
                           <span
-                            class="artist-name ${displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist ? "clickable-artist" : ""}"
+                            class="artist-name ${hasSearchableArtist ? "clickable-artist" : ""}"
                             @click=${(e) => {
-                              if (displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) {
+                              if (hasSearchableArtist) {
                                 e.stopPropagation();
                                 this._searchArtistFromNowPlaying();
                               }
                             }}
-                            title=${(displaySource?.attributes?.media_artist || stateObj?.attributes?.media_artist) ? localize("search.search_artist") : ""}
+                            title=${searchArtistTitle}
                           >${artist}</span>
                         ` : album ? html`
                           <span
@@ -8807,7 +8810,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                               e.stopPropagation();
                               this._searchAlbumFromNowPlaying();
                             }}
-                            title=${localize("search.search_album") || localize("search.browse_album", { "{album}": album })}
+                            title=${searchAlbumTitle}
                           >${album}</span>
                         ` : html`&nbsp;`
                       ) : html`&nbsp;`}</span>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1465,6 +1465,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._upcomingFilterActive = false;
     this._recommendationsFilterActive = false;
     this._initialFavoritesLoaded = false;
+    this._lastSearchUsedServerFavorites = false;
 
     // Render, then run search
     this.requestUpdate();
@@ -1506,6 +1507,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._upcomingFilterActive = false;
     this._recommendationsFilterActive = false;
     this._initialFavoritesLoaded = false;
+    this._lastSearchUsedServerFavorites = false;
 
     this.requestUpdate();
 
@@ -1652,6 +1654,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._addToPlaylistTarget = null; // Clear playlist target
     this._dismissMenuAfterPlaylistAdd = false; // Clear dismiss flag
     this._recommendationsFilterActive = false;
+    this._lastSearchUsedServerFavorites = false;
     if (this._quickMenuInvoke) {
       this._showEntityOptions = false;
       this._quickMenuInvoke = false;
@@ -10466,6 +10469,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         this._searchHierarchy = [];
         this._searchBreadcrumb = "";
         this._addToPlaylistTarget = null;
+        this._lastSearchUsedServerFavorites = false;
         this.requestUpdate();
       }
       // Clear quick menu flag on any overlay close


### PR DESCRIPTION
## Summary

This PR introduces the `show_album` configuration option, enabling clickable album names alongside artist details with quick-search integration, and enhances favorite button entity detection.

### User-Facing Changes
- **Album Name in Player Details**: Added a new card configuration toggle `show_album` (defaults to `true`) to show the album name alongside the artist name (`Artist - Album`).
- **Interactive Quick Search**: Both artist and album are individually clickable with hover cues and localized tooltips. Clicking the album name directly opens hierarchical search filtered to that album's tracks.
- **Seamless Back Navigation**: Returning back from a now-playing-initiated quick search automatically closes the search overlay back to the media player.
- **Visual Editor Toggle**: Added a toggle for "Show album name" (`show_album`) in the visual card editor under display options.
- **Broader Favorite Button Support**: Generalized favorite button detection in `findAssociatedButtonEntities` by supporting entity ID matching (e.g. `button.<player>_favorite`) and removing Music Assistant dependency constraints.
- **Full Localization**: Added translations for `show_album` labels, subtitles, and search tooltips across all 9 supported languages (`de`, `en`, `es`, `fr`, `it`, `nl`, `pt`, `sk`, `sl`).
- **Documentation**: Updated `README.md`, `config-schema.js`, and `types.d.ts`.