### PR TITLE
fix: action placement template evaluation and schema registration

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -186,6 +186,7 @@ export const TEMPLATE_SUPPORTED_FIELDS = Object.freeze(
     "name",
     "icon",
     "action_in_menu",
+    "placement",
     "hide_controls",
     "lyrics",
     "title",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -127,7 +127,16 @@ export interface ActionConfig {
   icon?: string;
   name?: string;
   label?: string;
-  placement?: "chips" | "menu" | "both";
+  placement?:
+    | "chip"
+    | "menu"
+    | "hidden"
+    | "replace_search"
+    | "replace_power"
+    | "replace_mute"
+    | "replace_favorite"
+    | string;
+  in_menu?: boolean | "hidden" | string;
   alignment?: "left" | "right";
   hide_inactive?: boolean;
 }

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -673,6 +673,7 @@ export function getActionPlacement(action, index) {
     return action.placement;
   }
   // Legacy fallback
+  if (typeof action?.in_menu === "string") return action.in_menu;
   if (action?.in_menu === "hidden") return "hidden";
   if (action?.in_menu === true) return "menu";
   return "chip";

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1199,7 +1199,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       processItem('card', rawConfigData);
     } else if (type === 'action_in_menu') {
       const actions = rawConfigData || [];
-      actions.forEach((act, idx) => processItem(idx, act?.in_menu));
+      actions.forEach((act, idx) => processItem(idx, getActionPlacement(act, idx)));
 
       // Clean up any stale subscriptions for indices beyond the current actions length
       let checkIdx = actions.length;
@@ -8025,16 +8025,23 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           inMenuVal = cached;
         } else {
           // Fallback for initial render before subscription resolves
-          if (!actionTemplateFallbackContext) {
-            actionTemplateFallbackContext = {
-              ...this._getTemplateContext(),
-              state: this.hass?.states[this.currentEntityId]?.state || "unknown",
-              attributes: this.hass?.states[this.currentEntityId]?.attributes || {}
-            };
-          }
-          const resolved = resolveStringTemplateSync(this.hass, inMenuVal, actionTemplateFallbackContext);
-          if (resolved !== null) {
-            inMenuVal = resolved;
+          if (inMenuVal.trim().startsWith("[[[")) {
+            const evaluated = this._evaluateJsTemplate(inMenuVal);
+            if (evaluated !== undefined) {
+              inMenuVal = evaluated;
+            }
+          } else {
+            if (!actionTemplateFallbackContext) {
+              actionTemplateFallbackContext = {
+                ...this._getTemplateContext(),
+                state: this.hass?.states[this.currentEntityId]?.state || "unknown",
+                attributes: this.hass?.states[this.currentEntityId]?.attributes || {}
+              };
+            }
+            const resolved = resolveStringTemplateSync(this.hass, inMenuVal, actionTemplateFallbackContext);
+            if (resolved !== null) {
+              inMenuVal = resolved;
+            }
           }
         }
       }


### PR DESCRIPTION
### Summary of Changes

- **Template Subscription Synchronization**: Updated `_syncTemplateSubscriptions` in `src/yet-another-media-player.js` to process action placement via `getActionPlacement(act, idx)` rather than only inspecting legacy `act?.in_menu`. This ensures templates configured on `placement` (both Jinja2 and JS templates) are properly subscribed to and evaluated.
- **Synchronous JS Template Fallback**: Added immediate evaluation of JavaScript template strings (`[[[ ... ]]]`) via `_evaluateJsTemplate` in `localPlacement` for initial render before subscription resolutions finish.
- **Helper Consistency**: Updated `getActionPlacement` in `src/yamp-utils.js` to preserve string and template expressions passed in `in_menu`.
- **Schema & Types**: Added `placement` to `TEMPLATE_SUPPORTED_FIELDS` in `src/config-schema.js` and updated type declarations for `ActionConfig.placement` in `src/types.d.ts`.