### PR TITLE
fix: prevent infinite loop when navigating back in album search hierarchy

### DIFF
--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -2704,16 +2704,23 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       } else if (currentLevel.type === 'album') {
         this._searchBreadcrumb = `Tracks from ${currentLevel.name}`;
         this._searchMediaClassFilter = 'track';
+        const artistLevel = this._searchHierarchy.find(level => level.type === 'artist');
+        const artistName = artistLevel ? artistLevel.name : null;
         if (currentLevel.uri && this._isMusicAssistantEntity()) {
-          this._searchQuery = currentLevel.name;
-          this._searchAlbumTracks(currentLevel.name, null, currentLevel.uri);
+          this._searchQuery = "";
+          this._currentSearchQuery = "";
+          this._searchResults = [];
+          this._searchLoading = true;
+          this.requestUpdate();
+          this._loadAlbumTracks(currentLevel.uri, currentLevel.name, artistName).then(() => {
+            this._scrollToTop();
+          });
           return;
         }
         // Fallback search
-        const artistLevel = this._searchHierarchy.find(level => level.type === 'artist');
         const searchParams = { album: currentLevel.name };
-        if (artistLevel) {
-          searchParams.artist = artistLevel.name;
+        if (artistName) {
+          searchParams.artist = artistName;
         }
         this._doSearch('track', searchParams);
       } else if (currentLevel.type === 'playlist') {
@@ -4102,20 +4109,8 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
   }
 
-  // Handle hierarchical search - search for tracks by album
-  async _searchAlbumTracks(albumName, artistName, albumUri = null) {
-    this._searchHierarchy.push({ type: 'album', name: albumName, query: this._searchQuery, uri: albumUri, filter: this._searchMediaClassFilter });
-    this._searchBreadcrumb = `Tracks from ${albumName}`;
-    this._searchResultsByType = {}; // Clear cache for new search
-    this._currentSearchQuery = "";
-    this._searchMediaClassFilter = 'track';
-
-    // Immediate loading state
-    this._searchResults = [];
-    this._searchLoading = true;
-    this._searchQuery = "";
-    this.requestUpdate();
-
+  // Stack-safe loader: fetches album tracks without modifying _searchHierarchy
+  async _loadAlbumTracks(albumUri, albumName, artistName = null) {
     // Priority 1: Use mass_queue integration if available (preferred for Music Assistant)
     if (albumUri && (await this._isMassQueueIntegrationAvailable(this.hass))) {
       const mqTracks = await this._fetchMassQueueTracks(albumUri, "get_album_tracks");
@@ -4174,11 +4169,28 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       searchParams.artist = artistName;
     }
 
+    // Use Music Assistant search with specific parameters for tracks
+    await this._doSearch('track', searchParams);
+  }
+
+  // Handle hierarchical search - search for tracks by album
+  async _searchAlbumTracks(albumName, artistName, albumUri = null) {
+    this._searchHierarchy.push({ type: 'album', name: albumName, query: this._searchQuery, uri: albumUri, filter: this._searchMediaClassFilter });
+    this._searchBreadcrumb = `Tracks from ${albumName}`;
+    this._searchResultsByType = {}; // Clear cache for new search
+    this._currentSearchQuery = "";
+    this._searchMediaClassFilter = 'track';
+
+    // Immediate loading state
+    this._searchResults = [];
+    this._searchLoading = true;
+    this._searchQuery = "";
+    this.requestUpdate();
+
     // Remove swipe handlers when entering hierarchy
     this._removeSearchSwipeHandlers();
 
-    // Use Music Assistant search with specific parameters for tracks
-    await this._doSearch('track', searchParams);
+    await this._loadAlbumTracks(albumUri, albumName, artistName);
   }
 
   // Helper to load tracks for a playlist via mass_queue or browse_media


### PR DESCRIPTION
## Overview
Fixes #477

Separates album track fetching into a dedicated stack-safe loader helper (`_loadAlbumTracks`) to prevent duplicate stack entries during search hierarchy back navigation.

## Problem
When navigating back from a sub-level within an album view (such as the "Add to playlist" modal/picker), `_goBackInSearch` previously called `_searchAlbumTracks(currentLevel.name, null, currentLevel.uri)`. `_searchAlbumTracks` unconditionally pushed a new entry onto `_searchHierarchy`, re-adding the popped level and trapping the user in an infinite back navigation loop.

## Changes
- Extracted stack-safe `_loadAlbumTracks(albumUri, albumName, artistName)` from `_searchAlbumTracks`.
- Updated `_goBackInSearch` to invoke `_loadAlbumTracks` directly instead of `_searchAlbumTracks`, matching the existing pattern used by `_loadPlaylistTracks`.
- Updated `_searchAlbumTracks` to delegate loading to `_loadAlbumTracks` while maintaining initial forward navigation behavior (stack push and swipe handler management).
- Cleaned up duplicate handler removals and return types to keep track loading helpers consistent.

## Verification
- Validated via full test pipeline (`npm run validate`: ESLint, Prettier, TypeScript `tsc --noEmit`, and Rollup build).
- Verified on local Home Assistant instance across Music Assistant queue, browse_media, and fallback search paths.