### PR TITLE
fix: improve localization detection with browser fallbacks and dynamic options (#476)

### DIFF
--- a/src/localize/localize.js
+++ b/src/localize/localize.js
@@ -20,15 +20,53 @@ const languages = {
   sl,
 };
 
-export function localize(string, search = "", replace = "") {
+let activeHassLanguage = null;
+
+export function setHassLanguage(lang) {
+  if (typeof lang === "string" && lang.trim() !== "") {
+    activeHassLanguage = lang.trim();
+  } else {
+    activeHassLanguage = null;
+  }
+}
+
+function getBrowserLanguage() {
+  if (typeof navigator === "undefined") return "";
+  if (Array.isArray(navigator.languages)) {
+    for (const l of navigator.languages) {
+      if (!l || typeof l !== "string") continue;
+      const normalized = l.replace(/['"]+/g, "").replace("-", "_");
+      const base = normalized.split("_")[0];
+      if (languages[normalized] || languages[base]) {
+        return normalized;
+      }
+    }
+  }
+  return (Array.isArray(navigator.languages) && navigator.languages[0]) || navigator.language || "";
+}
+
+export function getActiveLanguage() {
+  const haElement =
+    typeof document !== "undefined" ? document.querySelector("home-assistant") : null;
+  const haHass = haElement?.hass;
+
   const rawLang = (
-    localStorage.getItem("selectedLanguage") ||
-    document.querySelector("home-assistant")?.hass?.language ||
+    (typeof localStorage !== "undefined" && localStorage.getItem("selectedLanguage")) ||
+    haHass?.selectedLanguage ||
+    haHass?.language ||
+    haHass?.locale?.language ||
+    activeHassLanguage ||
+    getBrowserLanguage() ||
     "en"
   )
     .replace(/['"]+/g, "")
     .replace("-", "_");
-  const lang = languages[rawLang] ? rawLang : rawLang.split("_")[0];
+
+  return languages[rawLang] ? rawLang : rawLang.split("_")[0];
+}
+
+export function localize(string, search = "", replace = "") {
+  const lang = getActiveLanguage();
 
   let translated;
   const parts = string.split(".");

--- a/src/search-sheet.js
+++ b/src/search-sheet.js
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { isMusicAssistantEntity, applyHostnameToUrl } from "./yamp-utils.js";
 import { localize } from "./localize/localize.js";
 
-const playOptions = [
+const getPlayOptions = () => [
   { mode: "replace", icon: "mdi:playlist-remove", label: localize("search.replace") },
   { mode: "next", icon: "mdi:playlist-play", label: localize("search.play_next") },
   { mode: "replace_next", icon: "mdi:playlist-music", label: localize("search.replace_play") },
@@ -818,7 +818,7 @@ export function renderSearchOptionsOverlay({
         <div class="entity-options-sheet">
           <div class="entity-options-title">${item.title}</div>
 
-          ${playOptions
+          ${getPlayOptions()
             .filter((option) => {
               if (option.mode === "add_to_playlist") {
                 return isTrack(item) && massQueueAvailable;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -106,6 +106,7 @@ export interface HomeAssistant {
     is_owner: boolean;
   };
   language: string;
+  selectedLanguage?: string | null;
   locale: {
     language: string;
     number_format?: string;

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -1,18 +1,18 @@
 import { LitElement, html, css, nothing } from "lit";
 import * as yaml from "js-yaml";
-import { localize } from "./localize/localize.js";
+import { localize, setHassLanguage } from "./localize/localize.js";
 
 import { SUPPORT_GROUPING, TEMPLATE_CONFIGS, DEFAULT_LYRICS_BACKGROUND_FADE } from "./constants.js";
 import { isMusicAssistantEntity, getActionPlacement } from "./yamp-utils.js";
 import "./yamp-sortable.js";
 
-const ADAPTIVE_TEXT_SELECTOR_OPTIONS = Object.freeze([
+const getAdaptiveTextSelectorOptions = () => [
   { value: "details", label: localize("card.sections.details") },
   { value: "menu", label: localize("card.sections.menu") },
   { value: "action_chips", label: localize("card.sections.action_chips") },
   { value: "lyrics", label: localize("card.sections.lyrics") },
-]);
-const ADAPTIVE_TEXT_SELECTOR_VALUES = ADAPTIVE_TEXT_SELECTOR_OPTIONS.map((opt) => opt.value);
+];
+const ADAPTIVE_TEXT_SELECTOR_VALUES = Object.freeze(["details", "menu", "action_chips", "lyrics"]);
 
 const VOLUME_MODE_SELECTOR = Object.freeze({
   select: {
@@ -98,6 +98,11 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
   updated(changedProperties) {
     if (changedProperties.has("hass")) {
+      const currentLang =
+        this.hass?.selectedLanguage || this.hass?.language || this.hass?.locale?.language;
+      if (currentLang) {
+        setHassLanguage(currentLang);
+      }
       const oldHass = changedProperties.get("hass");
       if (this.hass?.services !== oldHass?.services) {
         this._serviceItems = this._getServiceItems();
@@ -1142,6 +1147,13 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
 
   render() {
     if (!this._config) return html``;
+    if (this.hass) {
+      const currentLang =
+        this.hass?.selectedLanguage || this.hass?.language || this.hass?.locale?.language;
+      if (currentLang) {
+        setHassLanguage(currentLang);
+      }
+    }
 
     const currentTemplate = this._yamlConfig.template || "custom";
 
@@ -3016,7 +3028,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
               .selector=${{
                 select: {
                   multiple: true,
-                  options: ADAPTIVE_TEXT_SELECTOR_OPTIONS,
+                  options: getAdaptiveTextSelectorOptions(),
                 },
               }}
               .value=${this._getAdaptiveTextTargetsValue()}

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -43,7 +43,7 @@ import {
   isValidArtworkUrl,
   getValidArtworkAttr
 } from "./yamp-utils.js";
-import { localize } from "./localize/localize.js";
+import { localize, setHassLanguage } from "./localize/localize.js";
 
 
 import {
@@ -6339,10 +6339,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     const isAdmin = this.hass?.user?.is_admin === true;
     if (!isAdmin && configSource !== "lrclib") {
       if (configSource === "mass") {
-        console.warn(`YAMP: ${this.localize('lyrics.admin_only_mass')}`);
+        console.warn(`YAMP: ${localize('lyrics.admin_only_mass')}`);
 
         const event = new Event("hass-notification", { bubbles: true, composed: true });
-        event.detail = { message: this.localize('lyrics.admin_only_mass') };
+        event.detail = { message: localize('lyrics.admin_only_mass') };
         this.dispatchEvent(event);
 
         this._fetchingLyrics = false;
@@ -6350,7 +6350,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         this.requestUpdate();
         return;
       } else {
-        console.log(`YAMP: ${this.localize('lyrics.fallback_to_lrclib_non_admin')}`);
+        console.log(`YAMP: ${localize('lyrics.fallback_to_lrclib_non_admin')}`);
         configSource = "lrclib";
       }
     }
@@ -6620,6 +6620,12 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
 
   updated(changedProps) {
+    if (changedProps.has("hass") && this.hass) {
+      const currentLang = this.hass.selectedLanguage || this.hass.language || this.hass.locale?.language;
+      if (currentLang) {
+        setHassLanguage(currentLang);
+      }
+    }
     this._updateHostAttributes();
     if (this._idleImageTemplate && changedProps.has("hass")) {
       this._idleImageTemplateNeedsResolve = true;
@@ -8207,6 +8213,11 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
   render() {
     if (!this.hass || !this.config) return nothing;
+
+    const currentLang = this.hass.selectedLanguage || this.hass.language || this.hass.locale?.language;
+    if (currentLang) {
+      setHassLanguage(currentLang);
+    }
 
 
 


### PR DESCRIPTION
### Summary of Changes

Fixes #476 where YAMP fell back to English on full page reloads when `document.querySelector("home-assistant")?.hass?.language` was not yet available, and prevents static module-level translation freezing.

- **Enhanced Language Fallback Chain (`src/localize/localize.js`)**:
  - Added `getBrowserLanguage()` to inspect `navigator.languages` and `navigator.language`, matching against supported base languages (e.g., `fr-CA` -> `fr`).
  - Added `setHassLanguage(lang)` and an `activeHassLanguage` cache to allow components (`YetAnotherMediaPlayerCard`, `YetAnotherMediaPlayerEditor`) to directly supply the active language from `this.hass`. This also supports Home Assistant Cast and embedded environments where `<home-assistant>` is absent from the DOM.
  - Added checks for `hass.selectedLanguage` and `hass.locale?.language`.
- **Dynamic Search Play Options (`src/search-sheet.js`)**:
  - Replaced the static module-level `playOptions` array with `getPlayOptions()`, ensuring action items in the search sheet evaluate dynamically in the active language at render time rather than freezing in English at module import time.
- **Dynamic Editor Selector Options (`src/yamp-editor.js`)**:
  - Replaced static `ADAPTIVE_TEXT_SELECTOR_OPTIONS` with `getAdaptiveTextSelectorOptions()` and made `ADAPTIVE_TEXT_SELECTOR_VALUES` static.
  - Synced `setHassLanguage()` on `hass` changes in `updated()` and `render()`.
- **Component Synchronization & Bug Fix (`src/yet-another-media-player.js`)**:
  - Synced `setHassLanguage()` on `hass` changes in `updated()` and `render()`.
  - Fixed an issue where `this.localize(...)` was incorrectly called instead of the imported `localize(...)` on lines 6342, 6345, and 6353.
- **TypeScript Types (`src/types.d.ts`)**:
  - Added `selectedLanguage?: string | null` to the `HomeAssistant` interface.

### Verification
- Ran full validation pipeline (`npm run validate`): ESLint, Prettier, TypeScript type check, and Rollup build passed cleanly.
- Verified language detection and fallback across 8 unit test scenarios (browser cold-load fallback, Home Assistant language/locale/selectedLanguage overrides, Cast environments, and multilingual browser fallbacks).
