### PR TITLE
feat: add animated playing indicator for instrumental gaps in synced lyrics

### DIFF
--- a/src/lyrics-parser.js
+++ b/src/lyrics-parser.js
@@ -52,14 +52,55 @@ export function parseLrc(lrcString) {
     }
   });
 
+  // Filter out empty text lines that are often used in LRCs to indicate silence/gap
+  const validLyrics = parsedLyrics.filter((l) => l.text !== "" || l.time === null);
+
   // Sort by time (required because LRC can have out-of-order tags like [01:00.00][02:00.00] Chorus)
   // Non-timed lines stay at the end or maintain relative order.
-  parsedLyrics.sort((a, b) => {
+  validLyrics.sort((a, b) => {
     if (a.time === null && b.time === null) return 0;
     if (a.time === null) return 1;
     if (b.time === null) return -1;
     return a.time - b.time;
   });
 
-  return parsedLyrics;
+  // Automatically insert instrumental break markers for gaps >= 10.0s in synced lyrics
+  const syncedLines = validLyrics.filter((l) => l.time !== null);
+  if (syncedLines.length > 0) {
+    const withInstrumentals = [];
+    const INSTRUMENTAL_GAP_THRESHOLD = 10.0;
+
+    // Check intro gap (before first lyric line)
+    if (syncedLines[0].time >= INSTRUMENTAL_GAP_THRESHOLD) {
+      withInstrumentals.push({
+        time: 0,
+        text: "",
+        isInstrumental: true,
+      });
+    }
+
+    for (let i = 0; i < syncedLines.length; i++) {
+      withInstrumentals.push(syncedLines[i]);
+      if (i < syncedLines.length - 1) {
+        const currentLine = syncedLines[i];
+        const nextLine = syncedLines[i + 1];
+        const gap = nextLine.time - currentLine.time;
+        if (gap >= INSTRUMENTAL_GAP_THRESHOLD) {
+          // Place the instrumental marker at ~3s after current line start (or mid-gap if shorter)
+          const instrumentalTime = gap >= 6.0 ? currentLine.time + 3.0 : currentLine.time + gap / 2;
+          withInstrumentals.push({
+            time: instrumentalTime,
+            text: "",
+            isInstrumental: true,
+          });
+        }
+      }
+    }
+
+    // Append any unsynced fallback lines that were at the end
+    const unsyncedLines = validLyrics.filter((l) => l.time === null);
+    return [...withInstrumentals, ...unsyncedLines];
+  }
+
+  return validLyrics;
 }

--- a/src/lyrics-view.js
+++ b/src/lyrics-view.js
@@ -182,7 +182,21 @@ export class YampLyricsView extends LitElement {
             active: isActive && !isUnsynced,
             unsynced: isUnsynced || isUnsyncedMode,
             "scroll-mode": isScrollMode && !isUnsynced,
+            "is-instrumental": Boolean(lyric.isInstrumental),
           };
+
+          if (lyric.isInstrumental) {
+            return html`
+              <div class="${classMap(classes)}" aria-label="Instrumental Break">
+                <span class="lyrics-playing-indicator">
+                  <span class="bar"></span>
+                  <span class="bar"></span>
+                  <span class="bar"></span>
+                </span>
+              </div>
+            `;
+          }
+
           return html` <div class="${classMap(classes)}">${lyric.text}</div> `;
         })}
         ${

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -263,6 +263,7 @@ export interface MusicAssistantItem {
 }
 
 export interface LyricsLine {
-  time: number;
+  time: number | null;
   text: string;
+  isInstrumental?: boolean;
 }

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4619,6 +4619,52 @@ export const lyricsStyles = css`
     filter: none;
   }
 
+  .lyric-line.is-instrumental {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 32px;
+    filter: none;
+  }
+
+  .lyrics-playing-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    height: 24px;
+    padding: 4px 8px;
+    opacity: 0.4;
+    transition:
+      opacity 0.4s cubic-bezier(0.25, 1, 0.5, 1),
+      transform 0.4s cubic-bezier(0.25, 1, 0.5, 1);
+  }
+
+  .lyrics-playing-indicator .bar {
+    width: 4px;
+    height: 6px;
+    background: currentColor;
+    border-radius: 2px;
+    transition: height 0.3s ease;
+  }
+
+  .lyric-line.active .lyrics-playing-indicator {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+
+  .lyric-line.active .lyrics-playing-indicator .bar:nth-child(1) {
+    animation: chipPlayingBar1 0.8s ease-in-out 0s infinite;
+  }
+
+  .lyric-line.active .lyrics-playing-indicator .bar:nth-child(2) {
+    animation: chipPlayingBar2 0.6s ease-in-out 0.15s infinite;
+  }
+
+  .lyric-line.active .lyrics-playing-indicator .bar:nth-child(3) {
+    animation: chipPlayingBar3 0.7s ease-in-out 0.3s infinite;
+  }
+
   .lyrics-loading,
   .lyrics-error,
   .lyrics-empty {


### PR DESCRIPTION
### Overview
Adds visual playing equalizer animation for instrumental breaks and long intro gaps in synced lyrics.

### User-Facing Changes
- **Instrumental Break Visualization**: When synced lyrics encounter an intro or gap between lyric lines $\ge 10.0$ seconds, a centered 3-bar equalizer playing indicator is rendered.
- **Rhythmic Equalizer Animation**: Animates fluidly and highlights with the active lyrics/theme color when the track position is currently within the instrumental break, and displays static/dimmed when inactive.
- **Single Line Consolidation**: Strips empty LRC silence lines so breaks are cleanly consolidated into a single indicator line throughout the entire gap.

### Technical Details
- **`src/lyrics-parser.js`**: Filters empty text lines and calculates $\ge 10.0$s gaps on sorted synced lines, injecting `{ time, text: "", isInstrumental: true }`.
- **`src/lyrics-view.js`**: Detects `isInstrumental` on lyric lines to render `.lyrics-playing-indicator` with equalizer bars.
- **`src/yamp-card-styles.js`**: Styled `.lyric-line.is-instrumental` and `.lyrics-playing-indicator` reusing the chip keyframe bar animations.
- **`src/types.d.ts`**: Updated `LyricsLine` type interface.
