### PR TITLE
fix: enable manual scrolling and optimize touch handling for plain text lyrics

### DIFF
--- a/src/lyrics-view.js
+++ b/src/lyrics-view.js
@@ -48,6 +48,11 @@ export class YampLyricsView extends LitElement {
     // Initial scroll position
     if (this._activeIndex !== -1) {
       this._scrollToActive("auto");
+    } else {
+      const container = this.renderRoot.querySelector(".lyrics-scroll-container");
+      if (container) {
+        container.scrollTop = 0;
+      }
     }
   }
 
@@ -56,8 +61,17 @@ export class YampLyricsView extends LitElement {
 
     if (changedProps.has("lyrics")) {
       this._activeIndex = -1;
-      // Re-scroll when lyrics change (new spacers or lines may have changed height)
-      requestAnimationFrame(() => this._scrollToActive("auto"));
+      const isUnsynced = !this.lyrics?.some((l) => l.time !== null);
+      const isUnsyncedMode = this.mode === "text";
+      if (isUnsynced || isUnsyncedMode) {
+        const container = this.renderRoot.querySelector(".lyrics-scroll-container");
+        if (container) {
+          container.scrollTo({ top: 0, behavior: "auto" });
+        }
+      } else {
+        // Re-scroll when lyrics change (new spacers or lines may have changed height)
+        requestAnimationFrame(() => this._scrollToActive("auto"));
+      }
     }
 
     if (changedProps.has("position") || changedProps.has("lyrics")) {
@@ -146,6 +160,7 @@ export class YampLyricsView extends LitElement {
     }
 
     const isUnsynced = !this.lyrics.some((l) => l.time !== null);
+    const isUnsyncedMode = this.mode === "text";
 
     return html`
       <div
@@ -153,10 +168,13 @@ export class YampLyricsView extends LitElement {
         @scroll=${this._handleScroll}
         style="--yamp-primary-color: ${this.activeThemeColor}"
       >
-        <div class="scroll-spacer"></div>
+        ${
+          !(isUnsynced || isUnsyncedMode)
+            ? html`<div class="scroll-spacer"></div>`
+            : html`<div class="plain-scroll-spacer-top"></div>`
+        }
         ${this.lyrics.map((lyric, index) => {
           const isActive = index === this._activeIndex;
-          const isUnsyncedMode = this.mode === "text";
           const isScrollMode = this.mode === "scroll";
 
           const classes = {
@@ -167,7 +185,11 @@ export class YampLyricsView extends LitElement {
           };
           return html` <div class="${classMap(classes)}">${lyric.text}</div> `;
         })}
-        <div class="scroll-spacer"></div>
+        ${
+          !(isUnsynced || isUnsyncedMode)
+            ? html`<div class="scroll-spacer"></div>`
+            : html`<div class="plain-scroll-spacer-bottom"></div>`
+        }
       </div>
     `;
   }

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1813,6 +1813,18 @@ export const yampCardStyles = css`
     height: 100%;
   }
 
+  .yamp-card-inner[data-lyrics-active="true"] .card-lower-content {
+    pointer-events: none;
+  }
+
+  .yamp-card-inner[data-lyrics-active="true"] .card-artwork-spacer {
+    pointer-events: none !important;
+  }
+
+  .yamp-card-inner[data-lyrics-active="true"] .card-lower-content > :not(.card-artwork-spacer) {
+    pointer-events: auto;
+  }
+
   .card-lower-content.transitioning .details,
   .card-lower-content.transitioning .card-artwork-spacer {
     transition: opacity 0.3s;
@@ -4507,6 +4519,7 @@ export const lyricsStyles = css`
     z-index: ${Z_LAYERS.LYRICS_OVERLAY};
     overflow: hidden;
     pointer-events: auto;
+    touch-action: pan-y;
     backdrop-filter: ${BLUR_5};
     -webkit-backdrop-filter: ${BLUR_5};
     background: var(--yamp-lyrics-bg, var(--yamp-overlay-bg));
@@ -4525,6 +4538,9 @@ export const lyricsStyles = css`
     padding-left: 12px;
     padding-right: 12px;
     scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+    overscroll-behavior-y: contain;
     mask-image: var(--yamp-lyrics-mask, ${LYRICS_MASK_GRADIENT});
     -webkit-mask-image: var(--yamp-lyrics-mask, ${LYRICS_MASK_GRADIENT});
     ${HIDE_SCROLLBAR}
@@ -4537,6 +4553,20 @@ export const lyricsStyles = css`
     flex: 0 0 50%;
     width: 100%;
     min-height: 50%;
+    pointer-events: none;
+  }
+
+  .plain-scroll-spacer-top {
+    flex: 0 0 24px;
+    width: 100%;
+    min-height: 24px;
+    pointer-events: none;
+  }
+
+  .plain-scroll-spacer-bottom {
+    flex: 0 0 32px;
+    width: 100%;
+    min-height: 32px;
     pointer-events: none;
   }
 

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8604,11 +8604,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             ` : nothing}
             ${(!useInsetArtwork && !artworkUrl && !idleImageUrl) ? html`
               <div class="media-artwork-placeholder"
-                @pointerdown=${this._onTapAreaPointerDown}
-                @pointermove=${this._onTapAreaPointerMove}
-                @pointerup=${this._onTapAreaPointerUp}
-                @pointercancel=${this._onTapAreaPointerCancel}
-                style="${this._getGestureStyles()}"
+                @pointerdown=${!this._lyricsActive ? this._onTapAreaPointerDown : nothing}
+                @pointermove=${!this._lyricsActive ? this._onTapAreaPointerMove : nothing}
+                @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
+                @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
+                style="${this._getGestureStyles(!this._lyricsActive)}"
               >
                 <svg
                   viewBox="0 0 184 184"
@@ -8633,14 +8633,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 .activeThemeColor=${this.config.match_theme === true ? "var(--custom-accent, var(--state-media_player-active-color, var(--primary-color, #ffffff)))" : "var(--custom-accent, #ffffff)"}
                 .mode=${this._isCurrentlyPlayingRadio() ? 'text' : (this.config.lyrics_mode || 'default')}
                 .preRoll=${this.config.lyrics_pre_roll ?? 0}
-                @pointerdown=${this._onTapAreaPointerDown}
-                @pointermove=${this._onTapAreaPointerMove}
-                @pointerup=${this._onTapAreaPointerUp}
-                @pointercancel=${this._onTapAreaPointerCancel}
                 style="${[
                   `--yamp-lyrics-top-offset: ${showChipsInline ? 48 : 0}px`,
-                  `--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px`,
-                  this._getGestureStyles()
+                  `--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px`
                 ].filter(Boolean).join('; ')}"
               ></yamp-lyrics-view>
             ` : nothing}
@@ -8679,15 +8674,15 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 ${collapsed && artworkUrl && collapsedArtworkSize > 0 && isValidArtworkUrl(artworkUrl) ? html`
                   <div
                     class="collapsed-artwork-container"
-                    @pointerdown=${this._onTapAreaPointerDown}
-                    @pointermove=${this._onTapAreaPointerMove}
-                    @pointerup=${this._onTapAreaPointerUp}
-                    @pointercancel=${this._onTapAreaPointerCancel}
+                    @pointerdown=${!this._lyricsActive ? this._onTapAreaPointerDown : nothing}
+                    @pointermove=${!this._lyricsActive ? this._onTapAreaPointerMove : nothing}
+                    @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
+                    @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
                     style="${[
           `background: linear-gradient(120deg, ${this._collapsedArtDominantColor}bb 60%, transparent 100%)`,
           collapsedExtraSpace > 0 ? `width:${Math.round(collapsedArtworkSize + 8)}px` : '',
           isCompact && collapsed ? 'top: -2px; height: auto !important; overflow: visible !important;' : '',
-          this._getGestureStyles()
+          this._getGestureStyles(!this._lyricsActive)
         ].filter(Boolean).join('; ')}"
                   >
                     <img
@@ -8703,13 +8698,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 ` : nothing}
                 ${this._lastSpacerRendered ? html`
                   <div class="card-artwork-spacer${showCollapsedPlaceholder ? ' show-placeholder' : ''}"
-                    @pointerdown=${this._onTapAreaPointerDown}
-                    @pointermove=${this._onTapAreaPointerMove}
-                    @pointerup=${this._onTapAreaPointerUp}
-                    @pointercancel=${this._onTapAreaPointerCancel}
+                    @pointerdown=${!this._lyricsActive ? this._onTapAreaPointerDown : nothing}
+                    @pointermove=${!this._lyricsActive ? this._onTapAreaPointerMove : nothing}
+                    @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
+                    @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
                     style="${[
-                      this._lyricsActive ? `height: ${lyricsSpacerHeight}px; min-height: ${lyricsSpacerHeight}px; max-height: ${lyricsSpacerHeight}px; flex: none;` : '',
-                      this._getGestureStyles()
+                      this._lyricsActive ? `height: ${lyricsSpacerHeight}px; min-height: ${lyricsSpacerHeight}px; max-height: ${lyricsSpacerHeight}px; flex: none; pointer-events: none;` : '',
+                      this._getGestureStyles(!this._lyricsActive)
                     ].filter(Boolean).join('; ')}"
                   >
                     ${useInsetArtwork && artworkUrl ? html`
@@ -8718,6 +8713,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                           class="inset-artwork"
                           src="${artworkUrl}" 
                           style="max-width: 100%; max-height: 100%; object-fit: contain; pointer-events: none;" 
+                          onload="this.style.display='block'"
+                          onerror="this.style.display='none'"
                         />
                       </div>
                     ` : nothing}


### PR DESCRIPTION
### Overview
Resolves an issue where plain text / unsynced lyrics could not be scrolled manually.

### Key Changes
- **Pointer Event Management**: Added `pointer-events: none` to `.card-lower-content` and `.card-artwork-spacer` during active lyrics so touch and mouse wheel scroll events pass directly to `<yamp-lyrics-view>`. All playback controls (`.details`, `.controls-row`, `.volume-row`) maintain `pointer-events: auto`.
- **Gesture Listener Suppression**: Suppressed card trigger gesture pointer bindings and styles on placeholders/spacers while lyrics are active (`!this._lyricsActive`).
- **Compact Spacers for Unsynced Lyrics**: Replaced the 50% vertical centering spacers with compact `.plain-scroll-spacer-top` (24px) and `.plain-scroll-spacer-bottom` (32px) when displaying plain text / unsynced lyrics.
- **Scroll Position Reset & Mobile Touch Support**: Ensured container `scrollTop` resets to `0` when new unsynced lyrics load, and added `touch-action: pan-y`, `-webkit-overflow-scrolling: touch`, and `overscroll-behavior-y: contain` to `.lyrics-scroll-container`.

### Validation
- Validated via `npm run validate` (ESLint, Prettier formatting check, TypeScript `tsc --noEmit`, and Rollup bundle).