### PR TITLE
fix(lyrics): eliminate GPU compositing edge artifact on inactive lyrics

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4586,13 +4586,11 @@ export const lyricsStyles = css`
     );
     width: 100%;
     max-width: 95%;
-    filter: blur(1px);
     text-align: center;
   }
 
   .lyric-line.active {
     opacity: 1;
-    filter: blur(0);
     color: var(
       --yamp-lyrics-active-color,
       var(--yamp-primary-color, var(--custom-accent, var(--accent-color, #ffffff)))


### PR DESCRIPTION
## Summary
Fixes a visual glitch where thin vertical lines (matching the system/theme accent color) appeared to the right of inactive lyrics lines on WebKit and iOS devices.

## Root Cause & Solution
- **Cause**: Applying `filter: blur(1px)` to `.lyric-line` caused WebKit to promote each inactive line into its own GPU compositing layer. Sub-pixel rounding along the right boundary of the bounded element (`max-width: 95%`) produced a 1px vertical artifact that picked up theme accent colors.
- **Fix**: Removed `filter: blur(1px)` from `.lyric-line` and the corresponding `filter: blur(0)` from `.lyric-line.active`. The existing `opacity: 0.4` styling provides clean visual separation between active and inactive lyrics lines without triggering compositing artifacts.

## User-Facing Changes
- Inactive lyrics lines no longer display thin vertical lines or artifacting on WebKit/iOS devices during lyrics playback.