### PR TITLE
fix: restore default white font and icon colors over cover artwork

### DIFF
--- a/src/yamp-card-styles.js
+++ b/src/yamp-card-styles.js
@@ -1159,6 +1159,7 @@ export const yampCardStyles = css`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    color: #fff;
   }
 
   :host([data-details-alignment="center"]) .details {
@@ -1918,7 +1919,7 @@ export const yampCardStyles = css`
     color: #fff;
   }
 
-  /* Match Theme mode, custom font color & Scaled Contain Alternate mode - use theme or custom colors */
+  /* Custom font color, Lyrics mode & Scaled Contain Alternate mode - use custom or theme colors */
   .yamp-card-inner[data-has-font-color="true"] .details,
   .yamp-card-inner[data-has-font-color="true"] .title,
   .yamp-card-inner[data-has-font-color="true"] .artist,
@@ -1935,22 +1936,6 @@ export const yampCardStyles = css`
   .yamp-card-inner[data-has-font-color="true"] .radio-mode-button,
   .yamp-card-inner[data-has-font-color="true"] .volume-slider-icon,
   .yamp-card-inner[data-has-font-color="true"] .timestamps-container,
-  .yamp-card-inner[data-match-theme="true"] .details,
-  .yamp-card-inner[data-match-theme="true"] .title,
-  .yamp-card-inner[data-match-theme="true"] .artist,
-  .yamp-card-inner[data-match-theme="true"] .source-menu-btn,
-  .yamp-card-inner[data-match-theme="true"] .source-selected,
-  .yamp-card-inner[data-match-theme="true"] .controls-row,
-  .yamp-card-inner[data-match-theme="true"] .button,
-  .yamp-card-inner[data-match-theme="true"] .modern-button,
-  .yamp-card-inner[data-match-theme="true"] .vol-stepper span,
-  .yamp-card-inner[data-match-theme="true"] .vol-label,
-  .yamp-card-inner[data-match-theme="true"] .more-info-btn ha-icon,
-  .yamp-card-inner[data-match-theme="true"] .volume-icon-btn,
-  .yamp-card-inner[data-match-theme="true"] .volume-icon-btn ha-icon,
-  .yamp-card-inner[data-match-theme="true"] .radio-mode-button,
-  .yamp-card-inner[data-match-theme="true"] .volume-slider-icon,
-  .yamp-card-inner[data-match-theme="true"] .timestamps-container,
   .yamp-card-inner[data-lyrics-active="true"] .details,
   .yamp-card-inner[data-lyrics-active="true"] .title,
   .yamp-card-inner[data-lyrics-active="true"] .artist,
@@ -1987,7 +1972,6 @@ export const yampCardStyles = css`
   }
 
   .yamp-card-inner[data-has-font-color="true"] .modern-button,
-  .yamp-card-inner[data-match-theme="true"] .modern-button,
   .yamp-card-inner[data-lyrics-active="true"] .modern-button,
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .modern-button {
     background: color-mix(in srgb, var(--primary-text), transparent 85%);
@@ -1996,7 +1980,6 @@ export const yampCardStyles = css`
 
   /* Hamburger icon (span) uses !important in base styles, so we override it here */
   .yamp-card-inner[data-has-font-color="true"] .more-info-icon,
-  .yamp-card-inner[data-match-theme="true"] .more-info-icon,
   .yamp-card-inner[data-lyrics-active="true"] .more-info-icon,
   .yamp-card-inner[data-artwork-fit="scaled-contain-alternate"] .more-info-icon {
     color: var(--primary-text) !important;


### PR DESCRIPTION
## Overview / What's New

- **Fixed Text and Icon Colors Over Cover Artwork**: Fixed an issue introduced in the previous update where track title, artist, volume, and playback controls turned black in light theme when artwork was in cover mode, restoring the expected white text for clear visibility over dark artwork gradients.

---

## User-Facing Changes

- **Restored White Text on Cover Artwork**: All playback text (track title, artist, timestamps) and control buttons now default to white when displaying artwork in cover mode, ensuring high contrast and legibility over artwork gradients regardless of whether Home Assistant is in light or dark mode.
- **Custom Font Color Intact**: Custom `font_color` settings and dynamic color templates continue to work as expected, overriding default colors only when explicitly configured.

---

## Technical Details

- **Scoping Text Color Overrides in `src/yamp-card-styles.js`**:
  - Removed unintended `.yamp-card-inner[data-match-theme="true"]` selectors from the `color: var(--primary-text);` rule block, modern button styling, and the hamburger menu icon.
  - Preserved theme-aware text coloring specifically where appropriate: explicit `font_color` (`[data-has-font-color="true"]`), active lyrics overlay (`[data-lyrics-active="true"]`), and inset artwork mode (`[data-artwork-fit="scaled-contain-alternate"]`).
  - Restored `color: #fff;` on `.artist` to guarantee white artist text defaults over cover artwork.

---

## Verification & Quality Checks

- Ran full automated validation pipeline (`npm run validate`):
  - ESLint passed with zero errors.
  - Prettier formatting check passed clean.
  - TypeScript compilation (`tsc --noEmit`) passed with zero errors.
  - Rollup production build generated cleanly.
- Manually deployed and verified bundle in Home Assistant.