### PR TITLE
fix: restore gestures and visual feedback when lyrics overlay is open

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -7265,11 +7265,16 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
    */
   _showGestureFeedback(type, clientX, clientY) {
     // Find the gesture feedback container in the shadow DOM
-    const tapArea = this._gestureTapArea || this.shadowRoot?.querySelector('.card-artwork-spacer') || this.shadowRoot?.querySelector('.collapsed-artwork-container') || this.shadowRoot?.querySelector('.media-artwork-placeholder');
+    const cardInner = this.shadowRoot?.querySelector('.yamp-card-inner');
+    const tapArea = this._gestureTapArea || this.shadowRoot?.querySelector('.card-artwork-spacer') || this.shadowRoot?.querySelector('.collapsed-artwork-container') || this.shadowRoot?.querySelector('.media-artwork-placeholder') || cardInner;
     if (!tapArea) return;
 
+    const feedbackHost = (tapArea.shadowRoot || tapArea.tagName === 'YAMP-LYRICS-VIEW')
+      ? (cardInner || tapArea)
+      : tapArea;
+
     // Get the bounding rect of the tap area to calculate relative position
-    const rect = tapArea.getBoundingClientRect();
+    const rect = feedbackHost.getBoundingClientRect();
     const x = clientX - rect.left;
     const y = clientY - rect.top;
 
@@ -7280,11 +7285,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     ripple.style.top = `${y}px`;
 
     // Find or create the feedback container
-    let container = tapArea.querySelector('.gesture-feedback-container');
+    let container = feedbackHost.querySelector('.gesture-feedback-container');
     if (!container) {
       container = document.createElement('div');
       container.className = 'gesture-feedback-container';
-      tapArea.appendChild(container);
+      feedbackHost.appendChild(container);
     }
 
     // Remove the ripple when the animation ends
@@ -8611,11 +8616,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             ` : nothing}
             ${(!useInsetArtwork && !artworkUrl && !idleImageUrl) ? html`
               <div class="media-artwork-placeholder"
-                @pointerdown=${!this._lyricsActive ? this._onTapAreaPointerDown : nothing}
-                @pointermove=${!this._lyricsActive ? this._onTapAreaPointerMove : nothing}
-                @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
-                @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
-                style="${this._getGestureStyles(!this._lyricsActive)}"
+                @pointerdown=${this._onTapAreaPointerDown}
+                @pointermove=${this._onTapAreaPointerMove}
+                @pointerup=${this._onTapAreaPointerUp}
+                @pointercancel=${this._onTapAreaPointerCancel}
+                style="${this._getGestureStyles()}"
               >
                 <svg
                   viewBox="0 0 184 184"
@@ -8640,9 +8645,14 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 .activeThemeColor=${this.config.match_theme === true ? "var(--custom-accent, var(--state-media_player-active-color, var(--primary-color, #ffffff)))" : "var(--custom-accent, #ffffff)"}
                 .mode=${this._isCurrentlyPlayingRadio() ? 'text' : (this.config.lyrics_mode || 'default')}
                 .preRoll=${this.config.lyrics_pre_roll ?? 0}
+                @pointerdown=${this._onTapAreaPointerDown}
+                @pointermove=${this._onTapAreaPointerMove}
+                @pointerup=${this._onTapAreaPointerUp}
+                @pointercancel=${this._onTapAreaPointerCancel}
                 style="${[
                   `--yamp-lyrics-top-offset: ${showChipsInline ? 48 : 0}px`,
-                  `--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px`
+                  `--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px`,
+                  this._getGestureStyles()
                 ].filter(Boolean).join('; ')}"
               ></yamp-lyrics-view>
             ` : nothing}
@@ -8681,15 +8691,15 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                 ${collapsed && artworkUrl && collapsedArtworkSize > 0 && isValidArtworkUrl(artworkUrl) ? html`
                   <div
                     class="collapsed-artwork-container"
-                    @pointerdown=${!this._lyricsActive ? this._onTapAreaPointerDown : nothing}
-                    @pointermove=${!this._lyricsActive ? this._onTapAreaPointerMove : nothing}
-                    @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
-                    @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
+                    @pointerdown=${this._onTapAreaPointerDown}
+                    @pointermove=${this._onTapAreaPointerMove}
+                    @pointerup=${this._onTapAreaPointerUp}
+                    @pointercancel=${this._onTapAreaPointerCancel}
                     style="${[
           `background: linear-gradient(120deg, ${this._collapsedArtDominantColor}bb 60%, transparent 100%)`,
           collapsedExtraSpace > 0 ? `width:${Math.round(collapsedArtworkSize + 8)}px` : '',
           isCompact && collapsed ? 'top: -2px; height: auto !important; overflow: visible !important;' : '',
-          this._getGestureStyles(!this._lyricsActive)
+          this._getGestureStyles()
         ].filter(Boolean).join('; ')}"
                   >
                     <img


### PR DESCRIPTION
## Summary
Fixes an issue where card gestures (single tap, double tap, hold, and swipe left/right) were unresponsive when the lyrics overlay was open.

## User-Facing Changes
- **Lyrics View Gestures**: Configured card gestures (tap to toggle play/pause, double tap to skip, hold for options, swipe to change tracks) now function seamlessly while viewing lyrics.
- **Visual Feedback Animations**: Gesture feedback ripples now render properly on top of the lyrics view overlay.
- **Uninterrupted Scrolling**: Vertical drag/scroll actions continue to scroll the lyrics naturally without accidentally triggering tap or swipe actions.

## Verification
- Validated with `npm run validate` (ESLint, Prettier, TypeScript, Rollup build).
- Verified gesture listeners and feedback mounting logic.