### PR TITLE
Fix idle_image fit and position artwork overrides

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -133,6 +133,8 @@ export const CARD_CONFIG_DEFAULTS = Object.freeze({
   show_chip_row: "always",
   idle_timeout_ms: DEFAULT_IDLE_TIMEOUT_MS,
   idle_screen: "default",
+  idle_image: "",
+  artwork_position: "top center",
   artwork_object_fit: "cover",
   extend_artwork: false,
   blurred_artwork: false,
@@ -192,6 +194,7 @@ export const TEMPLATE_SUPPORTED_FIELDS = Object.freeze(
     "title",
     "subtitle",
     "idle_artwork",
+    "idle_image",
   ])
 );
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -196,6 +196,9 @@ export interface YampCardConfig {
   show_chip_row?: "always" | "in_menu" | "in_menu_on_idle" | "never" | "auto" | string;
   idle_timeout_ms?: number;
   idle_screen?: "default" | "artwork" | "blank" | "collapsed" | "transparent" | string;
+  idle_image?: string;
+  media_artwork_overrides?: ArtworkOverrideRule[];
+  artwork_position?: "top center" | "center center" | "bottom center" | string;
   artwork_object_fit?:
     | "cover"
     | "contain"

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -85,6 +85,7 @@ export const yampCardStyles = css`
     --shadow-medium: 0 2px 8px rgba(0, 0, 0, 0.25);
     --shadow-heavy: 0 0 6px 1px rgba(0, 0, 0, 0.32), 0 0 1px 1px rgba(255, 255, 255, 0.13);
     --yamp-artwork-fit: cover;
+    --yamp-artwork-position: top center;
     --yamp-text-scale: 1;
     --yamp-text-scale-details: 1;
     --yamp-text-scale-menu: 1;
@@ -281,7 +282,7 @@ export const yampCardStyles = css`
     inset: -50px;
     z-index: ${Z_LAYERS.MEDIA_BACKGROUND};
     background-size: var(--yamp-artwork-bg-size, cover);
-    background-position: top center;
+    background-position: var(--yamp-artwork-position, top center);
     background-repeat: no-repeat;
     pointer-events: none;
     transform: translateZ(0);
@@ -1768,7 +1769,7 @@ export const yampCardStyles = css`
     inset: 0;
     z-index: ${Z_LAYERS.MEDIA_BACKGROUND};
     background-size: var(--yamp-artwork-bg-size, cover);
-    background-position: top center;
+    background-position: var(--yamp-artwork-position, top center);
     background-repeat: no-repeat;
     pointer-events: none;
     height: 100%;

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -151,6 +151,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           image_url: item.missing_art_url ?? "",
           size_percentage: sizePercentage,
           object_fit: item.object_fit,
+          object_position: item.object_position,
         };
       }
 
@@ -161,6 +162,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           image_url: item.idle_image_url ?? item.image_url ?? "",
           size_percentage: sizePercentage,
           object_fit: item.object_fit,
+          object_position: item.object_position,
         };
       }
 

--- a/src/yamp-utils.js
+++ b/src/yamp-utils.js
@@ -366,12 +366,43 @@ export function getSearchResultClickTitle(item) {
 function _findArtworkOverride(state, overrides, resolveOverrideSource, options = {}) {
   if (!overrides || !Array.isArray(overrides) || !overrides.length) return null;
 
-  const attrs = state.attributes;
-  const entityId = state.entity_id;
+  const attrs = state?.attributes || {};
+  const entityId = state?.entity_id;
+
+  if (options.isIdleImageActive) {
+    // When idle image is active, match idle_image overrides only (specific entity_id first, then general)
+    const idleOverride = overrides.find(
+      (item) =>
+        (item?.idle_image === true ||
+          item?.idle_image_url !== undefined ||
+          item?.match_type === "idle_image") &&
+        (!item?.entity_id || item.entity_id === entityId || item.entity_id === "*")
+    );
+    if (idleOverride) {
+      const overrideSource = idleOverride.idle_image_url || idleOverride.image_url || null;
+      let resolvedOverride = null;
+      if (overrideSource) {
+        resolvedOverride =
+          typeof resolveOverrideSource === "function"
+            ? resolveOverrideSource(idleOverride, overrideSource, "idle", state)
+            : overrideSource;
+      }
+      return {
+        url: resolvedOverride,
+        sizePercentage: idleOverride?.size_percentage,
+        objectFit: idleOverride?.object_fit ?? null,
+        objectPosition: idleOverride?.object_position ?? null,
+      };
+    }
+    return null;
+  }
 
   const findSpecificMatch = () =>
-    overrides.find((override) =>
-      ARTWORK_OVERRIDE_MATCH_KEYS.some((key) => {
+    overrides.find((override) => {
+      // Don't match idle_image rules when not in idle image mode
+      if (override?.idle_image === true || override?.match_type === "idle_image") return false;
+
+      return ARTWORK_OVERRIDE_MATCH_KEYS.some((key) => {
         const expected = override[key];
         if (expected === undefined || expected === null || expected === "") return false;
 
@@ -466,8 +497,8 @@ function _findArtworkOverride(state, overrides, resolveOverrideSource, options =
           return regex.test(String(value || ""));
         }
         return value === expected;
-      })
-    );
+      });
+    });
 
   const hasExistingArtwork =
     getValidArtworkAttr(attrs, "entity_picture_local") ||
@@ -483,9 +514,6 @@ function _findArtworkOverride(state, overrides, resolveOverrideSource, options =
   } else if (override?.missing_art_url && !hasExistingArtwork) {
     overrideSource = override.missing_art_url;
     overrideType = "missing";
-  } else if (override?.idle_image_url && options.isIdleImageActive) {
-    overrideSource = override.idle_image_url;
-    overrideType = "idle";
   } else if (override && hasExistingArtwork) {
     overrideSource =
       getValidArtworkAttr(attrs, "entity_picture_local") ||
@@ -499,17 +527,6 @@ function _findArtworkOverride(state, overrides, resolveOverrideSource, options =
       override = missingOverride;
       overrideSource = missingOverride.missing_art_url;
       overrideType = "missing";
-    }
-  }
-
-  if (!override && options.isIdleImageActive) {
-    const idleOverride = overrides.find(
-      (item) => item?.idle_image === true || item?.idle_image_url !== undefined
-    );
-    if (idleOverride) {
-      override = idleOverride;
-      overrideSource = idleOverride.idle_image_url || idleOverride.image_url;
-      overrideType = "idle";
     }
   }
 
@@ -584,8 +601,8 @@ export function getArtworkUrl(
     objectPosition = resolvedOverride.objectPosition;
   }
 
-  // If no override found, use standard artwork
-  if (!artworkUrl) {
+  // If no override found, use standard artwork (only when not in idle image mode)
+  if (!artworkUrl && !isIdleImageActive) {
     artworkUrl =
       getValidArtworkAttr(attrs, "entity_picture_local") ||
       getValidArtworkAttr(attrs, "entity_picture") ||
@@ -593,8 +610,8 @@ export function getArtworkUrl(
       null;
   }
 
-  // If still no artwork, check for configured fallback artwork
-  if (!artworkUrl && fallbackArtwork) {
+  // If still no artwork, check for configured fallback artwork (only when not in idle image mode)
+  if (!artworkUrl && fallbackArtwork && !isIdleImageActive) {
     if (fallbackArtwork === "smart") {
       const isTV =
         attrs.media_title === "TV" ||

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -8200,7 +8200,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         idleImageUrl =
           sensorState.attributes.entity_picture_local ||
           sensorState.attributes.entity_picture ||
-          (sensorState.state && sensorState.startsWith("http") ? sensorState.state : null);
+          (sensorState.state && typeof sensorState.state === "string" && sensorState.state.startsWith("http") ? sensorState.state : null);
       }
       // Check if it's a direct URL or file path
       else if (normalizedIdleImageInput.startsWith("http") || normalizedIdleImageInput.startsWith("/")) {
@@ -8312,6 +8312,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
     if (displayTitle && (!selectedArt || !selectedArt.url) && mainArtwork?.url && mainState?.attributes?.media_title === displayTitle) {
       selectedArt = mainArtwork;
+    }
+    if (!selectedArt) {
+      selectedArt = playbackArtwork || mainArtwork || null;
     }
 
 
@@ -8496,6 +8499,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     } else {
       // Even if idle, we apply layout properties from selectedArt, 
       // because _getArtworkUrl correctly finds idle_image overrides for us.
+      if (selectedArt?.url) {
+        idleImageUrl = selectedArt.url;
+      }
       if (selectedArt?.objectFit) {
         artworkObjectFit = selectedArt.objectFit;
       }
@@ -9100,7 +9106,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const playbackEntityId = this._getEntityForPurpose(this._selectedIndex, 'playback_control');
     const playbackStateObj = (this.hass && this.hass.states && playbackEntityId) ? this.hass.states[playbackEntityId] : undefined;
     const isCurrentPlayingForIdle = playbackStateObj ? this._isEntityPlaying(playbackStateObj) : false;
-    const normalizedIdleImageInput = config.idle_image ? resolveStringTemplateSync(this.hass, config.idle_image, this._getTemplateContext()) : null;
+    const isJsTemplate = typeof config.idle_image === "string" && config.idle_image.trim().startsWith("[[[");
+    const rawIdleImageInput = isJsTemplate
+      ? this._evaluateJsTemplate(config.idle_image)
+      : (this._idleImageTemplate ? this._idleImageTemplateResult : (config.idle_image ? resolveStringTemplateSync(this.hass, config.idle_image, this._getTemplateContext()) : null));
+    const normalizedIdleImageInput = this._normalizeImageSourceValue(rawIdleImageInput);
     const forceIdleImage = config.show_idle_artwork_when_not_playing === true && !isCurrentPlayingForIdle && normalizedIdleImageInput;
 
     const isActuallyPlaying = this._isCurrentEntityPlaying();
@@ -9290,6 +9300,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     if (displayTitle && (!selectedArt || !selectedArt.url) && mainArtwork?.url && mainState?.attributes?.media_title === displayTitle) {
       selectedArt = mainArtwork;
     }
+    if (!selectedArt) {
+      selectedArt = playbackArtwork || mainArtwork || null;
+    }
 
     let artworkObjectFit = this._artworkObjectFit;
     if (selectedArt?.objectFit) {
@@ -9300,6 +9313,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const backgroundSize = this._getBackgroundSizeForFit(activeArtworkFit);
     host.style.setProperty('--yamp-artwork-fit', activeArtworkFit);
     host.style.setProperty('--yamp-artwork-bg-size', backgroundSize);
+    if (selectedArt?.objectPosition) {
+      host.style.setProperty('--yamp-artwork-position', selectedArt.objectPosition);
+    } else if (this.config?.artwork_position) {
+      host.style.setProperty('--yamp-artwork-position', this.config.artwork_position);
+    } else {
+      host.style.setProperty('--yamp-artwork-position', 'top center');
+    }
   }
 
   _updateHostAttributes() {


### PR DESCRIPTION
## Overview
Fixes an issue where `idle_image` fit (`object_fit`) and alignment (`object_position`) artwork override rules failed to apply when the media player was idle.

## Key Changes
- **Priority Isolation**: Updated `_findArtworkOverride` in `src/yamp-utils.js` to match `idle_image` rules directly when `isIdleImageActive` is true, preventing generic `missing_art_url` overrides or lingering track metadata rules from intercepting idle state.
- **Track Artwork Fallback Isolation**: Ensured `getArtworkUrl` does not fall back to previous/stale track artwork (`entity_picture` / `album_art`) when in idle image mode.
- **Layout & Style Application**: 
  - Propagated `object_fit`, `object_position`, and `size_percentage` from `selectedArt` to both inline styles and `--yamp-artwork-position` / `--yamp-artwork-fit` CSS variables on `:host`.
  - Added fallback in `render()` and `_updateHostArtworkStyles()` so `selectedArt` seamlessly resolves to `playbackArtwork` or `mainArtwork` when `metadataStateObj` has no track title.
- **Visual Editor Compatibility**: Fixed `_parseArtworkOverrides` in `src/yamp-editor.js` to preserve `object_position` for both `idle_image` and `missing_art` rules.
- **Schema & Types**: Registered `idle_image` and `artwork_position` defaults in `src/config-schema.js` and updated `src/types.d.ts`.

## Verification
- Passed `npm run validate` (ESLint, Prettier, TypeScript `tsc --noEmit`, and Rollup build).
- Verified bundle builds cleanly without regression.