### PR TITLE
fix: prevent layout overflow in artwork overrides editor row

### DIFF
--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -787,6 +787,9 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           display: flex;
           flex-wrap: wrap;
           gap: 12px;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .form-row-multi-column > div {
           flex: 1;
@@ -885,6 +888,9 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           gap: 8px;
           padding: 6px 0px 6px 6px;
           margin: 0px -14px 0px 0px;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         /* wraps the action icon, name textbox and edit button */
         .action-row-inner {
@@ -893,6 +899,9 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           gap: 8px;
           padding: 6px 0px 6px 6px;
           margin: 0px -14px 0px 0px;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .action-row-inner > ha-icon {
           margin-right: 5px;
@@ -903,10 +912,14 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           flex: 1;
           display: flex;
           min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .grow-children > * {
           flex: 1;
           min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .entity-editor-header, .action-editor-header {
           display: flex;
@@ -1077,6 +1090,16 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           align-items: flex-start;
           gap: 8px;
           width: 100%;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
+        }
+        ha-code-editor {
+          display: block;
+          width: 100%;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .icon-button-small {
           display: inline-flex;
@@ -1109,11 +1132,24 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           display: flex;
           justify-content: center;
         }
+        .artwork-row {
+          margin: 0;
+          padding: 6px 0px 6px 6px;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
+        }
+        .artwork-row + .artwork-row {
+          border-top: 1px solid var(--yamp-section-divider, rgba(255, 255, 255, 0.06));
+        }
         .artwork-row .artwork-fields {
           display: flex;
           flex-direction: column;
           gap: 8px;
           flex: 1;
+          min-width: 0;
+          max-width: 100%;
+          box-sizing: border-box;
         }
         .config-subtitle.small {
           font-size: 0.9em;
@@ -1543,6 +1579,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                           <div class="artwork-fields">
                             <ha-selector
                               .hass=${this.hass}
+                              class="full-width"
                               label="${localize("editor.fields.match_field")}"
                               .required=${true}
                               .selector=${{ select: { mode: "dropdown", options: matchOptions } }}
@@ -1779,7 +1816,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                             }
                             <div
                               class="form-row-multi-column"
-                              style="gap:12px; flex-wrap:wrap; align-items:flex-start;"
+                              style="gap:12px; flex-wrap:wrap; align-items:flex-start; width:100%; min-width:0; box-sizing:border-box;"
                             >
                               <div class="grow-children" style="flex:1; min-width: 100px;">
                                 <ha-selector
@@ -1796,6 +1833,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                               <div class="grow-children" style="flex:1.5; min-width: 120px;">
                                 <ha-selector
                                   .hass=${this.hass}
+                                  class="full-width"
                                   label="${localize("editor.fields.object_fit")}"
                                   .required=${false}
                                   .selector=${{
@@ -1851,6 +1889,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                               <div class="grow-children" style="flex:1.5; min-width: 120px;">
                                 <ha-selector
                                   .hass=${this.hass}
+                                  class="full-width"
                                   label="${localize("editor.fields.artwork_position")}"
                                   .required=${false}
                                   .selector=${{

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -889,7 +889,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           padding: 6px 0px 6px 6px;
           margin: 0px -14px 0px 0px;
           min-width: 0;
-          max-width: 100%;
           box-sizing: border-box;
         }
         /* wraps the action icon, name textbox and edit button */
@@ -900,7 +899,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           padding: 6px 0px 6px 6px;
           margin: 0px -14px 0px 0px;
           min-width: 0;
-          max-width: 100%;
           box-sizing: border-box;
         }
         .action-row-inner > ha-icon {
@@ -1134,7 +1132,6 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
         }
         .artwork-row {
           margin: 0;
-          padding: 6px 0px 6px 6px;
           min-width: 0;
           max-width: 100%;
           box-sizing: border-box;
@@ -1814,10 +1811,7 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                                     </div>
                                   `
                             }
-                            <div
-                              class="form-row-multi-column"
-                              style="gap:12px; flex-wrap:wrap; align-items:flex-start; width:100%; min-width:0; box-sizing:border-box;"
-                            >
+                            <div class="form-row-multi-column" style="align-items:flex-start;">
                               <div class="grow-children" style="flex:1; min-width: 100px;">
                                 <ha-selector
                                   .hass=${this.hass}


### PR DESCRIPTION
## Summary
Fixes an issue in the visual card editor where entering a long template or URL into the **Image URL** field in **Artwork Overrides** caused sibling configuration options (**Object Fit** and **Artwork Position**) to be pushed off-screen.

## Changes Made
- **Container Flex Sizing**: Added `min-width: 0`, `max-width: 100%`, and `box-sizing: border-box` to `.form-row-multi-column`, `.grow-children`, `.grow-children > *`, `.editor-field-wrapper`, and `.artwork-row .artwork-fields`.
- **Code Editor Width Constraining**: Added width constraints (`width: 100%`, `max-width: 100%`, `min-width: 0`) to `ha-code-editor` to prevent CodeMirror's intrinsic sizing from breaking out of flex containers.
- **Artwork Row Sizing**: Defined `.artwork-row` with `margin: 0` to counteract negative margins from `.action-row-inner`, and added `.artwork-row + .artwork-row` top border styling for clear visual separation.
- **Selector Full Width**: Added `class="full-width"` to selector elements in the artwork row (`match_field`, `object_fit`, and `artwork_position`).
- **Inline Style Cleanup**: Simplified the multi-column row markup in the artwork editor template.

## Verification
- Validated via `npm run validate` (ESLint, Prettier, TypeScript, Rollup build) with zero errors.
- Visual inspection confirmed controls remain visible and properly wrap or fit within the card editor drawer.