### PR TITLE
refactor: support Home Assistant device registry changes and child devices

### DIFF
--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -80,36 +80,44 @@ const MUSIC_ASSISTANT_CONFIG_TTL_MS = 30000;
 let cachedMusicAssistantEntryId = null;
 let cachedMusicAssistantEntryTs = 0;
 
-function _resolveIntegrationId(hass, targetEntityId, platforms) {
+export function _getDeviceConfigEntryId(device, allDevices = null) {
+  if (!device || typeof device !== "object") return null;
+  if (typeof device.config_entry_id === "string" && device.config_entry_id.length > 0) {
+    return device.config_entry_id;
+  }
+  if (Array.isArray(device.config_entries) && device.config_entries.length > 0) {
+    return device.config_entries[0];
+  }
+  if (device.parent_device_id && allDevices && allDevices[device.parent_device_id]) {
+    const parent = allDevices[device.parent_device_id];
+    return _getDeviceConfigEntryId(parent, null);
+  }
+  return null;
+}
+
+export function _resolveIntegrationId(hass, targetEntityId, platforms) {
   let resolvedId = null;
-  if (hass.entities && typeof hass.entities === "object") {
-    const entities = Object.values(hass.entities);
-    if (
-      targetEntityId &&
-      hass.entities[targetEntityId] &&
-      hass.entities[targetEntityId].device_id
-    ) {
-      const deviceId = hass.entities[targetEntityId].device_id;
-      if (
-        hass.devices &&
-        hass.devices[deviceId] &&
-        hass.devices[deviceId].config_entries &&
-        hass.devices[deviceId].config_entries.length > 0
-      ) {
-        resolvedId = hass.devices[deviceId].config_entries[0];
+  if (hass?.entities && typeof hass.entities === "object") {
+    const resolveFromEntity = (entity) => {
+      if (!entity) return null;
+      if (entity.config_entry_id) return entity.config_entry_id;
+      if (entity.device_id && hass.devices && hass.devices[entity.device_id]) {
+        return _getDeviceConfigEntryId(hass.devices[entity.device_id], hass.devices);
+      }
+      return null;
+    };
+
+    if (targetEntityId && hass.entities[targetEntityId]) {
+      const targetEntity = hass.entities[targetEntityId];
+      if (targetEntity && platforms.includes(targetEntity.platform)) {
+        resolvedId = resolveFromEntity(targetEntity);
       }
     }
     if (!resolvedId) {
+      const entities = Object.values(hass.entities);
       const entity = entities.find((e) => e && platforms.includes(e.platform));
       if (entity) {
-        if (entity.config_entry_id) {
-          resolvedId = entity.config_entry_id;
-        } else if (entity.device_id && hass.devices && hass.devices[entity.device_id]) {
-          const device = hass.devices[entity.device_id];
-          if (device.config_entries && device.config_entries.length > 0) {
-            resolvedId = device.config_entries[0];
-          }
-        }
+        resolvedId = resolveFromEntity(entity);
       }
     }
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -67,9 +67,38 @@ export interface HassEntity {
   };
 }
 
+export interface DeviceRegistryEntry {
+  id: string;
+  config_entry_id?: string | null;
+  config_subentry_id?: string | null;
+  config_entries?: string[];
+  parent_device_id?: string | null;
+  area_id?: string | null;
+  name?: string | null;
+  name_by_user?: string | null;
+  disabled_by?: string | null;
+  labels?: string[];
+  identifiers?: [string, string][];
+  [key: string]: any;
+}
+
+export interface EntityRegistryEntry {
+  id: string;
+  entity_id: string;
+  platform?: string;
+  config_entry_id?: string | null;
+  device_id?: string | null;
+  area_id?: string | null;
+  disabled_by?: string | null;
+  hidden_by?: string | null;
+  [key: string]: any;
+}
+
 export interface HomeAssistant {
   states: Record<string, HassEntity>;
   services: Record<string, Record<string, any>>;
+  entities?: Record<string, EntityRegistryEntry>;
+  devices?: Record<string, DeviceRegistryEntry>;
   user: {
     id: string;
     name: string;


### PR DESCRIPTION
## Description
Refactor device and entity registry resolution in `src/search-sheet.js` to align with the Home Assistant Core 2026.8 and 2026.9 device registry changes ([WebSocket API Changes](https://developers.home-assistant.io/blog/2026/08/19/device-registry-websocket-api-changes) and [Follow-up Deprecations](https://developers.home-assistant.io/blog/2026/08/24/device-registry-follow-up-changes)).

### Context & Changes
* **HA 2026.8+ `config_entry_id` Support**: Replaces reliance on the deprecated `device.config_entries` array (scheduled for removal in Core 2027.8) with `device.config_entry_id` as the primary lookup.
* **HA 2026.9+ Child Devices**: Child devices omit `config_entries` entirely. Added `_getDeviceConfigEntryId(device, allDevices)` which reads `config_entry_id` directly, supports 1-level parent device fallback via `parent_device_id`, and retains legacy `device.config_entries[0]` fallback for older Home Assistant versions (< 2026.8).
* **Target Entity Platform Guard**: Ensures `platforms.includes(targetEntity.platform)` before extracting its device's config entry, preventing unrelated players (such as a TV or generic DLNA renderer) from misattributing an invalid config entry to Music Assistant or Mass Queue.
* **Performance Optimization**: Encapsulated entity-to-config-entry resolution in `resolveFromEntity` and deferred `Object.values(hass.entities)` allocation until fallback search is needed.
* **Type Contracts**: Added `DeviceRegistryEntry` and `EntityRegistryEntry` interfaces to `src/types.d.ts` and exposed them on `HomeAssistant`.

### Compatibility
* **No minimum HA version required**: Progressive resolution retains 100% backward compatibility with Home Assistant < 2026.8 while proactively supporting 2026.9+ child devices and 2027.8+ deprecation removal.

### Verification
* Automated unit/compatibility test suite passed across 6 distinct scenarios (legacy HA, modern HA, child devices without `config_entries`, future HA after deprecation removal, unrelated target players, and direct entity config entries).
* Full validation pipeline (`npm run validate`: ESLint, Prettier, TypeScript, Rollup build) passed cleanly.