### PR TITLE
feat: add customizable background image, font color, and is_dark_mode template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Below you will find a list of all configuration options.
 | `adaptive_text`            | boolean/array| No           | `false`     | Set to `true` to scale all text, or supply a list of targets (`details`, `menu`, `action_chips`) to choose exactly which sections adapt |
 | `hide_active_entity_label` | boolean      | No           | `false`     | Hide the small entity name label shown at the bottom center when chips are placed in the menu |
 | `details_alignment`        | choice       | No           | `left`      | Align the track title and artist (`left`, `center`, `right`). Set to `none` to completely hide the details section. |
+| `font_color`               | color/string | No           | —           | Custom color for text and icons (hex, rgba, named, or template) ([Supports Templates](#template-support)) |
 | `card_height`              | number/string| No           | —           | Override the card height (in px) ([Supports Templates](#template-support)) |
 | `lyrics_background_fade`   | number/string| No           | `80`        | Opacity percentage (0–100%) for the lyrics overlay background and artwork gradient ([Supports Templates](#template-support)) |
 | `search_view`              | choice       | No           | `list`      | Choose the default layout for search results: `list`, `card`, or `card_minimal` |
@@ -113,6 +114,9 @@ Below you will find a list of all configuration options.
 | `queue_controls_style`     | choice       | No           | `drag_handle` | Style of queue controls: `drag_handle` replaces movement buttons with a single drag handle, `icons` shows classic up/down/next buttons |
 |                                                                                                 |
 | **Artwork**                |              |              |             |                                                                                                 |
+| `background_image`         | image/url/string | No       | —           | Persistent card background image URL, gradient, or color ([Supports Templates](#template-support)) |
+| `background_fit`           | choice       | No           | `cover`     | Control background image scaling: `cover`, `contain`, `fill`, `scale-down`, or `none`           |
+| `background_position`      | choice       | No           | `center center`| Control background image alignment: `center`, `top`, `bottom`, `center left`, `center right`, `top left`, `top right`, `bottom left`, `bottom right` |
 | `artwork_hostname`         | string       | No           | —           | Hostname URL (e.g., `http://192.168.1.50:8123`) prepended to relative artwork URLs; required when Casting to external devices |
 | `artwork_object_fit`       | choice       | No           | `cover`     | Control how artwork scales: `cover`, `contain`, `scaled-contain`, `scaled-contain-alternate`, `fill`, `scale-down`, `none`, or `no_artwork` |
 | `artwork_position`         | choice       | No           | `top center`| Control artwork alignment: `top center`, `center center`, or `bottom center`                     |

--- a/README.md
+++ b/README.md
@@ -658,6 +658,8 @@ The following configuration keys support templates:
 - **`card_height`**: Dynamically adjust the total height of the card.
 - **`lyrics_background_fade`**: Dynamically control the lyrics overlay background opacity percentage (0-100%).
 - **`idle_image`**: Change the background image shown when the player is idle.
+- **`background_image`**: Set a persistent card background image URL, gradient, or color.
+- **`font_color`**: Dynamically control text and icon color across the card.
 - **`navigation_path`**: Create dynamic navigation URLs (e.g., search IMDb or Genius).
 - **`volume_entity`**: Dynamically select which entity controls volume for a specific player.
 - **`music_assistant_entity`**: Dynamically select the companion Music Assistant entity.
@@ -682,6 +684,7 @@ All templates have access to standard Home Assistant template functions (`states
 | `is_source` | `boolean` | `true` if the source selection list is open. |
 | `is_options` | `boolean` | `true` if the entity options menu is open. |
 | `is_transfer_queue` | `boolean` | `true` if the transfer queue menu is open. |
+| `is_dark_mode` | `boolean` | `true` if Home Assistant is currently in dark mode. |
 
 ## Examples
 
@@ -756,6 +759,35 @@ entities:
         }
         return 'media_player.living_room_atv';
       ]]]
+```
+
+### Theme & Dark Mode Adaptation
+Switch background artwork, image, or font colors automatically based on Home Assistant's dark/light theme.
+
+**Jinja2 (Server-Side)**
+```yaml
+background_image: |
+  {% if is_dark_mode %}
+    /local/image/night_media_card.png
+  {% else %}
+    /local/image/noon_media_card.png
+  {% endif %}
+font_color: |
+  {% if is_dark_mode %} #ffffff {% else %} #222222 {% endif %}
+```
+
+**JavaScript (Client-Side)**
+```yaml
+background_image: |
+  [[[
+    return is_dark_mode
+      ? "url('/local/image/night_media_card.png')"
+      : "url('/local/image/noon_media_card.png')";
+  ]]]
+font_color: |
+  [[[
+    return is_dark_mode ? "#ffffff" : "#222222";
+  ]]]
 ```
 
 ## Controls & Typography

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -135,6 +135,10 @@ export const CARD_CONFIG_DEFAULTS = Object.freeze({
   idle_timeout_ms: DEFAULT_IDLE_TIMEOUT_MS,
   idle_screen: "default",
   idle_image: "",
+  background_image: "",
+  font_color: "",
+  background_position: "center center",
+  background_fit: "cover",
   artwork_position: "top center",
   artwork_object_fit: "cover",
   extend_artwork: false,
@@ -198,6 +202,8 @@ export const TEMPLATE_SUPPORTED_FIELDS = Object.freeze(
     "subtitle",
     "idle_artwork",
     "idle_image",
+    "background_image",
+    "font_color",
     "lyrics_background_fade",
   ])
 );

--- a/src/localize/languages/de.js
+++ b/src/localize/languages/de.js
@@ -85,6 +85,11 @@ export default {
           title: "Allgemeine Einstellungen",
           description: "Globale Steuerung der Artwork-Anzeige und -Abrufung.",
         },
+        background: {
+          title: "Hintergrundbild",
+          description:
+            "Konfigurieren Sie ein dauerhaftes Hintergrundbild für die Karte hinter den Wiedergabeinhalten.",
+        },
         idle: {
           title: "Artwork im Leerlauf",
           description:
@@ -236,6 +241,8 @@ export default {
         "Verwenden Sie immer die gekoppelte Music Assistant-Entität für Titel, Künstler und Artwork, auch wenn die primäre Entität gerade spielt.",
       show_volume_overlay:
         "Zeige kurz eine große Lautstärkeanzeige über dem Cover an, wenn sich die Lautstärke ändert.",
+      font_color_helper:
+        "Text- und Symbolfarben anpassen. Akzeptiert Hex, CSS-Namen, RGBA oder Vorlagen (Standard: Theme-Farbe).",
       queue_controls_style:
         "Wählen Sie, ob ein Ziehgriff oder einzelne Bewegungstasten für Warteschlangenelemente angezeigt werden sollen.",
     },
@@ -308,7 +315,12 @@ export default {
       card_height: "Kartenhöhe (px)",
       control_layout: "Steuerungs-Layout",
       idle_image: "Ruhebild",
-
+      background_image: "Hintergrundbild",
+      background_image_entity: "Hintergrundbild-Entität",
+      font_color: "Schriftfarbe",
+      font_color_entity: "Schriftfarbe",
+      background_position: "Hintergrundposition",
+      background_fit: "Hintergrundanpassung",
       image_url: "Bild-URL",
       fallback_image_url: "Fallback Bild-URL",
       move_to_main: "Aktion in Haupt-Chips verschieben",
@@ -422,6 +434,24 @@ export default {
       top: "Oben",
       center: "Mitte",
       bottom: "Unten",
+    },
+    background_fit: {
+      cover: "Ausfüllen",
+      contain: "Einpassen",
+      fill: "Dehnen",
+      "scale-down": "Herunterskalieren",
+      none: "Keine",
+    },
+    background_position: {
+      center: "Mitte",
+      top: "Oben",
+      bottom: "Unten",
+      "center left": "Mitte links",
+      "center right": "Mitte rechts",
+      "top left": "Oben links",
+      "top right": "Oben rechts",
+      "bottom left": "Unten links",
+      "bottom right": "Unten rechts",
     },
   },
   card: {

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -84,6 +84,11 @@ export default {
           title: "General Settings",
           description: "Global controls for how artwork is displayed and retrieved.",
         },
+        background: {
+          title: "Background Image",
+          description:
+            "Configure a persistent background image for the card behind playback content.",
+        },
         idle: {
           title: "Idle Artwork",
           description: "Show a static image or entity snapshot whenever nothing is playing.",
@@ -233,6 +238,8 @@ export default {
         "Always use the paired Music Assistant entity for track title, artist, and artwork, even if the primary entity is playing.",
       show_volume_overlay:
         "Briefly display a large volume indicator over the artwork when the volume level changes.",
+      font_color_helper:
+        "Customize text and icon colors. Accepts hex, CSS names, rgba, or templates (default: theme color).",
     },
     titles: {
       edit_entity: "Edit Entity",
@@ -303,6 +310,12 @@ export default {
       card_height: "Card Height (px)",
       control_layout: "Control Layout",
       idle_image: "Idle Image",
+      background_image: "Background Image",
+      background_image_entity: "Background Image Entity",
+      font_color: "Font Color",
+      font_color_entity: "Font Color Entity",
+      background_position: "Background Position",
+      background_fit: "Background Fit",
       image_url: "Image URL",
       fallback_image_url: "Fallback Image URL",
       move_to_main: "Move action to main chips",
@@ -416,6 +429,24 @@ export default {
       top: "Top",
       center: "Center",
       bottom: "Bottom",
+    },
+    background_fit: {
+      cover: "Cover",
+      contain: "Contain",
+      fill: "Fill",
+      "scale-down": "Scale Down",
+      none: "None",
+    },
+    background_position: {
+      center: "Center",
+      top: "Top",
+      bottom: "Bottom",
+      "center left": "Center Left",
+      "center right": "Center Right",
+      "top left": "Top Left",
+      "top right": "Top Right",
+      "bottom left": "Bottom Left",
+      "bottom right": "Bottom Right",
     },
   },
   card: {

--- a/src/localize/languages/en.js
+++ b/src/localize/languages/en.js
@@ -313,7 +313,7 @@ export default {
       background_image: "Background Image",
       background_image_entity: "Background Image Entity",
       font_color: "Font Color",
-      font_color_entity: "Font Color Entity",
+      font_color_entity: "Font Color",
       background_position: "Background Position",
       background_fit: "Background Fit",
       image_url: "Image URL",

--- a/src/localize/languages/es.js
+++ b/src/localize/languages/es.js
@@ -86,6 +86,11 @@ export default {
           title: "Ajustes generales",
           description: "Controles globales para la portada.",
         },
+        background: {
+          title: "Imagen de fondo",
+          description:
+            "Configura una imagen de fondo persistente para la tarjeta detrás del contenido de reproducción.",
+        },
         idle: {
           title: "Portada en reposo",
           description: "Mostrar imagen estática cuando nada se reproduce.",
@@ -222,6 +227,8 @@ export default {
         "Utilizar siempre la entidad de Music Assistant emparejada para el título de la pista, el artista y el arte, incluso si la entidad primaria está reproduciendo.",
       show_volume_overlay:
         "Muestra brevemente un indicador de volumen grande sobre la carátula cuando cambia el nivel de volumen.",
+      font_color_helper:
+        "Personaliza los colores del texto y los iconos. Acepta hex, nombres CSS, rgba o plantillas (predeterminado: color del tema).",
       queue_controls_style:
         "Elige si mostrar un tirador de arrastre o botones de movimento individuales para los elementos de la cola.",
     },
@@ -294,7 +301,12 @@ export default {
       card_height: "Altura (px)",
       control_layout: "Diseño",
       idle_image: "Imagen de reposo",
-
+      background_image: "Imagen de fondo",
+      background_image_entity: "Entidad de imagen de fondo",
+      font_color: "Color de fuente",
+      font_color_entity: "Color de fuente",
+      background_position: "Posición del fondo",
+      background_fit: "Ajuste del fondo",
       image_url: "URL imagen",
       fallback_image_url: "URL de respaldo",
       move_to_main: "Mover a chips principales",
@@ -408,6 +420,24 @@ export default {
       top: "Arriba",
       center: "Centro",
       bottom: "Abajo",
+    },
+    background_fit: {
+      cover: "Cubrir",
+      contain: "Contener",
+      fill: "Rellenar",
+      "scale-down": "Reducir escala",
+      none: "Ninguno",
+    },
+    background_position: {
+      center: "Centro",
+      top: "Arriba",
+      bottom: "Abajo",
+      "center left": "Centro izquierda",
+      "center right": "Centro derecha",
+      "top left": "Arriba izquierda",
+      "top right": "Arriba derecha",
+      "bottom left": "Abajo izquierda",
+      "bottom right": "Abajo derecha",
     },
   },
   card: {

--- a/src/localize/languages/fr.js
+++ b/src/localize/languages/fr.js
@@ -86,6 +86,11 @@ export default {
           title: "Paramètres Généraux",
           description: "Contrôles globaux pour l'affichage des illustrations.",
         },
+        background: {
+          title: "Image d'arrière-plan",
+          description:
+            "Configurez une image d'arrière-plan persistante pour la carte derrière le contenu en cours de lecture.",
+        },
         idle: {
           title: "Illustration au Repos",
           description: "Afficher une image statique lorsque rien n'est en lecture.",
@@ -227,6 +232,8 @@ export default {
         "Toujours utiliser l'entité Music Assistant associée pour le titre de la piste, l'artiste et l'image, même si l'entité principale est en cours de lecture.",
       show_volume_overlay:
         "Affiche brièvement un grand indicateur de volume sur l'illustration lorsque le niveau de volume change.",
+      font_color_helper:
+        "Personnalisez les couleurs du texte et des icônes. Accepte l'hexadécimal, les noms CSS, rgba ou les modèles (par défaut: couleur du thème).",
       queue_controls_style:
         "Choisissez d'afficher une poignée de glissement ou des boutons de déplacement individuels pour les éléments de la file d'attente.",
     },
@@ -299,7 +306,12 @@ export default {
       card_height: "Hauteur (px)",
       control_layout: "Mise en page",
       idle_image: "Image de veille",
-
+      background_image: "Image d'arrière-plan",
+      background_image_entity: "Entité d'image d'arrière-plan",
+      font_color: "Couleur de police",
+      font_color_entity: "Couleur de police",
+      background_position: "Position de l'arrière-plan",
+      background_fit: "Ajustement de l'arrière-plan",
       image_url: "URL image",
       fallback_image_url: "URL de secours",
       move_to_main: "Mettre dans les jetons principaux",
@@ -413,6 +425,24 @@ export default {
       top: "Haut",
       center: "Centre",
       bottom: "Bas",
+    },
+    background_fit: {
+      cover: "Couvrir",
+      contain: "Contenir",
+      fill: "Remplir",
+      "scale-down": "Réduire",
+      none: "Aucun",
+    },
+    background_position: {
+      center: "Centre",
+      top: "Haut",
+      bottom: "Bas",
+      "center left": "Centre gauche",
+      "center right": "Centre droite",
+      "top left": "Haut gauche",
+      "top right": "Haut droite",
+      "bottom left": "Bas gauche",
+      "bottom right": "Bas droite",
     },
   },
   card: {

--- a/src/localize/languages/it.js
+++ b/src/localize/languages/it.js
@@ -86,6 +86,11 @@ export default {
           title: "Impostazioni generali",
           description: "Controlli globali per la copertina.",
         },
+        background: {
+          title: "Immagine di sfondo",
+          description:
+            "Configura un'immagine di sfondo persistente per la scheda dietro il contenuto in riproduzione.",
+        },
         idle: {
           title: "Copertina in riposo",
           description: "Mostra un'immagine statica quando non c'è riproduzione.",
@@ -220,6 +225,8 @@ export default {
         "Utilizza sempre l'entità Music Assistant associata per il titolo del brano, l'artista e l'artwork, anche se l'entità principale è in riproduzione.",
       show_volume_overlay:
         "Visualizza brevemente un grande indicatore del volume sopra la copertina quando il livello del volume cambia.",
+      font_color_helper:
+        "Personalizza i colori di testo e icone. Accetta esadecimale, nomi CSS, rgba o modelli (predefinito: colore del tema).",
       queue_controls_style:
         "Scegli se mostrare una maniglia di trascinamento o pulsanti di movimento singoli per gli elementi della coda.",
     },
@@ -292,7 +299,12 @@ export default {
       card_height: "Altezza (px)",
       control_layout: "Design",
       idle_image: "Immagine di inattività",
-
+      background_image: "Immagine di sfondo",
+      background_image_entity: "Entità immagine di sfondo",
+      font_color: "Colore del carattere",
+      font_color_entity: "Colore del carattere",
+      background_position: "Posizione dello sfondo",
+      background_fit: "Adattamento sfondo",
       image_url: "URL immagine",
       fallback_image_url: "URL fallback",
       move_to_main: "Sposta in chip principali",
@@ -406,6 +418,24 @@ export default {
       top: "In alto",
       center: "Centro",
       bottom: "In basso",
+    },
+    background_fit: {
+      cover: "Copri",
+      contain: "Contieni",
+      fill: "Riempi",
+      "scale-down": "Riduci",
+      none: "Nessuno",
+    },
+    background_position: {
+      center: "Centro",
+      top: "In alto",
+      bottom: "In basso",
+      "center left": "Al centro a sinistra",
+      "center right": "Al centro a destra",
+      "top left": "In alto a sinistra",
+      "top right": "In alto a destra",
+      "bottom left": "In basso a sinistra",
+      "bottom right": "In basso a destra",
     },
   },
   card: {

--- a/src/localize/languages/nl.js
+++ b/src/localize/languages/nl.js
@@ -85,6 +85,11 @@ export default {
           title: "Algemene Instellingen",
           description: "Globale instellingen voor hoe artwork wordt weergegeven en opgehaald.",
         },
+        background: {
+          title: "Achtergrondafbeelding",
+          description:
+            "Configureer een persistente achtergrondafbeelding voor de kaart achter de afspeelcontent.",
+        },
         idle: {
           title: "Artwork bij Inactiviteit",
           description:
@@ -246,6 +251,8 @@ export default {
         "Gebruik altijd de gekoppelde Music Assistant-entiteit voor de tracktitel, artiest en artwork, zelfs als de primaire entiteit wordt afgespeeld.",
       show_volume_overlay:
         "Geef kort een grote volume-indicator weer over het artwork wanneer het volumeniveau verandert.",
+      font_color_helper:
+        "Pas tekst- en pictogramkleuren aan. Accepteert hex, CSS-namen, rgba of sjablonen (standaard: themakleur).",
       queue_controls_style:
         "Kies of u een sleephandgreep of individuele bewegingsknoppen wilt weergeven voor wachtrij-items.",
     },
@@ -318,7 +325,12 @@ export default {
       card_height: "Kaarthoogte (px)",
       control_layout: "Knoppen Lay-out",
       idle_image: "Rustafbeelding",
-
+      background_image: "Achtergrondafbeelding",
+      background_image_entity: "Achtergrondafbeelding Entiteit",
+      font_color: "Letterkleur",
+      font_color_entity: "Letterkleur",
+      background_position: "Achtergrondpositie",
+      background_fit: "Achtergrondpassing",
       image_url: "Afbeelding URL",
       fallback_image_url: "Fallback Afbeelding URL",
       move_to_main: "Verplaats actie naar hoofdchips",
@@ -432,6 +444,24 @@ export default {
       top: "Boven",
       center: "Midden",
       bottom: "Onder",
+    },
+    background_fit: {
+      cover: "Bedekken",
+      contain: "Passend maken",
+      fill: "Vullen",
+      "scale-down": "Verkleinen",
+      none: "Geen",
+    },
+    background_position: {
+      center: "Midden",
+      top: "Boven",
+      bottom: "Onder",
+      "center left": "Midden links",
+      "center right": "Midden rechts",
+      "top left": "Boven links",
+      "top right": "Boven rechts",
+      "bottom left": "Onder links",
+      "bottom right": "Onder rechts",
     },
   },
   card: {

--- a/src/localize/languages/pt.js
+++ b/src/localize/languages/pt.js
@@ -86,6 +86,11 @@ export default {
           title: "Definições gerais",
           description: "Controlos globais para a capa.",
         },
+        background: {
+          title: "Imagem de fundo",
+          description:
+            "Configure uma imagem de fundo persistente para o cartão atrás do conteúdo em reprodução.",
+        },
         idle: {
           title: "Capa em repouso",
           description: "Mostrar imagem estática quando nada toca.",
@@ -221,6 +226,8 @@ export default {
         "Utilizar sempre a entidade Music Assistant emparelhada para o título da faixa, artista e arte, mesmo que a entidade primária esteja a ser reproduzida.",
       show_volume_overlay:
         "Exibe brevemente um indicador de volume grande sobre a arte quando o nível de volume muda.",
+      font_color_helper:
+        "Personalize as cores do texto e dos ícones. Aceita hexadecimal, nomes CSS, rgba ou modelos (padrão: cor do tema).",
       queue_controls_style:
         "Escolha se deseja mostrar uma alça de arrastar ou botões de movimento individuais para itens da fila.",
     },
@@ -293,7 +300,12 @@ export default {
       card_height: "Altura (px)",
       control_layout: "Design",
       idle_image: "Imagem de inatividade",
-
+      background_image: "Imagem de fundo",
+      background_image_entity: "Entidade da imagem de fundo",
+      font_color: "Cor da fonte",
+      font_color_entity: "Cor da fonte",
+      background_position: "Posição do fundo",
+      background_fit: "Ajuste do fundo",
       image_url: "URL imagem",
       fallback_image_url: "URL de reserva",
       move_to_main: "Mover para chips principais",
@@ -407,6 +419,24 @@ export default {
       top: "Topo",
       center: "Centro",
       bottom: "Inferior",
+    },
+    background_fit: {
+      cover: "Cobrir",
+      contain: "Conter",
+      fill: "Preencher",
+      "scale-down": "Reduzir escala",
+      none: "Nenhum",
+    },
+    background_position: {
+      center: "Centro",
+      top: "Topo",
+      bottom: "Fundo",
+      "center left": "Centro esquerda",
+      "center right": "Centro direita",
+      "top left": "Topo esquerda",
+      "top right": "Topo direita",
+      "bottom left": "Fundo esquerda",
+      "bottom right": "Fundo direita",
     },
   },
   card: {

--- a/src/localize/languages/sk.js
+++ b/src/localize/languages/sk.js
@@ -85,6 +85,10 @@ export default {
           title: "Všeobecné nastavenia",
           description: "Globálne ovládanie toho, ako sa grafika zobrazuje a získava.",
         },
+        background: {
+          title: "Obrázok pozadia",
+          description: "Nakonfigurujte trvalý obrázok pozadia pre kartu za obsahom prehrávania.",
+        },
         idle: {
           title: "Grafika pri nečinnosti",
           description: "Zobraziť statický obrázok alebo snímku entity, keď sa nič neprehráva.",
@@ -237,6 +241,8 @@ export default {
         "Vždy používajte spárovanú entitu Music Assistant pre názov skladby, interpreta a grafiku, aj keď sa prehráva primárna entita.",
       show_volume_overlay:
         "Pri zmene úrovne hlasitosti nakrátko zobrazí veľký ukazovateľ hlasitosti cez grafiku albumu.",
+      font_color_helper:
+        "Prispôsobte farby textu a ikon. Prijíma hex, názvy CSS, rgba alebo šablóny (predvolené: farba motívu).",
       queue_controls_style:
         "Vyberte, či sa má pre položky fronty zobraziť úchyt na ťahanie alebo jednotlivé tlačidlá pohybu.",
     },
@@ -309,7 +315,12 @@ export default {
       card_height: "Výška karty (px)",
       control_layout: "Rozloženie ovládania",
       idle_image: "Obrázok nečinnosti",
-
+      background_image: "Obrázok pozadia",
+      background_image_entity: "Entita obrázka pozadia",
+      font_color: "Farba písma",
+      font_color_entity: "Farba písma",
+      background_position: "Pozícia pozadia",
+      background_fit: "Prispôsobenie pozadia",
       image_url: "URL obrázka",
       fallback_image_url: "Záložná URL obrázka",
       move_to_main: "Presunúť do hlavných čipov",
@@ -423,6 +434,24 @@ export default {
       top: "Hore",
       center: "Stred",
       bottom: "Dole",
+    },
+    background_fit: {
+      cover: "Pokryť",
+      contain: "Zmestiť",
+      fill: "Vyplniť",
+      "scale-down": "Zmenšiť",
+      none: "Žiadne",
+    },
+    background_position: {
+      center: "Stred",
+      top: "Hore",
+      bottom: "Dole",
+      "center left": "V strede vľavo",
+      "center right": "V strede vpravo",
+      "top left": "Vľavo hore",
+      "top right": "Vpravo hore",
+      "bottom left": "Vľavo dole",
+      "bottom right": "Vpravo dole",
     },
   },
   card: {

--- a/src/localize/languages/sl.js
+++ b/src/localize/languages/sl.js
@@ -85,6 +85,10 @@ export default {
           title: "Splošne nastavitve",
           description: "Globalni nadzor nad prikazom in pridobivanjem grafike.",
         },
+        background: {
+          title: "Slika ozadja",
+          description: "Konfigurirajte trajno sliko ozadja za kartico za vsebino predvajanja.",
+        },
         idle: {
           title: "Grafika v mirovanju",
           description: "Prikaži statično sliko ali posnetek entitete, ko se nič ne predvaja.",
@@ -218,6 +222,8 @@ export default {
         "Za naslov skladbe, izvajalca in grafiko vedno uporabi seznanjeno entiteto Music Assistant, tudi če se predvaja primarna entiteta.",
       show_volume_overlay:
         "Ob spremembi glasnosti za kratek čas prikaže velik indikator glasnosti čez naslovnico.",
+      font_color_helper:
+        "Prilagodite barve besedila in ikon. Sprejema šestnajstiško, imena CSS, rgba ali predloge (privzeto: barva teme).",
       queue_controls_style:
         "Izberite, ali želite prikazati ročaj za vlečenje ali posamezne gumbe za premikanje elementov čakalne vrste.",
     },
@@ -290,7 +296,12 @@ export default {
       card_height: "Višina kartice (px)",
       control_layout: "Postavitev kontrolnikov",
       idle_image: "Slika v mirovanju",
-
+      background_image: "Slika ozadja",
+      background_image_entity: "Entiteta slike ozadja",
+      font_color: "Barva pisave",
+      font_color_entity: "Barva pisave",
+      background_position: "Položaj ozadja",
+      background_fit: "Prilagajanje ozadja",
       image_url: "URL slike",
       fallback_image_url: "Rezervni URL slike",
       move_to_main: "Premakni dejanje na glavno vrstico",
@@ -404,6 +415,24 @@ export default {
       top: "Zgoraj",
       center: "Sredina",
       bottom: "Spodaj",
+    },
+    background_fit: {
+      cover: "Prekrij",
+      contain: "Prilagodi",
+      fill: "Zapolni",
+      "scale-down": "Pomanjšaj",
+      none: "Brez",
+    },
+    background_position: {
+      center: "Sredina",
+      top: "Zgoraj",
+      bottom: "Spodaj",
+      "center left": "Sredina levo",
+      "center right": "Sredina desno",
+      "top left": "Zgoraj levo",
+      "top right": "Zgoraj desno",
+      "bottom left": "Spodaj levo",
+      "bottom right": "Spodaj desno",
     },
   },
   card: {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -227,6 +227,10 @@ export interface YampCardConfig {
   idle_timeout_ms?: number;
   idle_screen?: "default" | "artwork" | "blank" | "collapsed" | "transparent" | string;
   idle_image?: string;
+  background_image?: string;
+  font_color?: string;
+  background_position?: "top center" | "center center" | "bottom center" | string;
+  background_fit?: "cover" | "contain" | "fill" | "scale-down" | "none" | string;
   media_artwork_overrides?: ArtworkOverrideRule[];
   artwork_position?: "top center" | "center center" | "bottom center" | string;
   artwork_object_fit?:

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -277,14 +277,23 @@ export interface YampCardConfig {
 export interface TemplateContext {
   is_playing: boolean;
   is_idle: boolean;
-  is_paused: boolean;
-  is_off: boolean;
-  current: HassEntity | null;
-  current_entity: HassEntity | null;
-  activeEntity: string;
-  selectedIndex: number;
-  hass: HomeAssistant;
-  config: YampCardConfig;
+  is_paused?: boolean;
+  is_off?: boolean;
+  is_search?: boolean;
+  is_grouping?: boolean;
+  is_source?: boolean;
+  is_lyrics?: boolean;
+  is_options?: boolean;
+  is_transfer_queue?: boolean;
+  is_any_menu_open?: boolean;
+  is_dark_mode: boolean;
+  entity?: string;
+  current: HassEntity | string | null;
+  current_entity?: HassEntity | null;
+  activeEntity?: string;
+  selectedIndex?: number;
+  hass?: HomeAssistant;
+  config?: YampCardConfig;
 }
 
 export interface MusicAssistantItem {

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1159,7 +1159,6 @@ export const yampCardStyles = css`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: #fff;
   }
 
   :host([data-details-alignment="center"]) .details {
@@ -1917,7 +1916,39 @@ export const yampCardStyles = css`
     color: #fff;
   }
 
-  /* Match Theme mode & Scaled Contain Alternate mode - use theme colors for high contrast in light/dark themes */
+  /* Match Theme mode, custom font color & Scaled Contain Alternate mode - use theme or custom colors */
+  .yamp-card-inner[data-has-font-color="true"] .details,
+  .yamp-card-inner[data-has-font-color="true"] .title,
+  .yamp-card-inner[data-has-font-color="true"] .artist,
+  .yamp-card-inner[data-has-font-color="true"] .source-menu-btn,
+  .yamp-card-inner[data-has-font-color="true"] .source-selected,
+  .yamp-card-inner[data-has-font-color="true"] .controls-row,
+  .yamp-card-inner[data-has-font-color="true"] .button,
+  .yamp-card-inner[data-has-font-color="true"] .modern-button,
+  .yamp-card-inner[data-has-font-color="true"] .vol-stepper span,
+  .yamp-card-inner[data-has-font-color="true"] .vol-label,
+  .yamp-card-inner[data-has-font-color="true"] .more-info-btn ha-icon,
+  .yamp-card-inner[data-has-font-color="true"] .volume-icon-btn,
+  .yamp-card-inner[data-has-font-color="true"] .volume-icon-btn ha-icon,
+  .yamp-card-inner[data-has-font-color="true"] .radio-mode-button,
+  .yamp-card-inner[data-has-font-color="true"] .volume-slider-icon,
+  .yamp-card-inner[data-has-font-color="true"] .timestamps-container,
+  .yamp-card-inner[data-match-theme="true"] .details,
+  .yamp-card-inner[data-match-theme="true"] .title,
+  .yamp-card-inner[data-match-theme="true"] .artist,
+  .yamp-card-inner[data-match-theme="true"] .source-menu-btn,
+  .yamp-card-inner[data-match-theme="true"] .source-selected,
+  .yamp-card-inner[data-match-theme="true"] .controls-row,
+  .yamp-card-inner[data-match-theme="true"] .button,
+  .yamp-card-inner[data-match-theme="true"] .modern-button,
+  .yamp-card-inner[data-match-theme="true"] .vol-stepper span,
+  .yamp-card-inner[data-match-theme="true"] .vol-label,
+  .yamp-card-inner[data-match-theme="true"] .more-info-btn ha-icon,
+  .yamp-card-inner[data-match-theme="true"] .volume-icon-btn,
+  .yamp-card-inner[data-match-theme="true"] .volume-icon-btn ha-icon,
+  .yamp-card-inner[data-match-theme="true"] .radio-mode-button,
+  .yamp-card-inner[data-match-theme="true"] .volume-slider-icon,
+  .yamp-card-inner[data-match-theme="true"] .timestamps-container,
   .yamp-card-inner[data-lyrics-active="true"] .details,
   .yamp-card-inner[data-lyrics-active="true"] .title,
   .yamp-card-inner[data-lyrics-active="true"] .artist,
@@ -1953,6 +1984,8 @@ export const yampCardStyles = css`
     color: var(--primary-text);
   }
 
+  .yamp-card-inner[data-has-font-color="true"] .modern-button,
+  .yamp-card-inner[data-match-theme="true"] .modern-button,
   .yamp-card-inner[data-lyrics-active="true"] .modern-button,
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .modern-button {
     background: color-mix(in srgb, var(--primary-text), transparent 85%);
@@ -1960,6 +1993,8 @@ export const yampCardStyles = css`
   }
 
   /* Hamburger icon (span) uses !important in base styles, so we override it here */
+  .yamp-card-inner[data-has-font-color="true"] .more-info-icon,
+  .yamp-card-inner[data-match-theme="true"] .more-info-icon,
   .yamp-card-inner[data-lyrics-active="true"] .more-info-icon,
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .more-info-icon {
     color: var(--primary-text) !important;

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1844,18 +1844,20 @@ export const yampCardStyles = css`
     .card-lower-content
     > :not(.card-artwork-spacer):not(.in-menu-active-label):not(.more-info-menu):not(
       .collapsed-artwork-container
-    ) {
+    ):not(.collapsed-progress-bar) {
     position: relative;
   }
 
   .yamp-card-inner[data-lyrics-active="true"] .in-menu-active-label,
   .yamp-card-inner[data-lyrics-active="true"] .more-info-menu.volume-collapsed,
-  .yamp-card-inner[data-lyrics-active="true"] .collapsed-artwork-container {
+  .yamp-card-inner[data-lyrics-active="true"] .collapsed-artwork-container,
+  .yamp-card-inner[data-lyrics-active="true"] .collapsed-progress-bar {
     position: absolute !important;
     z-index: ${Z_LAYERS.FLOATING_CONTROLS};
   }
 
-  .yamp-card-inner[data-lyrics-active="true"] .in-menu-active-label {
+  .yamp-card-inner[data-lyrics-active="true"] .in-menu-active-label,
+  .yamp-card-inner[data-lyrics-active="true"] .collapsed-progress-bar {
     pointer-events: none !important;
   }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -244,7 +244,9 @@ export const yampCardStyles = css`
   }
 
   ha-card.yamp-card {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
     border-radius: var(--border-radius);
     box-shadow: var(--ha-card-box-shadow, none);
     background: transparent;
@@ -258,8 +260,12 @@ export const yampCardStyles = css`
   }
 
   /* Static background color fallback for inset artwork layouts */
-  ha-card.yamp-card:has(> .yamp-card-inner[data-artwork-fit="scaled-contain"]),
-  ha-card.yamp-card:has(> .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"]) {
+  ha-card.yamp-card:has(
+      > .yamp-card-inner[data-has-background-image="false"][data-artwork-fit="scaled-contain"]
+    ),
+  ha-card.yamp-card:has(
+      > .yamp-card-inner[data-has-background-image="false"][data-artwork-fit="scaled-contain-alternate"]
+    ) {
     background: var(--card-bg);
   }
 
@@ -267,12 +273,37 @@ export const yampCardStyles = css`
     position: relative;
     z-index: ${Z_LAYERS.FLOATING_ELEMENT};
     height: 100%;
+    min-height: 100%;
+    flex: 1 1 100%;
     display: flex;
     flex-direction: column;
     overflow: hidden;
     container-type: inline-size;
     border-radius: var(--border-radius);
     clip-path: inset(0 round var(--border-radius));
+    transform: translateZ(0);
+  }
+
+  .card-background-image-layer {
+    position: absolute;
+    inset: 0;
+    z-index: ${Z_LAYERS.MEDIA_BACKGROUND};
+    background-repeat: no-repeat;
+    pointer-events: none;
+    transform: translateZ(0);
+  }
+
+  .card-background-image-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: ${Z_LAYERS.MEDIA_BACKGROUND};
+    pointer-events: none;
+    background: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.2) 0%,
+      rgba(0, 0, 0, 0.4) 50%,
+      rgba(0, 0, 0, 0.6) 100%
+    );
     transform: translateZ(0);
   }
 

--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -307,6 +307,11 @@ export const yampCardStyles = css`
     transform: translateZ(0);
   }
 
+  .yamp-card-inner[data-lyrics-active="true"] .card-background-image-overlay,
+  :host([data-disable-artwork-gradient="true"]) .card-background-image-overlay {
+    display: none !important;
+  }
+
   .full-bleed-artwork-bg {
     position: absolute;
     inset: -50px;

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -1547,7 +1547,8 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                                     .value=${this._config.background_image ?? ""}
                                     @value-changed=${(e) =>
                                       this._updateConfig("background_image", e.detail.value)}
-                                    label="e.g., https://example.com/image.jpg or /local/custom/image.jpg"
+                                    .label=${localize("editor.fields.image_url")}
+                                    placeholder="https://... or /local/..."
                                     helper="${localize("editor.subtitles.image_url_helper")}"
                                   ></ha-selector>
                                 `
@@ -1741,7 +1742,8 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
                                     .value=${this._config.idle_image ?? ""}
                                     @value-changed=${(e) =>
                                       this._updateConfig("idle_image", e.detail.value)}
-                                    label="e.g., https://example.com/image.jpg or /local/custom/image.jpg"
+                                    .label=${localize("editor.fields.image_url")}
+                                    placeholder="https://... or /local/..."
                                     helper="${localize("editor.subtitles.image_url_helper")}"
                                   ></ha-selector>
                                 `

--- a/src/yamp-editor.js
+++ b/src/yamp-editor.js
@@ -380,6 +380,37 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
     return typeof val === "string" && /^[a-z_]+\.[a-zA-Z0-9_]+$/.test(val.trim());
   }
 
+  _toHexColor(val) {
+    if (!val || typeof val !== "string") return "#ffffff";
+    const trimmed = val.trim().toLowerCase();
+    if (/^#[0-9a-f]{6}$/.test(trimmed)) return trimmed;
+    if (/^#[0-9a-f]{3}$/.test(trimmed)) {
+      return "#" + trimmed[1] + trimmed[1] + trimmed[2] + trimmed[2] + trimmed[3] + trimmed[3];
+    }
+    const colorMap = {
+      black: "#000000",
+      white: "#ffffff",
+      red: "#ff0000",
+      green: "#008000",
+      blue: "#0000ff",
+      yellow: "#ffff00",
+      cyan: "#00ffff",
+      magenta: "#ff00ff",
+      orange: "#ffa500",
+      gray: "#808080",
+      grey: "#808080",
+    };
+    if (colorMap[trimmed]) return colorMap[trimmed];
+    const rgbMatch = trimmed.match(/^rgba?\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    if (rgbMatch) {
+      const r = Math.min(255, parseInt(rgbMatch[1], 10)).toString(16).padStart(2, "0");
+      const g = Math.min(255, parseInt(rgbMatch[2], 10)).toString(16).padStart(2, "0");
+      const b = Math.min(255, parseInt(rgbMatch[3], 10)).toString(16).padStart(2, "0");
+      return `#${r}${g}${b}`;
+    }
+    return "#ffffff";
+  }
+
   setConfig(config) {
     this._yamlConfig = { ...config };
     const rawEntities = config.entities ?? [];
@@ -1450,6 +1481,204 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
           </div>
         </div>
 
+        <div class="config-section">
+          <div class="section-header">
+            <div class="section-title">${localize("editor.sections.artwork.background.title")}</div>
+            <div class="section-description">${localize("editor.sections.artwork.background.description")}</div>
+          </div>
+          ${
+            this._isTemplateMode("background_image", this._config.background_image)
+              ? html`
+                  <div class="form-row">
+                    <div class="editor-field-wrapper">
+                      <div class="grow-children" style="flex-direction: column;">
+                        <span class="form-label"
+                          >${localize("editor.fields.background_image_entity")}</span
+                        >
+                        <ha-code-editor
+                          lint
+                          .hass=${this.hass}
+                          mode="jinja2"
+                          autocomplete-entities
+                          label="${localize("editor.sections.artwork.background.title")}"
+                          .value=${this._config.background_image ?? ""}
+                          @value-changed=${(e) => this._updateConfig("background_image", e.detail.value)}
+                        ></ha-code-editor>
+                      </div>
+                      <div class="field-actions">
+                        ${this._renderTemplateToggle(
+                          "background_image",
+                          this._config.background_image,
+                          (v) => this._updateConfig("background_image", v)
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                `
+              : html`
+                  <div class="form-row form-row-multi-column">
+                    <div style="display: flex; align-items: center; gap: 8px; flex: 1;">
+                      <ha-switch
+                        id="background-image-url-toggle"
+                        .checked=${
+                          this._useBackgroundImageUrl ??
+                          this._looksLikeUrlOrPath(this._config.background_image)
+                        }
+                        @change=${(e) => {
+                          this._useBackgroundImageUrl = e.target.checked;
+                          this._updateConfig("background_image", "");
+                        }}
+                      ></ha-switch>
+                      <label for="background-image-url-toggle"
+                        >${localize("editor.labels.use_url_path")}</label
+                      >
+                    </div>
+                    <div style="flex: 2; display: flex; align-items: center; gap: 8px;">
+                      <div class="editor-field-wrapper">
+                        <div class="grow-children">
+                          ${
+                            (this._useBackgroundImageUrl ??
+                            this._looksLikeUrlOrPath(this._config.background_image))
+                              ? html`
+                                  <ha-selector
+                                    .hass=${this.hass}
+                                    class="full-width"
+                                    .selector=${{ text: {} }}
+                                    .value=${this._config.background_image ?? ""}
+                                    @value-changed=${(e) =>
+                                      this._updateConfig("background_image", e.detail.value)}
+                                    label="e.g., https://example.com/image.jpg or /local/custom/image.jpg"
+                                    helper="${localize("editor.subtitles.image_url_helper")}"
+                                  ></ha-selector>
+                                `
+                              : html`
+                                  <ha-generic-picker
+                                    class="full-width"
+                                    .hass=${this.hass}
+                                    .value=${this._config.background_image ?? ""}
+                                    .label=${localize("editor.fields.background_image_entity")}
+                                    .valueRenderer=${(v) => this._entityValueRenderer(v)}
+                                    .rowRenderer=${(item) => this._entityRowRenderer(item)}
+                                    .getItems=${this._getEntityItems(["camera", "image"])}
+                                    @value-changed=${(e) =>
+                                      this._updateConfig("background_image", e.detail.value)}
+                                    allow-custom-value
+                                  ></ha-generic-picker>
+                                `
+                          }
+                        </div>
+                        <div class="field-actions">
+                          ${this._renderTemplateToggle(
+                            "background_image",
+                            this._config.background_image,
+                            (v) => this._updateConfig("background_image", v)
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                `
+          }
+          <div class="form-row form-row-multi-column" style="${!this._config.background_image ? "opacity: 0.4; pointer-events: none;" : ""}">
+            <div class="grow-children">
+              <ha-selector
+                .hass=${this.hass}
+                label="${localize("editor.fields.background_fit")}"
+                .disabled=${!this._config.background_image}
+                .selector=${{
+                  select: {
+                    mode: "dropdown",
+                    options: [
+                      {
+                        value: "cover",
+                        label: (localize("editor.background_fit.cover") || "Cover") + " (default)",
+                      },
+                      {
+                        value: "contain",
+                        label: localize("editor.background_fit.contain") || "Contain",
+                      },
+                      { value: "fill", label: localize("editor.background_fit.fill") || "Fill" },
+                      {
+                        value: "scale-down",
+                        label: localize("editor.background_fit.scale-down") || "Scale Down",
+                      },
+                      { value: "none", label: localize("editor.background_fit.none") || "None" },
+                    ],
+                  },
+                }}
+                .value=${this._config.background_fit ?? "cover"}
+                @value-changed=${(e) => {
+                  const value = e.detail.value;
+                  this._updateConfig("background_fit", value === "cover" ? undefined : value);
+                }}
+              ></ha-selector>
+            </div>
+            <div class="grow-children">
+              <ha-selector
+                .hass=${this.hass}
+                label="${localize("editor.fields.background_position")}"
+                .disabled=${!this._config.background_image}
+                .selector=${{
+                  select: {
+                    mode: "dropdown",
+                    options: [
+                      {
+                        value: "center center",
+                        label:
+                          (localize("editor.background_position.center") || "Center") +
+                          " (default)",
+                      },
+                      {
+                        value: "top center",
+                        label: localize("editor.background_position.top") || "Top",
+                      },
+                      {
+                        value: "bottom center",
+                        label: localize("editor.background_position.bottom") || "Bottom",
+                      },
+                      {
+                        value: "center left",
+                        label: localize("editor.background_position.center left") || "Center Left",
+                      },
+                      {
+                        value: "center right",
+                        label:
+                          localize("editor.background_position.center right") || "Center Right",
+                      },
+                      {
+                        value: "top left",
+                        label: localize("editor.background_position.top left") || "Top Left",
+                      },
+                      {
+                        value: "top right",
+                        label: localize("editor.background_position.top right") || "Top Right",
+                      },
+                      {
+                        value: "bottom left",
+                        label: localize("editor.background_position.bottom left") || "Bottom Left",
+                      },
+                      {
+                        value: "bottom right",
+                        label:
+                          localize("editor.background_position.bottom right") || "Bottom Right",
+                      },
+                    ],
+                  },
+                }}
+                .value=${this._config.background_position ?? "center center"}
+                @value-changed=${(e) => {
+                  const value = e.detail.value;
+                  this._updateConfig(
+                    "background_position",
+                    value === "center center" ? undefined : value
+                  );
+                }}
+              ></ha-selector>
+            </div>
+          </div>
+
+
+        </div>
         <div class="config-section">
           <div class="section-header">
             <div class="section-title">${localize("editor.sections.artwork.idle.title")}</div>
@@ -2672,6 +2901,67 @@ export class YetAnotherMediaPlayerEditor extends LitElement {
             label="${localize("editor.fields.appearance")}"
             @value-changed=${(e) => this._updateConfig("appearance", e.detail.value)}
           ></ha-selector>
+        </div>
+
+        <div class="form-row" data-search-keys="font_color font color appearance text_color">
+          <div class="editor-field-wrapper">
+            ${
+              this._isTemplateMode("font_color", this._config.font_color)
+                ? html`
+                    <div class="grow-children" style="flex-direction: column;">
+                      <span class="form-label">${localize("editor.fields.font_color_entity")}</span>
+                      <ha-code-editor
+                        lint
+                        .hass=${this.hass}
+                        mode="jinja2"
+                        autocomplete-entities
+                        label="${localize("editor.fields.font_color")}"
+                        .value=${this._config.font_color ?? ""}
+                        @value-changed=${(e) => this._updateConfig("font_color", e.detail.value)}
+                      ></ha-code-editor>
+                    </div>
+                  `
+                : html`
+                    <div
+                      class="grow-children"
+                      style="display: flex; align-items: flex-start; gap: 12px;"
+                    >
+                      <div
+                        style="position: relative; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; border: 2px solid var(--divider-color, rgba(255,255,255,0.2)); flex: 0 0 36px; cursor: pointer; margin-top: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.2);"
+                        title="${localize("editor.fields.font_color")}"
+                      >
+                        <input
+                          type="color"
+                          .value=${this._toHexColor(this._config.font_color)}
+                          @input=${(e) => this._updateConfig("font_color", e.target.value)}
+                          style="position: absolute; top: -50%; left: -50%; width: 200%; height: 200%; cursor: pointer; border: none; padding: 0; background: transparent;"
+                        />
+                      </div>
+                      <ha-selector
+                        .hass=${this.hass}
+                        class="full-width"
+                        style="flex: 1;"
+                        .selector=${{ text: {} }}
+                        .value=${this._config.font_color ?? ""}
+                        label="${localize("editor.fields.font_color")}"
+                        helper="${localize("editor.subtitles.font_color_helper") || "e.g., #ffffff, rgba(255, 255, 255, 0.9), white"}"
+                        @value-changed=${(e) => this._updateConfig("font_color", e.detail.value)}
+                      ></ha-selector>
+                    </div>
+                  `
+            }
+            <div class="field-actions">
+              ${this._renderTemplateToggle("font_color", this._config.font_color, (v) =>
+                this._updateConfig("font_color", v)
+              )}
+              <ha-icon
+                class="icon-button-small ${!this._config.font_color ? "icon-button-disabled" : ""}"
+                icon="mdi:restore"
+                title="${localize("common.reset_default")}"
+                @click=${() => this._updateConfig("font_color", undefined)}
+              ></ha-icon>
+            </div>
+          </div>
         </div>
 
         <div

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -731,6 +731,14 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._idleImageTemplateResult = "";
     this._resolvingIdleImageTemplate = false;
     this._idleImageTemplateNeedsResolve = false;
+    this._backgroundImageTemplate = null;
+    this._backgroundImageTemplateResult = "";
+    this._resolvingBackgroundImageTemplate = false;
+    this._backgroundImageTemplateNeedsResolve = false;
+    this._fontColorTemplate = null;
+    this._fontColorTemplateResult = "";
+    this._resolvingFontColorTemplate = false;
+    this._fontColorTemplateNeedsResolve = false;
     this._artworkOverrideTemplateCache = {};
     this._artworkOverrideIndexMap = null;
     this._hideActiveEntityLabel = false;
@@ -4680,6 +4688,38 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
   }
 
+  async _resolveBackgroundImageTemplate() {
+    if (!this._backgroundImageTemplate || this._resolvingBackgroundImageTemplate || !this.hass) return;
+    this._resolvingBackgroundImageTemplate = true;
+    try {
+      const context = this._getTemplateContext();
+      const result = await resolveStringTemplate(this.hass, this._backgroundImageTemplate, context);
+      this._backgroundImageTemplateResult = (result ?? "").toString().trim();
+    } catch (error) {
+      this._backgroundImageTemplateResult = "";
+    } finally {
+      this._resolvingBackgroundImageTemplate = false;
+      this._backgroundImageTemplateNeedsResolve = false;
+      this.requestUpdate();
+    }
+  }
+
+  async _resolveFontColorTemplate() {
+    if (!this._fontColorTemplate || this._resolvingFontColorTemplate || !this.hass) return;
+    this._resolvingFontColorTemplate = true;
+    try {
+      const context = this._getTemplateContext();
+      const result = await resolveStringTemplate(this.hass, this._fontColorTemplate, context);
+      this._fontColorTemplateResult = (result ?? "").toString().trim();
+    } catch (error) {
+      this._fontColorTemplateResult = "";
+    } finally {
+      this._resolvingFontColorTemplate = false;
+      this._fontColorTemplateNeedsResolve = false;
+      this.requestUpdate();
+    }
+  }
+
   _getTemplateContext() {
     return {
       entity: this.currentEntityId || '',
@@ -4963,6 +5003,23 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     return trimmed;
   }
 
+  _resolveImageUrlFromInput(input) {
+    const normalized = this._normalizeImageSourceValue(input);
+    if (!normalized || !this.hass) return null;
+    if (this.hass.states?.[normalized]) {
+      const stateObj = this.hass.states[normalized];
+      return (
+        stateObj.attributes?.entity_picture_local ||
+        stateObj.attributes?.entity_picture ||
+        (stateObj.state && typeof stateObj.state === "string" && (stateObj.state.startsWith("http") || stateObj.state.startsWith("/")) ? stateObj.state : null)
+      );
+    }
+    if (normalized.startsWith("http") || normalized.startsWith("/")) {
+      return normalized;
+    }
+    return null;
+  }
+
   setConfig(rawConfig) {
     if (!rawConfig.entities || !Array.isArray(rawConfig.entities) || rawConfig.entities.length === 0) {
       throw new Error("You must define at least one media_player entity.");
@@ -5069,6 +5126,28 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       this._idleImageTemplate = null;
       this._idleImageTemplateResult = "";
       this._idleImageTemplateNeedsResolve = false;
+    }
+    // Handle background image templates
+    if (typeof config.background_image === "string" &&
+      (config.background_image.includes("{{") || config.background_image.includes("{%"))) {
+      this._backgroundImageTemplate = config.background_image;
+      this._backgroundImageTemplateResult = "";
+      this._backgroundImageTemplateNeedsResolve = true;
+    } else {
+      this._backgroundImageTemplate = null;
+      this._backgroundImageTemplateResult = "";
+      this._backgroundImageTemplateNeedsResolve = false;
+    }
+    // Handle font color templates
+    if (typeof config.font_color === "string" &&
+      (config.font_color.includes("{{") || config.font_color.includes("{%"))) {
+      this._fontColorTemplate = config.font_color;
+      this._fontColorTemplateResult = "";
+      this._fontColorTemplateNeedsResolve = true;
+    } else {
+      this._fontColorTemplate = null;
+      this._fontColorTemplateResult = "";
+      this._fontColorTemplateNeedsResolve = false;
     }
     // Handle card_height templates (similar to idle_image)
     // card_height now uses websocket template subscriptions
@@ -6646,12 +6725,16 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     if (this._idleImageTemplate && changedProps.has("hass")) {
       this._idleImageTemplateNeedsResolve = true;
     }
+    if (this._backgroundImageTemplate && changedProps.has("hass")) {
+      this._backgroundImageTemplateNeedsResolve = true;
+    }
     const currentContext = JSON.stringify(this._getTemplateContext());
     this._syncTemplateSubscriptions('action_in_menu', currentContext, this.config?.actions);
     this._syncTemplateSubscriptions('always_collapsed', currentContext, this.config?.always_collapsed);
     this._syncTemplateSubscriptions('control_layout', currentContext, this.config?.control_layout);
     this._syncTemplateSubscriptions('card_height', currentContext, this.config?.card_height);
     this._syncTemplateSubscriptions('lyrics_background_fade', currentContext, this.config?.lyrics_background_fade);
+    this._syncTemplateSubscriptions('font_color', currentContext, this.config?.font_color);
     this._syncEntityTemplateSubscriptions('ma', currentContext);
     this._syncEntityTemplateSubscriptions('vol', currentContext);
     this._syncEntityTemplateSubscriptions('remote', currentContext);
@@ -8425,12 +8508,42 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     if (this._idleImageTemplate && this._idleImageTemplateNeedsResolve && !this._resolvingIdleImageTemplate && this._isIdle) {
       void this._resolveIdleImageTemplate();
     }
+    if (this._backgroundImageTemplate && this._backgroundImageTemplateNeedsResolve && !this._resolvingBackgroundImageTemplate) {
+      void this._resolveBackgroundImageTemplate();
+    }
+    if (this._fontColorTemplateNeedsResolve && !this._resolvingFontColorTemplate) {
+      void this._resolveFontColorTemplate();
+    }
     // Idle image "picture frame" mode when idle
     const isJsTemplate = typeof this.config.idle_image === "string" && this.config.idle_image.trim().startsWith("[[[");
     const rawIdleImageInput = isJsTemplate
       ? this._evaluateJsTemplate(this.config.idle_image)
       : (this._idleImageTemplate ? this._idleImageTemplateResult : this.config.idle_image);
     const normalizedIdleImageInput = this._normalizeImageSourceValue(rawIdleImageInput);
+
+    // Persistent card background image
+    const isBgJsTemplate = typeof this.config.background_image === "string" && this.config.background_image.trim().startsWith("[[[");
+    const rawBgImageInput = isBgJsTemplate
+      ? this._evaluateJsTemplate(this.config.background_image)
+      : (this._backgroundImageTemplate ? this._backgroundImageTemplateResult : this.config.background_image);
+    const cardBackgroundImageUrl = this._resolveImageUrlFromInput(rawBgImageInput);
+    const trimmedBgInput = (typeof rawBgImageInput === "string" && rawBgImageInput.trim().length > 0) ? rawBgImageInput.trim() : "";
+    const isDirectColorOrGradient = !cardBackgroundImageUrl && trimmedBgInput.length > 0 && (
+      trimmedBgInput.startsWith("#") ||
+      trimmedBgInput.startsWith("rgb") ||
+      trimmedBgInput.startsWith("hsl") ||
+      trimmedBgInput.startsWith("linear-gradient") ||
+      trimmedBgInput.startsWith("radial-gradient") ||
+      /^[a-zA-Z]+$/.test(trimmedBgInput)
+    );
+    const hasCardBg = !!(cardBackgroundImageUrl || isDirectColorOrGradient);
+
+    const isFcJsTemplate = typeof this.config.font_color === "string" && this.config.font_color.trim().startsWith("[[[");
+    const rawFontColorInput = isFcJsTemplate
+      ? this._evaluateJsTemplate(this.config.font_color)
+      : (this._fontColorTemplate ? this._fontColorTemplateResult : this.config.font_color);
+    const cardFontColor = (typeof rawFontColorInput === "string" && rawFontColorInput.trim().length > 0) ? rawFontColorInput.trim() : null;
+    const hasFontColor = !!cardFontColor;
 
     // Use the unified entity resolution system for playback state.
     // (Note: resolved here at the top of render to support show_idle_artwork_when_not_playing detection)
@@ -8441,18 +8554,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
 
     let idleImageUrl = null;
     if (normalizedIdleImageInput && (this._isIdle || forceIdleImage)) {
-      // Check if it's an entity ID
-      if (this.hass.states[normalizedIdleImageInput]) {
-        const sensorState = this.hass.states[normalizedIdleImageInput];
-        idleImageUrl =
-          sensorState.attributes.entity_picture_local ||
-          sensorState.attributes.entity_picture ||
-          (sensorState.state && typeof sensorState.state === "string" && sensorState.state.startsWith("http") ? sensorState.state : null);
-      }
-      // Check if it's a direct URL or file path
-      else if (normalizedIdleImageInput.startsWith("http") || normalizedIdleImageInput.startsWith("/")) {
-        idleImageUrl = normalizedIdleImageInput;
-      }
+      idleImageUrl = this._resolveImageUrlFromInput(normalizedIdleImageInput);
     }
     const dimIdleFrame = !!idleImageUrl;
     const hideControlsNow = this._idleTimeoutMs === 0 ? false : this._isIdle;
@@ -8821,6 +8923,21 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       `filter: ${backgroundFilter}`
     ].join('; ');
 
+    const bgFit = this.config.background_fit || "cover";
+    const bgPosition = this.config.background_position || "center center";
+    const bgSize = this._getBackgroundSizeForFit(bgFit);
+    const cardBgStyle = cardBackgroundImageUrl ? [
+      `background-image: url('${cardBackgroundImageUrl}')`,
+      `background-size: ${bgSize}`,
+      `background-position: ${bgPosition}`,
+      "background-repeat: no-repeat"
+    ].join('; ') : (isDirectColorOrGradient ? [
+      trimmedBgInput.startsWith("linear-gradient") || trimmedBgInput.startsWith("radial-gradient")
+        ? `background-image: ${trimmedBgInput}`
+        : `background-color: ${trimmedBgInput}`,
+      "background-repeat: no-repeat"
+    ].join('; ') : '');
+
 
 
     const isVolumeHiddenByConfig =
@@ -8859,8 +8976,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           <div
             data-match-theme="${String(this.config.match_theme === true)}"
             data-artwork-fit="${activeArtworkFit}"
+            data-has-background-image="${String(hasCardBg)}"
             data-lyrics-active="${String(this._lyricsActive === true)}"
-            style=${this._lyricsActive ? `--yamp-lyrics-fade: ${lyricsFade}%; --yamp-lyrics-backdrop-filter: ${lyricsBackdropFilter};` : nothing}
+            style=${[
+              (hasCustomCardHeight && (!collapsed || this._alwaysCollapsed)) ? `height:${customCardHeight}px;` : null,
+              this._lyricsActive ? `--yamp-lyrics-fade: ${lyricsFade}%; --yamp-lyrics-backdrop-filter: ${lyricsBackdropFilter}` : null,
+              hasFontColor ? `--primary-text: ${cardFontColor}; --primary-text-color: ${cardFontColor}; --yamp-icon-color: ${cardFontColor}; --secondary-text-color: ${cardFontColor};` : null
+            ].filter(Boolean).join('; ') || nothing}
             class=${classMap({
       "yamp-card-inner": true,
       "compact-collapsed": isCompact && collapsed,
@@ -8869,11 +8991,15 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       "collapsed": collapsed
     })}
           >
+            ${hasCardBg ? html`
+              <div class="card-background-image-layer" style="${cardBgStyle}"></div>
+              <div class="card-background-image-overlay"></div>
+            ` : nothing}
             ${artworkFullBleed && hasBackgroundImage ? html`
               <div class="full-bleed-artwork-bg" style="${sharedBackgroundStyle}"></div>
               ${!this._artworkGradientDisabled && !(dimIdleFrame || this._isIdle || this._lyricsActive) ? html`<div class="full-bleed-artwork-fade"></div>` : nothing}
             ` : nothing}
-            ${(!useInsetArtwork && !artworkUrl && !idleImageUrl) ? html`
+            ${(!useInsetArtwork && !artworkUrl && !idleImageUrl && !hasCardBg) ? html`
               <div class="media-artwork-placeholder"
                 @pointerdown=${this._onTapAreaPointerDown}
                 @pointermove=${this._onTapAreaPointerMove}
@@ -8944,7 +9070,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
         return styles.join('; ');
       })()}"
               ></div>
-              ${!this._artworkGradientDisabled && !(dimIdleFrame || this._isIdle || this._lyricsActive) && (!useInsetArtwork || activeArtworkFit === "scaled-contain") ? html`<div class="card-lower-fade" style="--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px;"></div>` : nothing}
+              ${!this._artworkGradientDisabled && !(dimIdleFrame || this._isIdle || this._lyricsActive || (!artworkUrl && hasCardBg)) && (!useInsetArtwork || activeArtworkFit === "scaled-contain") ? html`<div class="card-lower-fade" style="--yamp-lyrics-bottom-offset: ${lyricsBottomOffset}px;"></div>` : nothing}
               <div class="card-lower-content${collapsed ? ' collapsed transitioning' : ' transitioning'}${collapsed && artworkUrl && collapsedArtworkSize > 0 ? ' has-artwork' : ''}" style="${(() => {
         if (!hideControlsNow) return '';
         return collapsed
@@ -10278,6 +10404,13 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
             domain: "",
             multiple: false
           }
+        },
+        required: false
+      },
+      {
+        name: "background_image",
+        selector: {
+          text: {}
         },
         required: false
       },

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -1160,16 +1160,16 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       if (!this._compiledJsTemplates[code]) {
         const body = code.includes("return") ? code : `return (${code});`;
         this._compiledJsTemplates[code] = new Function(
-          "hass", "states", "user", "is_state", "state_attr",
+          "hass", "states", "user", "is_state", "state_attr", "context",
           "current", "is_idle", "is_playing", "is_search", "is_grouping",
-          "is_source", "is_lyrics", "is_options", "is_transfer_queue", "is_any_menu_open",
+          "is_source", "is_lyrics", "is_options", "is_transfer_queue", "is_any_menu_open", "is_dark_mode",
           body
         );
       }
       return this._compiledJsTemplates[code](
-        hass, states, user, is_state, state_attr,
+        hass, states, user, is_state, state_attr, context,
         context.current, context.is_idle, context.is_playing, context.is_search, context.is_grouping,
-        context.is_source, context.is_lyrics, context.is_options, context.is_transfer_queue, context.is_any_menu_open
+        context.is_source, context.is_lyrics, context.is_options, context.is_transfer_queue, context.is_any_menu_open, context.is_dark_mode
       );
     } catch (err) {
       console.warn("yamp: failed to evaluate JS template:", templateStr, err);
@@ -4721,6 +4721,10 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
   }
 
   _getTemplateContext() {
+    const isDarkMode = Boolean(
+      this.hass?.themes?.darkMode ??
+      (typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)")?.matches)
+    );
     return {
       entity: this.currentEntityId || '',
       is_idle: this._isIdle,
@@ -4732,6 +4736,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
       is_options: this._showEntityOptions,
       is_transfer_queue: this._showTransferQueue,
       is_any_menu_open: this.isAnyMenuOpen,
+      is_dark_mode: isDarkMode,
       current: this.currentActivePlaybackEntityId || this.currentEntityId || '',
     };
   }
@@ -6727,6 +6732,9 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     }
     if (this._backgroundImageTemplate && changedProps.has("hass")) {
       this._backgroundImageTemplateNeedsResolve = true;
+    }
+    if (this._fontColorTemplate && changedProps.has("hass")) {
+      this._fontColorTemplateNeedsResolve = true;
     }
     const currentContext = JSON.stringify(this._getTemplateContext());
     this._syncTemplateSubscriptions('action_in_menu', currentContext, this.config?.actions);
@@ -8993,7 +9001,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           >
             ${hasCardBg ? html`
               <div class="card-background-image-layer" style="${cardBgStyle}"></div>
-              <div class="card-background-image-overlay"></div>
+              ${!this._artworkGradientDisabled && !isDirectColorOrGradient ? html`<div class="card-background-image-overlay"></div>` : nothing}
             ` : nothing}
             ${artworkFullBleed && hasBackgroundImage ? html`
               <div class="full-bleed-artwork-bg" style="${sharedBackgroundStyle}"></div>

--- a/src/yet-another-media-player.js
+++ b/src/yet-another-media-player.js
@@ -6742,7 +6742,6 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     this._syncTemplateSubscriptions('control_layout', currentContext, this.config?.control_layout);
     this._syncTemplateSubscriptions('card_height', currentContext, this.config?.card_height);
     this._syncTemplateSubscriptions('lyrics_background_fade', currentContext, this.config?.lyrics_background_fade);
-    this._syncTemplateSubscriptions('font_color', currentContext, this.config?.font_color);
     this._syncEntityTemplateSubscriptions('ma', currentContext);
     this._syncEntityTemplateSubscriptions('vol', currentContext);
     this._syncEntityTemplateSubscriptions('remote', currentContext);
@@ -8519,7 +8518,7 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
     if (this._backgroundImageTemplate && this._backgroundImageTemplateNeedsResolve && !this._resolvingBackgroundImageTemplate) {
       void this._resolveBackgroundImageTemplate();
     }
-    if (this._fontColorTemplateNeedsResolve && !this._resolvingFontColorTemplate) {
+    if (this._fontColorTemplate && this._fontColorTemplateNeedsResolve && !this._resolvingFontColorTemplate) {
       void this._resolveFontColorTemplate();
     }
     // Idle image "picture frame" mode when idle
@@ -8983,13 +8982,14 @@ class YetAnotherMediaPlayerCard extends QueueDragMixin(LitElement) {
           style=${(hasCustomCardHeight && (!collapsed || this._alwaysCollapsed)) ? `height:${customCardHeight}px;` : nothing}>
           <div
             data-match-theme="${String(this.config.match_theme === true)}"
+            data-has-font-color="${String(hasFontColor)}"
             data-artwork-fit="${activeArtworkFit}"
             data-has-background-image="${String(hasCardBg)}"
             data-lyrics-active="${String(this._lyricsActive === true)}"
             style=${[
               (hasCustomCardHeight && (!collapsed || this._alwaysCollapsed)) ? `height:${customCardHeight}px;` : null,
               this._lyricsActive ? `--yamp-lyrics-fade: ${lyricsFade}%; --yamp-lyrics-backdrop-filter: ${lyricsBackdropFilter}` : null,
-              hasFontColor ? `--primary-text: ${cardFontColor}; --primary-text-color: ${cardFontColor}; --yamp-icon-color: ${cardFontColor}; --secondary-text-color: ${cardFontColor};` : null
+              hasFontColor ? `--primary-text: ${cardFontColor}; --primary-text-color: ${cardFontColor}; --secondary-text: ${cardFontColor}; --secondary-text-color: ${cardFontColor}; --yamp-icon-color: ${cardFontColor};` : null
             ].filter(Boolean).join('; ') || nothing}
             class=${classMap({
       "yamp-card-inner": true,


### PR DESCRIPTION
## Overview / What's New

- **Custom Background Images**: You can now set a persistent background image behind your media card that stays visible regardless of what is playing (with support for camera/image entities, direct URLs, local paths, or dynamic templates).
- **Custom Font & Icon Colors**: You can now customize the text and button colors on the card using any color code or dynamic schedule, making it easy to keep labels readable over any background image.
- **Dark Mode Template Variable**: Templates can now detect whether Home Assistant is in light or dark mode, allowing your card to automatically switch background artwork and text colors between daytime and nighttime themes.
- **Visual Editor Controls**: New settings for background image source, fit modes, alignment, and a font color picker (with live color swatch and template toggle) have been added directly to the card's visual editor.
- **Alternate Progress Bar in Lyrics Fix**: When viewing lyrics with the alternate progress bar enabled, the progress bar now stays properly pinned to the bottom of the card instead of shifting into the middle of the screen.

---

## User-Facing Changes

- **New Setting: `background_image`**: Set a persistent card background using image URLs, local paths (`/local/...`), or camera/image entities. In YAML or templates, CSS gradients and direct color codes are also supported.
- **New Settings: `background_fit` & `background_position`**: Choose how background images scale (`cover`, `contain`, `fill`, `scale-down`, `none`) and align (`center`, `top`, `bottom`, corners, sides).
- **New Setting: `font_color`**: Sets the color for track details, artist, album, control icons, and timestamps. Supports hex values, color names, rgba, and Jinja2/JavaScript templates. Overrides theme colors when populated, and automatically falls back to Home Assistant theme colors when `match_theme` is active.
- **Template Context: `is_dark_mode`**: Added a boolean flag to both Jinja2 and JS template engines indicating if Home Assistant is currently in dark mode.
- **Progress Bar During Lyrics**: Fixed layout positioning when `alternate_progress_bar: true` and lyrics overlay is active.
- **Editor Improvements**: Added a dedicated "Background Image" subsection in the Artwork tab, and a Font Color control with color picker in the Look and Feel tab.

---

## Technical Details

- **Config Schema & Type Safety**:
  - Registered `background_image`, `font_color`, `background_position`, and `background_fit` defaults and template capability flags in `src/config-schema.js`.
  - Updated `YampCardConfig` and `TemplateContext` interfaces in `src/types.d.ts`.
- **Card Rendering & Lifecycle**:
  - Implemented persistent background layer `.card-background-image-layer` with support for images, direct colors, and CSS gradients in `src/yet-another-media-player.js`.
  - Added dual-engine template evaluation for `background_image` and `font_color`.
  - Added `data-has-font-color` attribute to `.yamp-card-inner` and set CSS variables `--primary-text`, `--primary-text-color`, `--secondary-text`, `--secondary-text-color`, and `--yamp-icon-color`.
  - Fixed `.artist` style rule in `src/yamp-card-styles.js` by removing duplicate `color: #fff;` override.
  - Excluded `.collapsed-progress-bar` from `position: relative` override during lyrics mode.
- **Localization**:
  - Added full translation keys for `background`, `font_color`, `background_fit`, and `background_position` across all 9 languages (`de`, `en`, `es`, `fr`, `it`, `nl`, `pt`, `sk`, `sl`).
- **Documentation**:
  - Updated `README.md` configuration table, templating guides, and dark mode template examples.

---

## Verification & Quality Checks

- Ran full automated validation pipeline (`npm run validate`):
  - ESLint passed clean.
  - Prettier formatting check passed clean.
  - TypeScript compilation (`tsc --noEmit`) passed clean.
  - Production bundle generated without warnings.
- Tested and verified on Home Assistant frontend.