### PR TITLE
fix: preserve search token and watchdog timer across DOM disconnect (#462)

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -10271,7 +10271,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       clearTimeout(this._manualSelectTimeout);
       this._manualSelectTimeout = null;
     }
-    if (this._searchTimeoutHandle) {
+    if (this._searchTimeoutHandle && !this._searchLoading) {
       clearTimeout(this._searchTimeoutHandle);
       this._searchTimeoutHandle = null;
     }
@@ -10305,8 +10305,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       clearTimeout(this._queueOpsTimeout);
       this._queueOpsTimeout = null;
     }
-
-    this._latestSearchToken = 0;
 
     this._removeSourceDropdownOutsideHandler();
     this._removeGrabScrollHandlers();


### PR DESCRIPTION
### Summary of Changes

Fixes #462.

Resolves an issue where a search initiated on card mount (e.g., when configured with `idle_screen: search` or in search card mode) hangs indefinitely with a loading spinner when the card element is moved or reparented in the DOM during initial layout calculation (such as by `custom:layout-card`, Lovelace masonry column rebalancing, or card wrappers).

#### Root Cause
Under the Custom Elements specification, moving a DOM element between containers invokes `disconnectedCallback()` followed immediately by `connectedCallback()`. In `src/yet-another-media-player.js`, `disconnectedCallback()` previously zeroed `this._latestSearchToken = 0;` and destroyed `this._searchTimeoutHandle`.
When the in-flight WebSocket query resolved, `_doSearch()`'s staleness guard (`this._latestSearchToken !== searchToken`) matched because `_latestSearchToken` had been reset to `0`, causing it to treat the search as superseded. Consequently, the method returned early before resetting `_searchLoading = false;`. With the watchdog timer also cancelled, the card remained permanently frozen on the spinner.

#### Changes
- **Preserve Concurrency Token**: Removed `this._latestSearchToken = 0;` from `disconnectedCallback()`. In-flight searches now cleanly deliver their results to the reconnected element. Genuine superseded searches remain protected by new tokens generated upon starting subsequent queries or manual queue operations.
- **Preserve Watchdog Timer**: Updated timer teardown in `disconnectedCallback()` to only clear `_searchTimeoutHandle` if `!this._searchLoading`. If a search is actively in flight, the 15s watchdog stays alive to safely recover the UI in the event of an actual backend stall or network failure across DOM moves.

#### Verification & Testing
- Automated browser test suite executed with all 4 test cases passing:
  1. Mid-flight DOM reparenting: Search completes and cleanly dismisses the loading spinner.
  2. Watchdog timeout recovery across reparenting: Watchdog fires cleanly if a backend call hangs.
  3. Concurrency integrity: Newer searches still supersede older in-flight searches across DOM reparents.
  4. Idle screen mount simulation: Card mounts with `idle_screen: search`, reparents mid-flight, and populates favorites.
- Full validation pipeline (`npm run validate`: ESLint, Prettier, TypeScript `tsc --noEmit`, and Rollup bundle) passed with zero errors.