### PR TITLE
Fix lyrics layout shifts and card height shrinkage

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -702,7 +702,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._hideActiveEntityLabelOnIdle = false;
     this._currentDetailsScale = null;
     this._lastTitleLength = 0;
-    this._lastNonLyricsLowerContentHeight = null;
     this._lowerControlsHeight = null;
 
     // Lyrics state
@@ -4230,12 +4229,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const detailScale = this._calculateDetailsScale(width, height, scale, this._lastTitleLength || 0);
     const textScaleChanged = this._currentTextScale === null || Math.abs(this._currentTextScale - scale) > 0.01;
     const detailScaleChanged = this._currentDetailsScale === null || Math.abs(this._currentDetailsScale - detailScale) > 0.02;
-    if (!this._lyricsActive) {
-      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
-      if (lowerContentEl && lowerContentEl.offsetHeight > 50) {
-        this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
-      }
-    }
     if (textScaleChanged || detailScaleChanged) {
       this._currentTextScale = scale;
       this._currentDetailsScale = detailScale;
@@ -6613,26 +6606,26 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       }
     }
 
-    if (!this._lyricsActive) {
-      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
-      if (lowerContentEl && lowerContentEl.offsetHeight > 50) {
-        this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
-      }
-    } else {
-      const detailsEl = this.shadowRoot?.querySelector('.details');
-      if (detailsEl) {
-        let controlsH = detailsEl.offsetHeight;
-        const progressEl = this.shadowRoot?.querySelector('.progress-bar-container:not(.alternate)');
-        if (progressEl) controlsH += progressEl.offsetHeight;
-        const controlsRowEl = this.shadowRoot?.querySelector('.controls-row');
-        if (controlsRowEl) controlsH += controlsRowEl.offsetHeight;
-        const volumeRowEl = this.shadowRoot?.querySelector('.volume-row');
-        if (volumeRowEl) controlsH += volumeRowEl.offsetHeight;
-        
-        if (controlsH > 30 && this._lowerControlsHeight !== controlsH) {
-          this._lowerControlsHeight = controlsH;
-          this.requestUpdate();
-        }
+    const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
+    const detailsEl = this.shadowRoot?.querySelector('.details');
+    const firstControlEl = detailsEl || this.shadowRoot?.querySelector('.progress-bar-container:not(.alternate)') || this.shadowRoot?.querySelector('.controls-row') || this.shadowRoot?.querySelector('.volume-row');
+    let controlsH = 0;
+    if (lowerContentEl && firstControlEl && lowerContentEl.contains(firstControlEl)) {
+      controlsH = lowerContentEl.offsetHeight - firstControlEl.offsetTop;
+    }
+    if (controlsH <= 0) {
+      if (detailsEl) controlsH += detailsEl.offsetHeight;
+      const progressEl = this.shadowRoot?.querySelector('.progress-bar-container:not(.alternate)');
+      if (progressEl) controlsH += progressEl.offsetHeight;
+      const controlsRowEl = this.shadowRoot?.querySelector('.controls-row');
+      if (controlsRowEl) controlsH += controlsRowEl.offsetHeight;
+      const volumeRowEl = this.shadowRoot?.querySelector('.volume-row');
+      if (volumeRowEl) controlsH += volumeRowEl.offsetHeight;
+    }
+    if (controlsH > 30 && this._lowerControlsHeight !== controlsH) {
+      this._lowerControlsHeight = controlsH;
+      if (this._lyricsActive) {
+        this.requestUpdate();
       }
     }
 
@@ -8589,10 +8582,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       (hideControlsNow ? 0 : 56) +
       (volumeRowWillCollapse ? 0 : 56)
     );
-    const spacerMarginBottom = 8; // details margin-top is 8px at scale 1.0
-    const lyricsSpacerHeight = this._lastNonLyricsLowerContentHeight != null
-      ? Math.max(48, Math.round(this._lastNonLyricsLowerContentHeight - lowerControlsH - spacerMarginBottom))
-      : 180;
     const lyricsBottomOffset = lowerControlsH;
 
     return html`
@@ -8720,7 +8709,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                     @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
                     @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
                     style="${[
-                      this._lyricsActive ? `height: ${lyricsSpacerHeight}px; min-height: ${lyricsSpacerHeight}px; max-height: ${lyricsSpacerHeight}px; flex: none; pointer-events: none;` : '',
+                      this._lyricsActive ? 'pointer-events: none;' : '',
                       this._getGestureStyles(!this._lyricsActive)
                     ].filter(Boolean).join('; ')}"
                   >

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -702,6 +702,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._hideActiveEntityLabelOnIdle = false;
     this._currentDetailsScale = null;
     this._lastTitleLength = 0;
+    this._lastNonLyricsLowerContentHeight = null;
     this._lowerControlsHeight = null;
 
     // Lyrics state
@@ -4229,6 +4230,12 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const detailScale = this._calculateDetailsScale(width, height, scale, this._lastTitleLength || 0);
     const textScaleChanged = this._currentTextScale === null || Math.abs(this._currentTextScale - scale) > 0.01;
     const detailScaleChanged = this._currentDetailsScale === null || Math.abs(this._currentDetailsScale - detailScale) > 0.02;
+    if (!this._lyricsActive) {
+      const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
+      if (lowerContentEl && lowerContentEl.offsetHeight > 50) {
+        this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
+      }
+    }
     if (textScaleChanged || detailScaleChanged) {
       this._currentTextScale = scale;
       this._currentDetailsScale = detailScale;
@@ -6607,6 +6614,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
 
     const lowerContentEl = this.shadowRoot?.querySelector('.card-lower-content');
+    if (!this._lyricsActive) {
+      if (lowerContentEl && lowerContentEl.offsetHeight > 50) {
+        this._lastNonLyricsLowerContentHeight = lowerContentEl.offsetHeight;
+      }
+    }
     const detailsEl = this.shadowRoot?.querySelector('.details');
     const firstControlEl = detailsEl || this.shadowRoot?.querySelector('.progress-bar-container:not(.alternate)') || this.shadowRoot?.querySelector('.controls-row') || this.shadowRoot?.querySelector('.volume-row');
     let controlsH = 0;
@@ -8672,10 +8684,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               ></div>
               ${!(dimIdleFrame || this._isIdle) && (!useInsetArtwork || activeArtworkFit === "scaled-contain" || this._lyricsActive) ? html`<div class="card-lower-fade" style="--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px;"></div>` : nothing}
               <div class="card-lower-content${collapsed ? ' collapsed transitioning' : ' transitioning'}${collapsed && artworkUrl && collapsedArtworkSize > 0 ? ' has-artwork' : ''}" style="${(() => {
-        if (!hideControlsNow) return '';
+        if (!hideControlsNow && !this._lyricsActive) return '';
         return collapsed
           ? `min-height: ${this._collapsedBaselineHeight || 220}px;`
-          : `min-height: ${hasCustomCardHeight ? `${customCardHeight}px` : '350px'};`;
+          : `min-height: ${hasCustomCardHeight ? `${customCardHeight}px` : `${this._lastNonLyricsLowerContentHeight || 350}px`};`;
       })()}">
                 ${collapsed && artworkUrl && collapsedArtworkSize > 0 && isValidArtworkUrl(artworkUrl) ? html`
                   <div
@@ -8709,7 +8721,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
                     @pointerup=${!this._lyricsActive ? this._onTapAreaPointerUp : nothing}
                     @pointercancel=${!this._lyricsActive ? this._onTapAreaPointerCancel : nothing}
                     style="${[
-                      this._lyricsActive ? 'pointer-events: none;' : '',
+                      this._lyricsActive ? 'min-height: 0; pointer-events: none;' : '',
                       this._getGestureStyles(!this._lyricsActive)
                     ].filter(Boolean).join('; ')}"
                   >


### PR DESCRIPTION
### Description
This PR fixes two layout issues that occurred when opening the lyrics view:
1. The controls row and volume row nudged upwards because the `.card-artwork-spacer` was assigned a static minimum height (`lyricsSpacerHeight`) and `flex: none`, rather than being allowed to flex dynamically. 
2. For cards without a custom configured height, opening the lyrics view would shrink the total card height because the adaptive `.details` block shrunk down to a `1.0` scale.

### User-facing changes
- The height of the `ha-card` remains stable when toggling the lyrics view.
- The playback controls on the bottom remain anchored in their exact position when the lyrics overlay slides up.

### Technical details
- Removed the static height calculation for `lyricsSpacerHeight` and applied `min-height: 0;` to `.card-artwork-spacer` in lyrics mode, leveraging flexbox to fill the space cleanly.
- Added tracking for `_lastNonLyricsLowerContentHeight`. When `_lyricsActive` becomes true, the `.card-lower-content` element is assigned a `min-height` locking it to the cached natural size of the card prior to the overlay, preventing the card from collapsing.