### PR TITLE
fix: safely parse localStorage selectedLanguage to prevent invalid fallback (#476)

### DIFF
--- a/src/localize/localize.js
+++ b/src/localize/localize.js
@@ -23,11 +23,53 @@ const languages = {
 let activeHassLanguage = null;
 
 export function setHassLanguage(lang) {
-  if (typeof lang === "string" && lang.trim() !== "") {
+  if (
+    typeof lang === "string" &&
+    lang.trim() !== "" &&
+    lang.trim().toLowerCase() !== "null" &&
+    lang.trim().toLowerCase() !== "undefined"
+  ) {
     activeHassLanguage = lang.trim();
   } else {
     activeHassLanguage = null;
   }
+}
+
+function getStoredLanguage() {
+  if (typeof localStorage === "undefined") return "";
+  try {
+    const raw = localStorage.getItem("selectedLanguage");
+    if (!raw) return "";
+    let val = raw;
+    try {
+      val = JSON.parse(raw);
+    } catch {
+      // raw was not JSON-encoded (e.g. set directly as a plain string in console)
+    }
+    if (typeof val === "string") {
+      const cleaned = val.replace(/['"]+/g, "").trim();
+      // JSON.parse("null") yields JS null (caught by typeof check above).
+      // This guard covers direct console entry: localStorage.setItem("selectedLanguage", "null")
+      if (
+        cleaned !== "" &&
+        cleaned.toLowerCase() !== "null" &&
+        cleaned.toLowerCase() !== "undefined"
+      ) {
+        return cleaned;
+      }
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+function sanitizeLanguage(val) {
+  if (typeof val !== "string") return "";
+  const cleaned = val.replace(/['"]+/g, "").trim();
+  return cleaned !== "" && cleaned.toLowerCase() !== "null" && cleaned.toLowerCase() !== "undefined"
+    ? cleaned
+    : "";
 }
 
 function getBrowserLanguage() {
@@ -51,11 +93,11 @@ export function getActiveLanguage() {
   const haHass = haElement?.hass;
 
   const rawLang = (
-    (typeof localStorage !== "undefined" && localStorage.getItem("selectedLanguage")) ||
-    haHass?.selectedLanguage ||
-    haHass?.language ||
-    haHass?.locale?.language ||
-    activeHassLanguage ||
+    getStoredLanguage() ||
+    sanitizeLanguage(haHass?.selectedLanguage) ||
+    sanitizeLanguage(haHass?.language) ||
+    sanitizeLanguage(haHass?.locale?.language) ||
+    sanitizeLanguage(activeHassLanguage) ||
     getBrowserLanguage() ||
     "en"
   )


### PR DESCRIPTION
## Summary

Fixes #476.

Resolves an issue where Yet Another Media Player falls back to English when a user's language is configured via Home Assistant user profile settings rather than an explicitly selected language in browser local storage.

### Root Cause
Home Assistant's frontend stores `localStorage.setItem("selectedLanguage", JSON.stringify(null))` when a user chooses the automatic/default language setting. Because `localStorage.getItem("selectedLanguage")` returns the literal string `"null"`, YAMP's previous truthiness check treated `"null"` as a valid language code, short-circuiting the fallback chain before checking `hass.selectedLanguage`, `hass.language`, `hass.locale.language`, or `navigator.languages`.

### Changes
- Added [getStoredLanguage()](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/localize/localize.js): Safely reads `localStorage.getItem("selectedLanguage")` with `JSON.parse()`. Rejects `"null"`, `"undefined"`, empty strings, and non-string parsed results.
- Added [sanitizeLanguage()](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/localize/localize.js): Validates candidate strings across the fallback chain, stripping quotation artifacts and rejecting `"null"` / `"undefined"`.
- Updated [setHassLanguage()](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/localize/localize.js): Guards against `"null"` and `"undefined"` strings.
- Updated [getActiveLanguage()](file:///Volumes/Jason/Documents/github/yet-another-media-player/src/localize/localize.js): Employs safe stored language parsing and candidate sanitization throughout the fallback chain.

### Verification
- Full validation pipeline passed (`npm run validate`: ESLint, Prettier, TypeScript, Rollup build).
- Tested 13/13 scenarios including DanyLes's specific runtime environment (`localStorage.selectedLanguage = "null"`, `hass.language = "de"` -> correctly resolves to `de`).
- Tested clean fallbacks across empty values, JSON-encoded strings, raw strings, browser language fallbacks, and default `"en"`.