### PR TITLE
feat: enhance instrumental track support with UI rendering, playing status indicators, and automated parsing logic

### DIFF
--- a/src/lyrics-parser.js
+++ b/src/lyrics-parser.js
@@ -1,3 +1,5 @@
+import { localize } from "./localize/localize.js";
+
 /**
  * Parses a standard LRC (LyRiCs) string into an array of timed lyric objects.
  * Supports basic [mm:ss.xx] and [mm:ss:xx] formats.
@@ -63,6 +65,20 @@ export function parseLrc(lrcString) {
     if (b.time === null) return -1;
     return a.time - b.time;
   });
+
+  // If the parsed lyrics consist solely of an instrumental indicator
+  if (
+    validLyrics.length === 1 &&
+    /^(\[|\()?instrumental(\s+track)?(\]|\))?$/i.test(validLyrics[0].text.trim())
+  ) {
+    return [
+      {
+        time: 0,
+        text: localize("lyrics.instrumental") || "Instrumental Track",
+        isInstrumental: true,
+      },
+    ];
+  }
 
   // Automatically insert instrumental break markers for gaps >= 10.0s in synced lyrics
   const syncedLines = validLyrics.filter((l) => l.time !== null);

--- a/src/lyrics-view.js
+++ b/src/lyrics-view.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { classMap } from "lit/directives/class-map.js";
 import { lyricsStyles } from "./yamp-card-styles.js";
 import { localize } from "./localize/localize.js";
@@ -11,6 +11,7 @@ export class YampLyricsView extends LitElement {
       position: { type: Number },
       loading: { type: Boolean },
       error: { type: Boolean },
+      playing: { type: Boolean },
       activeThemeColor: { type: String },
       mode: { type: String },
       preRoll: { type: Number },
@@ -28,6 +29,7 @@ export class YampLyricsView extends LitElement {
     this.position = 0;
     this.loading = false;
     this.error = false;
+    this.playing = true;
     this.activeThemeColor = "#ffffff";
     this.mode = "default";
     this.preRoll = 0;
@@ -45,6 +47,10 @@ export class YampLyricsView extends LitElement {
   }
 
   firstUpdated() {
+    const isInstrumentalTrack = this.lyrics?.length === 1 && Boolean(this.lyrics[0].isInstrumental);
+    if (isInstrumentalTrack) {
+      this._activeIndex = 0;
+    }
     // Initial scroll position
     if (this._activeIndex !== -1) {
       this._scrollToActive("auto");
@@ -61,8 +67,10 @@ export class YampLyricsView extends LitElement {
 
     if (changedProps.has("lyrics")) {
       this._activeIndex = -1;
-      const isUnsynced = !this.lyrics?.some((l) => l.time !== null);
-      const isUnsyncedMode = this.mode === "text";
+      const isInstrumentalTrack =
+        this.lyrics?.length === 1 && Boolean(this.lyrics[0].isInstrumental);
+      const isUnsynced = !isInstrumentalTrack && !this.lyrics?.some((l) => l.time !== null);
+      const isUnsyncedMode = !isInstrumentalTrack && this.mode === "text";
       if (isUnsynced || isUnsyncedMode) {
         const container = this.renderRoot.querySelector(".lyrics-scroll-container");
         if (container) {
@@ -80,7 +88,17 @@ export class YampLyricsView extends LitElement {
   }
 
   _updateActiveLyric() {
-    if (!this.lyrics || this.lyrics.length === 0 || this.mode === "text") return;
+    if (!this.lyrics || this.lyrics.length === 0) return;
+
+    if (this.lyrics.length === 1 && Boolean(this.lyrics[0].isInstrumental)) {
+      if (this._activeIndex !== 0) {
+        this._activeIndex = 0;
+        this.updateComplete.then(() => this._scrollToActive());
+      }
+      return;
+    }
+
+    if (this.mode === "text") return;
 
     // If not a single line has a time, treat as unsynced
     const isUnsynced = !this.lyrics.some((l) => l.time !== null);
@@ -159,8 +177,9 @@ export class YampLyricsView extends LitElement {
       `;
     }
 
-    const isUnsynced = !this.lyrics.some((l) => l.time !== null);
-    const isUnsyncedMode = this.mode === "text";
+    const isInstrumentalTrack = this.lyrics.length === 1 && Boolean(this.lyrics[0].isInstrumental);
+    const isUnsynced = !isInstrumentalTrack && !this.lyrics.some((l) => l.time !== null);
+    const isUnsyncedMode = !isInstrumentalTrack && this.mode === "text";
 
     return html`
       <div
@@ -174,7 +193,7 @@ export class YampLyricsView extends LitElement {
             : html`<div class="plain-scroll-spacer-top"></div>`
         }
         ${this.lyrics.map((lyric, index) => {
-          const isActive = index === this._activeIndex;
+          const isActive = index === this._activeIndex || isInstrumentalTrack;
           const isScrollMode = this.mode === "scroll";
 
           const classes = {
@@ -187,8 +206,9 @@ export class YampLyricsView extends LitElement {
 
           if (lyric.isInstrumental) {
             return html`
-              <div class="${classMap(classes)}" aria-label="Instrumental Break">
-                <span class="lyrics-playing-indicator">
+              <div class="${classMap(classes)}" aria-label=${lyric.text || "Instrumental Break"}>
+                ${lyric.text ? html`<div class="lyric-instrumental-text">${lyric.text}</div>` : nothing}
+                <span class="lyrics-playing-indicator ${this.playing === false ? "paused" : ""}">
                   <span class="bar"></span>
                   <span class="bar"></span>
                   <span class="bar"></span>

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -4620,10 +4620,53 @@ export const lyricsStyles = css`
 
   .lyric-line.is-instrumental {
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 12px;
     min-height: 32px;
     filter: none;
+  }
+
+  .lyric-instrumental-text {
+    font-size: calc(
+      var(--yamp-lyrics-instrumental-font-size, 1.4rem) * var(--yamp-text-scale-lyrics, 1)
+    );
+    font-weight: 700;
+    line-height: 1.3;
+    opacity: 0.85;
+    text-align: center;
+    letter-spacing: 0.3px;
+    text-shadow: var(--yamp-overlay-text-shadow, 0 2px 4px rgba(0, 0, 0, 0.5));
+  }
+
+  /* Playing indicator animation - equalizer bars within lyricsStyles */
+  @keyframes chipPlayingBar1 {
+    0%,
+    100% {
+      height: 3px;
+    }
+    50% {
+      height: 10px;
+    }
+  }
+  @keyframes chipPlayingBar2 {
+    0%,
+    100% {
+      height: 5px;
+    }
+    50% {
+      height: 12px;
+    }
+  }
+  @keyframes chipPlayingBar3 {
+    0%,
+    100% {
+      height: 4px;
+    }
+    50% {
+      height: 8px;
+    }
   }
 
   .lyrics-playing-indicator {
@@ -4662,6 +4705,11 @@ export const lyricsStyles = css`
 
   .lyric-line.active .lyrics-playing-indicator .bar:nth-child(3) {
     animation: chipPlayingBar3 0.7s ease-in-out 0.3s infinite;
+  }
+
+  :host([data-playing="false"]) .lyrics-playing-indicator .bar,
+  .lyrics-playing-indicator.paused .bar {
+    animation-play-state: paused !important;
   }
 
   .lyrics-loading,

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -6498,6 +6498,15 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         } else if (typeof lyricsArray === "string") {
           lrcString = lyricsArray;
         } else if (typeof lyricsArray === "object") {
+          if (lyricsArray.instrumental) {
+            return [
+              {
+                time: 0,
+                text: localize("lyrics.instrumental") || "Instrumental Track",
+                isInstrumental: true,
+              },
+            ];
+          }
           lrcString = lyricsArray.lyrics || lyricsArray.text || "";
         }
         return lrcString ? parseLrc(lrcString) : [];
@@ -6554,7 +6563,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
       if (data) {
         if (data.instrumental) {
-          return [{ time: null, text: localize("lyrics.instrumental") || "Instrumental Track" }];
+          return [
+            {
+              time: 0,
+              text: localize("lyrics.instrumental") || "Instrumental Track",
+              isInstrumental: true,
+            },
+          ];
         }
         const lrcString = data.syncedLyrics || data.plainLyrics || "";
         return lrcString ? parseLrc(lrcString) : [];
@@ -8811,11 +8826,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
               <yamp-lyrics-view
                 data-match-theme="${String(this.config.match_theme === true)}"
                 data-artwork-fit="${activeArtworkFit}"
+                data-playing="${String(this._isCurrentEntityPlaying())}"
                 .hass=${this.hass}
                 .lyrics=${this._massLyrics}
                 .position=${pos}
                 .loading=${this._fetchingLyrics}
                 .error=${this._lyricsError}
+                .playing=${this._isCurrentEntityPlaying()}
                 .activeThemeColor=${this.config.match_theme === true ? "var(--custom-accent, var(--state-media_player-active-color, var(--primary-color, #ffffff)))" : "var(--custom-accent, #ffffff)"}
                 .mode=${this._isCurrentlyPlayingRadio() ? 'text' : (this.config.lyrics_mode || 'default')}
                 .preRoll=${this.config.lyrics_pre_roll ?? 0}


### PR DESCRIPTION
### Overview
Adds visual and functional enhancements for instrumental tracks in the lyrics view, aligning them with the standard instrumental animation rendered during instrumental breaks on tracks with synced lyrics.

### Changes
1. **Instrumental Track Detection & Formatting**:
   - In `src/yet-another-media-player.js` (`_getLrclibLyrics` and `_getMassLyrics`), explicitly return timed items `{ time: 0, text: localize("lyrics.instrumental") || "Instrumental Track", isInstrumental: true }` when an instrumental track is detected.
   - In `src/lyrics-parser.js` (`parseLrc`), identify standalone instrumental indicators (e.g., `Instrumental`, `[Instrumental]`, `(Instrumental)`, `Instrumental Track`) and parse them as timed instrumental items.

2. **Instrumental View & Animations**:
   - In `src/lyrics-view.js` (`YampLyricsView`), handle single-line instrumental tracks to keep them vertically and horizontally centered with 50% scroll spacers.
   - Render the equalizer playing indicator (`.lyrics-playing-indicator`) alongside the localized instrumental track label.
   - Support pausing equalizer animations when playback is paused via `.playing` property and `data-playing` attribute binding.
   - In `src/yamp-card-styles.js` (`lyricsStyles`), define `@keyframes chipPlayingBar1/2/3` inside the Shadow DOM stylesheet and add `.lyric-instrumental-text` styling.

### Verification
- `npm run validate` passed (ESLint, Prettier, TypeScript `tsc --noEmit`, and Rollup bundle).
- Deployed bundle verified in Home Assistant www path.